### PR TITLE
fix(javascript): resolve the theme asset paths the docs document

### DIFF
--- a/packages/javascript/lumis/examples/highlight-lines.html
+++ b/packages/javascript/lumis/examples/highlight-lines.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Line highlighting</title>
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-  <link rel="stylesheet" href="https://unpkg.com/@lumis-sh/themes/css/dracula.css">
+  <link rel="stylesheet" href="https://unpkg.com/@lumis-sh/themes/dist/css/dracula.css">
     <style>
     pre.lumis { padding: 1rem; border-radius: 0.5rem; overflow-x: auto; }
   </style>

--- a/packages/javascript/lumis/examples/html-linked.html
+++ b/packages/javascript/lumis/examples/html-linked.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>htmlLinked options</title>
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-  <link rel="stylesheet" href="https://unpkg.com/@lumis-sh/themes/css/dracula.css">
+  <link rel="stylesheet" href="https://unpkg.com/@lumis-sh/themes/dist/css/dracula.css">
     <style>
     :root {
       color-scheme: dark;

--- a/packages/javascript/lumis/examples/injected-languages.html
+++ b/packages/javascript/lumis/examples/injected-languages.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Injected languages showcase</title>
   <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
-  <link rel="stylesheet" href="https://unpkg.com/@lumis-sh/themes/css/dracula.css">
+  <link rel="stylesheet" href="https://unpkg.com/@lumis-sh/themes/dist/css/dracula.css">
     <style>
     :root {
       color-scheme: dark;

--- a/packages/javascript/lumis/test/theme-css.test.ts
+++ b/packages/javascript/lumis/test/theme-css.test.ts
@@ -83,3 +83,17 @@ html[data-theme="dark"] .l-tag-attribute {
     expect(buildCss(githubLight)).toBe(bundled);
   });
 });
+
+// `./css/*` maps onto `./dist/css/*.css`, so it appends the extension itself and
+// the specifier every doc page shows, with one, resolved to `github_light.css.css`.
+// Both forms are mapped now, and this fails if either stops resolving.
+describe("bundled asset specifiers", () => {
+  it.each([
+    "@lumis-sh/themes/css/github_light.css",
+    "@lumis-sh/themes/css/github_light",
+    "@lumis-sh/themes/json/github_light.json",
+    "@lumis-sh/themes/json/github_light",
+  ])("resolves %s", (specifier) => {
+    expect(readFileSync(require.resolve(specifier), "utf-8").length).toBeGreaterThan(0);
+  });
+});

--- a/packages/javascript/lumis/test/theme-css.test.ts
+++ b/packages/javascript/lumis/test/theme-css.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
+import { sep } from "node:path";
 import { buildCss, type ThemeData } from "@lumis-sh/themes";
 import githubLight from "@lumis-sh/themes/github_light";
 import { describe, expect, it } from "vitest";
@@ -89,11 +90,14 @@ html[data-theme="dark"] .l-tag-attribute {
 // Both forms are mapped now, and this fails if either stops resolving.
 describe("bundled asset specifiers", () => {
   it.each([
-    "@lumis-sh/themes/css/github_light.css",
-    "@lumis-sh/themes/css/github_light",
-    "@lumis-sh/themes/json/github_light.json",
-    "@lumis-sh/themes/json/github_light",
-  ])("resolves %s", (specifier) => {
-    expect(readFileSync(require.resolve(specifier), "utf-8").length).toBeGreaterThan(0);
+    ["@lumis-sh/themes/css/github_light.css", "dist/css/github_light.css"],
+    ["@lumis-sh/themes/css/github_light", "dist/css/github_light.css"],
+    ["@lumis-sh/themes/json/github_light.json", "dist/json/github_light.json"],
+    ["@lumis-sh/themes/json/github_light", "dist/json/github_light.json"],
+  ])("resolves %s", (specifier, target) => {
+    const resolved = require.resolve(specifier).replaceAll(sep, "/");
+
+    expect(resolved.endsWith(`/${target}`)).toBe(true);
+    expect(readFileSync(resolved, "utf-8").length).toBeGreaterThan(0);
   });
 });

--- a/packages/javascript/lumis/test/theme-css.test.ts
+++ b/packages/javascript/lumis/test/theme-css.test.ts
@@ -87,7 +87,8 @@ html[data-theme="dark"] .l-tag-attribute {
 
 // `./css/*` maps onto `./dist/css/*.css`, so it appends the extension itself and
 // the specifier every doc page shows, with one, resolved to `github_light.css.css`.
-// Both forms are mapped now, and this fails if either stops resolving.
+// Both forms are mapped now, and this fails if either stops resolving or lands
+// on the wrong asset.
 describe("bundled asset specifiers", () => {
   it.each([
     ["@lumis-sh/themes/css/github_light.css", "dist/css/github_light.css"],

--- a/packages/javascript/themes/package.json
+++ b/packages/javascript/themes/package.json
@@ -27,7 +27,9 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./json/*.json": "./dist/json/*.json",
     "./json/*": "./dist/json/*.json",
+    "./css/*.css": "./dist/css/*.css",
     "./css/*": "./dist/css/*.css",
     "./*": {
       "types": "./dist/themes/*.d.ts",


### PR DESCRIPTION
Every doc page shows this import, and it has never resolved:

```js
import '@lumis-sh/themes/css/dracula.css'
```

`@lumis-sh/themes` maps `"./css/*"` onto `"./dist/css/*.css"`, so it appends the extension itself and the specifier above asks for `dist/css/dracula.css.css`. What resolves today is the extensionless form, which nothing documents and only a test uses.

Rather than change one and break the other, both are mapped now. `"./json/*"` had the identical shape and gets the same treatment.

## The CDN URL was a 404

A CDN serves files, not the export map, so the path has to be the one on disk:

```
https://unpkg.com/@lumis-sh/themes/css/dracula.css        404
https://unpkg.com/@lumis-sh/themes/dist/css/dracula.css   200
```

Three example pages linked the first one, so `html-linked.html`, `highlight-lines.html` and `injected-languages.html` were rendering `htmlLinked` output with no stylesheet at all, which looks like Lumis emitting nothing. The docs and the package README already use `dist/css/`; only the examples were wrong.

## The guard

`theme-css.test.ts` gains four resolution cases. Removing the two new export patterns turns exactly the two extension-carrying ones red:

```
× resolves @lumis-sh/themes/css/github_light.css
× resolves @lumis-sh/themes/json/github_light.json
```

Found while building the `htmlLinked` demo for #1141, which works around both by using the forms that resolve today.