### PR TITLE
fix(html): render attribute-less spans consistently

### DIFF
--- a/crates/lumis-core/src/formatter/html.rs
+++ b/crates/lumis-core/src/formatter/html.rs
@@ -51,6 +51,9 @@ pub fn span_inline_attrs(
 }
 
 /// Generate an HTML `<span>` element with inline CSS styles.
+///
+/// A scope that resolves to no attributes still gets a bare `<span>`, matching
+/// the built-in formatters.
 pub fn span_inline(
     text: &str,
     language: Option<Language>,
@@ -62,11 +65,7 @@ pub fn span_inline(
     let escaped = escape(text);
     let attrs = span_inline_attrs(language, scope, theme, italic, include_highlights);
 
-    if attrs.is_empty() {
-        escaped
-    } else {
-        format!("<span {}>{}</span>", attrs, escaped)
-    }
+    format!("{}{}</span>", open_span(&attrs), escaped)
 }
 
 /// Generate HTML attributes for a span with CSS class.
@@ -329,10 +328,6 @@ pub fn span_multi_themes(
 ) -> String {
     let escaped = escape(text);
 
-    if themes.is_empty() {
-        return escaped;
-    }
-
     let attrs = span_multi_themes_attrs(
         scope,
         language,
@@ -343,11 +338,7 @@ pub fn span_multi_themes(
         include_highlights,
     );
 
-    if attrs.is_empty() {
-        escaped
-    } else {
-        format!("<span {}>{}</span>", attrs, escaped)
-    }
+    format!("{}{}</span>", open_span(&attrs), escaped)
 }
 
 /// Escape text for safe HTML output.
@@ -578,11 +569,15 @@ pub fn escape_fragment(text: &str) -> String {
     escape(text)
 }
 
+fn open_span(attrs: &str) -> String {
+    if attrs.is_empty() {
+        "<span>".to_string()
+    } else {
+        format!("<span {attrs}>")
+    }
+}
+
 /// Render highlight events into HTML lines, reopening active spans at line boundaries.
-///
-/// A scope whose attributes come out empty is not wrapped at all, matching
-/// [`span_inline`]. Such a span carries no class, style or data attribute, so
-/// nothing can select it and it only adds noise to the output.
 pub fn render_lines_from_events<F>(
     source: &str,
     events: &[crate::events::HighlightEvent],
@@ -592,7 +587,7 @@ where
     F: Fn(usize, &str) -> String,
 {
     let mut lines = vec![String::new()];
-    let mut stack: Vec<OpenSpan> = Vec::new();
+    let mut stack: Vec<(usize, String)> = Vec::new();
 
     for event in events {
         match event {
@@ -601,18 +596,11 @@ where
                 language,
             } => {
                 let attrs = span_attrs(*scope_index, language);
-                let emitted = !attrs.is_empty();
-                if emitted {
-                    append_fragment(&mut lines, &format!("<span {attrs}>"));
-                }
-                stack.push(OpenSpan {
-                    scope_index: *scope_index,
-                    language: language.clone(),
-                    emitted,
-                });
+                append_fragment(&mut lines, &open_span(&attrs));
+                stack.push((*scope_index, language.clone()));
             }
             crate::events::HighlightEvent::End => {
-                if stack.pop().is_some_and(|span| span.emitted) {
+                if stack.pop().is_some() {
                     append_fragment(&mut lines, "</span>");
                 }
             }
@@ -624,26 +612,19 @@ where
         }
     }
 
-    while let Some(span) = stack.pop() {
-        if span.emitted {
-            append_fragment(&mut lines, "</span>");
-        }
+    while stack.pop().is_some() {
+        append_fragment(&mut lines, "</span>");
     }
 
     lines
 }
 
-/// A span currently open on the render stack.
-struct OpenSpan {
-    scope_index: usize,
-    language: String,
-    /// False when the scope resolved to no attributes, so nothing was written
-    /// and there is no tag to close or reopen.
-    emitted: bool,
-}
-
-fn render_source_event<F>(lines: &mut Vec<String>, text: &str, stack: &[OpenSpan], span_attrs: &F)
-where
+fn render_source_event<F>(
+    lines: &mut Vec<String>,
+    text: &str,
+    stack: &[(usize, String)],
+    span_attrs: &F,
+) where
     F: Fn(usize, &str) -> String,
 {
     let mut remaining = text;
@@ -653,7 +634,7 @@ where
             Some(newline_index) => {
                 let fragment = &remaining[..newline_index];
                 append_fragment(lines, &escape_fragment(fragment));
-                close_open_spans(lines, stack);
+                close_open_spans(lines, stack.len());
                 lines.push(String::new());
                 reopen_spans(lines, stack, span_attrs);
                 remaining = &remaining[newline_index + 1..];
@@ -666,19 +647,19 @@ where
     }
 }
 
-fn close_open_spans(lines: &mut Vec<String>, stack: &[OpenSpan]) {
-    for _ in stack.iter().rev().filter(|span| span.emitted) {
+fn close_open_spans(lines: &mut Vec<String>, len: usize) {
+    for _ in 0..len {
         append_fragment(lines, "</span>");
     }
 }
 
-fn reopen_spans<F>(lines: &mut Vec<String>, stack: &[OpenSpan], span_attrs: &F)
+fn reopen_spans<F>(lines: &mut Vec<String>, stack: &[(usize, String)], span_attrs: &F)
 where
     F: Fn(usize, &str) -> String,
 {
-    for span in stack.iter().filter(|span| span.emitted) {
-        let attrs = span_attrs(span.scope_index, &span.language);
-        append_fragment(lines, &format!("<span {attrs}>"));
+    for (scope_index, language) in stack {
+        let attrs = span_attrs(*scope_index, language);
+        append_fragment(lines, &open_span(&attrs));
     }
 }
 
@@ -686,9 +667,6 @@ where
 ///
 /// This is a simplified version of the vendored HtmlRenderer that works with
 /// pre-computed `HighlightEvent` slices instead of tree-sitter iterators.
-///
-/// A scope for which `attribute_callback` writes nothing is not wrapped at all,
-/// matching [`render_lines_from_events`] and [`span_inline`].
 pub fn render_events<F>(
     source: &str,
     events: &[crate::events::HighlightEvent],
@@ -700,7 +678,7 @@ where
     let source = source.as_bytes();
     let mut html = Vec::new();
     let mut line_offsets = vec![0u32];
-    let mut highlight_stack: Vec<bool> = Vec::new();
+    let mut highlight_stack: Vec<(usize, String)> = Vec::new();
 
     for event in events {
         match event {
@@ -710,18 +688,18 @@ where
             } => {
                 let mut attrs = Vec::new();
                 attribute_callback(*scope_index, language, &mut attrs);
-                let emitted = !attrs.is_empty();
-                if emitted {
+                if attrs.is_empty() {
+                    html.extend_from_slice(b"<span>");
+                } else {
                     html.extend_from_slice(b"<span ");
                     html.extend_from_slice(&attrs);
                     html.push(b'>');
                 }
-                highlight_stack.push(emitted);
+                highlight_stack.push((*scope_index, language.clone()));
             }
             crate::events::HighlightEvent::End => {
-                if highlight_stack.pop().unwrap_or(false) {
-                    html.extend_from_slice(b"</span>");
-                }
+                html.extend_from_slice(b"</span>");
+                highlight_stack.pop();
             }
             crate::events::HighlightEvent::Source { start, end } => {
                 let s = (*start).min(source.len());
@@ -815,6 +793,31 @@ mod tests {
     #[test]
     fn test_escape_empty_string() {
         assert_eq!(escape(""), "");
+    }
+
+    #[test]
+    fn test_span_inline_without_attributes() {
+        assert_eq!(
+            span_inline("<b>", None, "string", None, false, false),
+            "<span>&lt;b&gt;</span>"
+        );
+    }
+
+    #[test]
+    fn test_span_multi_themes_without_attributes() {
+        assert_eq!(
+            span_multi_themes(
+                "<b>",
+                "string",
+                None,
+                &std::collections::HashMap::new(),
+                None,
+                "--lumis",
+                false,
+                false,
+            ),
+            "<span>&lt;b&gt;</span>"
+        );
     }
 
     #[test]

--- a/crates/lumis-core/src/formatter/html.rs
+++ b/crates/lumis-core/src/formatter/html.rs
@@ -51,9 +51,6 @@ pub fn span_inline_attrs(
 }
 
 /// Generate an HTML `<span>` element with inline CSS styles.
-///
-/// A scope that resolves to no attributes still gets a bare `<span>`, matching
-/// the built-in formatters.
 pub fn span_inline(
     text: &str,
     language: Option<Language>,

--- a/crates/lumis-core/src/formatter/html.rs
+++ b/crates/lumis-core/src/formatter/html.rs
@@ -579,6 +579,10 @@ pub fn escape_fragment(text: &str) -> String {
 }
 
 /// Render highlight events into HTML lines, reopening active spans at line boundaries.
+///
+/// A scope whose attributes come out empty is not wrapped at all, matching
+/// [`span_inline`]. Such a span carries no class, style or data attribute, so
+/// nothing can select it and it only adds noise to the output.
 pub fn render_lines_from_events<F>(
     source: &str,
     events: &[crate::events::HighlightEvent],
@@ -588,7 +592,7 @@ where
     F: Fn(usize, &str) -> String,
 {
     let mut lines = vec![String::new()];
-    let mut stack: Vec<(usize, String)> = Vec::new();
+    let mut stack: Vec<OpenSpan> = Vec::new();
 
     for event in events {
         match event {
@@ -597,11 +601,18 @@ where
                 language,
             } => {
                 let attrs = span_attrs(*scope_index, language);
-                append_fragment(&mut lines, &format!("<span {attrs}>"));
-                stack.push((*scope_index, language.clone()));
+                let emitted = !attrs.is_empty();
+                if emitted {
+                    append_fragment(&mut lines, &format!("<span {attrs}>"));
+                }
+                stack.push(OpenSpan {
+                    scope_index: *scope_index,
+                    language: language.clone(),
+                    emitted,
+                });
             }
             crate::events::HighlightEvent::End => {
-                if stack.pop().is_some() {
+                if stack.pop().is_some_and(|span| span.emitted) {
                     append_fragment(&mut lines, "</span>");
                 }
             }
@@ -613,19 +624,26 @@ where
         }
     }
 
-    while stack.pop().is_some() {
-        append_fragment(&mut lines, "</span>");
+    while let Some(span) = stack.pop() {
+        if span.emitted {
+            append_fragment(&mut lines, "</span>");
+        }
     }
 
     lines
 }
 
-fn render_source_event<F>(
-    lines: &mut Vec<String>,
-    text: &str,
-    stack: &[(usize, String)],
-    span_attrs: &F,
-) where
+/// A span currently open on the render stack.
+struct OpenSpan {
+    scope_index: usize,
+    language: String,
+    /// False when the scope resolved to no attributes, so nothing was written
+    /// and there is no tag to close or reopen.
+    emitted: bool,
+}
+
+fn render_source_event<F>(lines: &mut Vec<String>, text: &str, stack: &[OpenSpan], span_attrs: &F)
+where
     F: Fn(usize, &str) -> String,
 {
     let mut remaining = text;
@@ -635,7 +653,7 @@ fn render_source_event<F>(
             Some(newline_index) => {
                 let fragment = &remaining[..newline_index];
                 append_fragment(lines, &escape_fragment(fragment));
-                close_open_spans(lines, stack.len());
+                close_open_spans(lines, stack);
                 lines.push(String::new());
                 reopen_spans(lines, stack, span_attrs);
                 remaining = &remaining[newline_index + 1..];
@@ -648,18 +666,18 @@ fn render_source_event<F>(
     }
 }
 
-fn close_open_spans(lines: &mut Vec<String>, len: usize) {
-    for _ in 0..len {
+fn close_open_spans(lines: &mut Vec<String>, stack: &[OpenSpan]) {
+    for _ in stack.iter().rev().filter(|span| span.emitted) {
         append_fragment(lines, "</span>");
     }
 }
 
-fn reopen_spans<F>(lines: &mut Vec<String>, stack: &[(usize, String)], span_attrs: &F)
+fn reopen_spans<F>(lines: &mut Vec<String>, stack: &[OpenSpan], span_attrs: &F)
 where
     F: Fn(usize, &str) -> String,
 {
-    for (scope_index, language) in stack {
-        let attrs = span_attrs(*scope_index, language);
+    for span in stack.iter().filter(|span| span.emitted) {
+        let attrs = span_attrs(span.scope_index, &span.language);
         append_fragment(lines, &format!("<span {attrs}>"));
     }
 }
@@ -668,6 +686,9 @@ where
 ///
 /// This is a simplified version of the vendored HtmlRenderer that works with
 /// pre-computed `HighlightEvent` slices instead of tree-sitter iterators.
+///
+/// A scope for which `attribute_callback` writes nothing is not wrapped at all,
+/// matching [`render_lines_from_events`] and [`span_inline`].
 pub fn render_events<F>(
     source: &str,
     events: &[crate::events::HighlightEvent],
@@ -679,7 +700,7 @@ where
     let source = source.as_bytes();
     let mut html = Vec::new();
     let mut line_offsets = vec![0u32];
-    let mut highlight_stack: Vec<(usize, String)> = Vec::new();
+    let mut highlight_stack: Vec<bool> = Vec::new();
 
     for event in events {
         match event {
@@ -687,14 +708,20 @@ where
                 scope_index,
                 language,
             } => {
-                html.extend_from_slice(b"<span ");
-                attribute_callback(*scope_index, language, &mut html);
-                html.push(b'>');
-                highlight_stack.push((*scope_index, language.clone()));
+                let mut attrs = Vec::new();
+                attribute_callback(*scope_index, language, &mut attrs);
+                let emitted = !attrs.is_empty();
+                if emitted {
+                    html.extend_from_slice(b"<span ");
+                    html.extend_from_slice(&attrs);
+                    html.push(b'>');
+                }
+                highlight_stack.push(emitted);
             }
             crate::events::HighlightEvent::End => {
-                html.extend_from_slice(b"</span>");
-                highlight_stack.pop();
+                if highlight_stack.pop().unwrap_or(false) {
+                    html.extend_from_slice(b"</span>");
+                }
             }
             crate::events::HighlightEvent::Source { start, end } => {
                 let s = (*start).min(source.len());

--- a/crates/lumis/src/formatter/html.rs
+++ b/crates/lumis/src/formatter/html.rs
@@ -35,6 +35,14 @@ use std::io::{self, Write};
 /// let span = html::span_inline("fn", Some(Language::Rust), "keyword", theme.as_ref(), false, true);
 /// assert_eq!(span, r#"<span data-highlight="keyword" style="color: #ff79c6;">fn</span>"#);
 /// ```
+///
+/// A scope that resolves to no attributes still gets a bare `<span>`:
+///
+/// ```rust
+/// use lumis::html;
+///
+/// assert_eq!(html::span_inline("fn", None, "keyword", None, false, false), "<span>fn</span>");
+/// ```
 pub fn span_inline(
     text: &str,
     language: Option<Language>,
@@ -43,14 +51,14 @@ pub fn span_inline(
     italic: bool,
     include_highlights: bool,
 ) -> String {
-    let escaped = escape(text);
-    let attrs = span_inline_attrs(language, scope, theme, italic, include_highlights);
-
-    if attrs.is_empty() {
-        escaped
-    } else {
-        format!("<span {}>{}</span>", attrs, escaped)
-    }
+    lumis_core::formatter::html::span_inline(
+        text,
+        language,
+        scope,
+        theme,
+        italic,
+        include_highlights,
+    )
 }
 
 /// Generate HTML attributes for a span with inline CSS styles.
@@ -487,13 +495,8 @@ pub fn span_multi_themes(
     italic: bool,
     include_highlights: bool,
 ) -> String {
-    let escaped = escape(text);
-
-    if themes.is_empty() {
-        return escaped;
-    }
-
-    let attrs = span_multi_themes_attrs(
+    lumis_core::formatter::html::span_multi_themes(
+        text,
         scope,
         language,
         themes,
@@ -501,13 +504,7 @@ pub fn span_multi_themes(
         css_variable_prefix,
         italic,
         include_highlights,
-    );
-
-    if attrs.is_empty() {
-        escaped
-    } else {
-        format!("<span {}>{}</span>", attrs, escaped)
-    }
+    )
 }
 
 /// Escape text for safe HTML output.
@@ -972,7 +969,22 @@ mod tests {
     #[test]
     fn test_span_inline_no_theme() {
         let result = span_inline("text", None, "text", None, false, false);
-        assert_str_eq!(result, "text");
+        assert_str_eq!(result, "<span>text</span>");
+    }
+
+    #[test]
+    fn test_span_multi_themes_no_theme() {
+        let result = span_multi_themes(
+            "<b>",
+            "text",
+            None,
+            &std::collections::HashMap::new(),
+            None,
+            "--lumis",
+            false,
+            false,
+        );
+        assert_str_eq!(result, "<span>&lt;b&gt;</span>");
     }
 
     #[test]

--- a/crates/lumis/src/formatter/html_inline.rs
+++ b/crates/lumis/src/formatter/html_inline.rs
@@ -266,9 +266,37 @@ mod tests {
         let mut buffer = Vec::new();
         formatter.format(code, &mut buffer).unwrap();
         let result = String::from_utf8(buffer).unwrap();
-        let expected = r#"<pre class="lumis"><code class="language-elixir" translate="no" tabindex="0"><div class="l-line" data-line="1"><span ><span >@<span ><span >lang <span >:rust</span></span></span></span></span>
+        let expected = r#"<pre class="lumis"><code class="language-elixir" translate="no" tabindex="0"><div class="l-line" data-line="1">@lang :rust
 </div></code></pre>"#;
         assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_unstyled_scope_is_not_wrapped() {
+        let theme = themes::get("dracula").unwrap();
+        let code = "# *italic*";
+        let formatter = HtmlInline::new(
+            Language::Markdown,
+            Some(theme),
+            None,
+            false,
+            false,
+            None,
+            None,
+        );
+        let mut buffer = Vec::new();
+        formatter.format(code, &mut buffer).unwrap();
+        let result = String::from_utf8(buffer).unwrap();
+
+        assert!(
+            !result.contains("<span >"),
+            "a scope with no resolved style must not be wrapped: {result}"
+        );
+        assert_eq!(
+            result.matches("<span").count(),
+            result.matches("</span>").count(),
+            "open and close tags must stay balanced: {result}"
+        );
     }
 
     #[test]
@@ -472,10 +500,10 @@ mod tests {
         formatter.format(code, &mut buffer).unwrap();
         let result = String::from_utf8(buffer).unwrap();
 
-        let expected = r#"<pre class="lumis"><code class="language-rust" translate="no" tabindex="0"><div class="l-line custom-highlight" data-line="1"><span >fn</span> <span >main</span><span >(</span><span >)</span> <span >{</span>
-</div><div class="l-line" data-line="2">    <span >println</span><span >!</span><span >(</span><span >&quot;Hello, world!&quot;</span><span >)</span><span >;</span>
-</div><div class="l-line custom-highlight" data-line="3">    <span >let</span> <span >x</span> <span >=</span> <span >42</span><span >;</span>
-</div><div class="l-line" data-line="4"><span >}</span>
+        let expected = r#"<pre class="lumis"><code class="language-rust" translate="no" tabindex="0"><div class="l-line custom-highlight" data-line="1">fn main() {
+</div><div class="l-line" data-line="2">    println!(&quot;Hello, world!&quot;);
+</div><div class="l-line custom-highlight" data-line="3">    let x = 42;
+</div><div class="l-line" data-line="4">}
 </div></code></pre>"#;
         assert_str_eq!(result, expected);
     }
@@ -528,7 +556,7 @@ mod tests {
         formatter.format(code, &mut buffer).unwrap();
         let result = String::from_utf8(buffer).unwrap();
 
-        let expected = r#"<section class="highlight" data-lang="rust"><pre class="lumis custom-class"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span >fn</span> <span >main</span><span >(</span><span >)</span> <span >{</span> <span >}</span>
+        let expected = r#"<section class="highlight" data-lang="rust"><pre class="lumis custom-class"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1">fn main() { }
 </div></code></pre></section>"#;
         assert_str_eq!(result, expected);
     }

--- a/crates/lumis/src/formatter/html_inline.rs
+++ b/crates/lumis/src/formatter/html_inline.rs
@@ -266,13 +266,13 @@ mod tests {
         let mut buffer = Vec::new();
         formatter.format(code, &mut buffer).unwrap();
         let result = String::from_utf8(buffer).unwrap();
-        let expected = r#"<pre class="lumis"><code class="language-elixir" translate="no" tabindex="0"><div class="l-line" data-line="1">@lang :rust
+        let expected = r#"<pre class="lumis"><code class="language-elixir" translate="no" tabindex="0"><div class="l-line" data-line="1"><span><span>@<span><span>lang <span>:rust</span></span></span></span></span>
 </div></code></pre>"#;
         assert_eq!(result, expected)
     }
 
     #[test]
-    fn test_unstyled_scope_is_not_wrapped() {
+    fn test_unstyled_scope_opens_a_bare_span() {
         let theme = themes::get("dracula").unwrap();
         let code = "# *italic*";
         let formatter = HtmlInline::new(
@@ -289,13 +289,12 @@ mod tests {
         let result = String::from_utf8(buffer).unwrap();
 
         assert!(
-            !result.contains("<span >"),
-            "a scope with no resolved style must not be wrapped: {result}"
+            result.contains("<span>*italic*</span>"),
+            "a scope dracula does not define must open a bare `<span>`: {result}"
         );
-        assert_eq!(
-            result.matches("<span").count(),
-            result.matches("</span>").count(),
-            "open and close tags must stay balanced: {result}"
+        assert!(
+            !result.contains("<span >"),
+            "an attribute-less span must not carry a trailing space: {result}"
         );
     }
 
@@ -500,10 +499,10 @@ mod tests {
         formatter.format(code, &mut buffer).unwrap();
         let result = String::from_utf8(buffer).unwrap();
 
-        let expected = r#"<pre class="lumis"><code class="language-rust" translate="no" tabindex="0"><div class="l-line custom-highlight" data-line="1">fn main() {
-</div><div class="l-line" data-line="2">    println!(&quot;Hello, world!&quot;);
-</div><div class="l-line custom-highlight" data-line="3">    let x = 42;
-</div><div class="l-line" data-line="4">}
+        let expected = r#"<pre class="lumis"><code class="language-rust" translate="no" tabindex="0"><div class="l-line custom-highlight" data-line="1"><span>fn</span> <span>main</span><span>(</span><span>)</span> <span>{</span>
+</div><div class="l-line" data-line="2">    <span>println</span><span>!</span><span>(</span><span>&quot;Hello, world!&quot;</span><span>)</span><span>;</span>
+</div><div class="l-line custom-highlight" data-line="3">    <span>let</span> <span>x</span> <span>=</span> <span>42</span><span>;</span>
+</div><div class="l-line" data-line="4"><span>}</span>
 </div></code></pre>"#;
         assert_str_eq!(result, expected);
     }
@@ -556,7 +555,7 @@ mod tests {
         formatter.format(code, &mut buffer).unwrap();
         let result = String::from_utf8(buffer).unwrap();
 
-        let expected = r#"<section class="highlight" data-lang="rust"><pre class="lumis custom-class"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1">fn main() { }
+        let expected = r#"<section class="highlight" data-lang="rust"><pre class="lumis custom-class"><code class="language-rust" translate="no" tabindex="0"><div class="l-line" data-line="1"><span>fn</span> <span>main</span><span>(</span><span>)</span> <span>{</span> <span>}</span>
 </div></code></pre></section>"#;
         assert_str_eq!(result, expected);
     }

--- a/fixtures/conformance/markdown-inline-basic/html-inline.html
+++ b/fixtures/conformance/markdown-inline-basic/html-inline.html
@@ -1,3 +1,3 @@
-<pre class="lumis" style="color: #f8f8f2; background-color: #282a36;"><code class="language-markdown" translate="no" tabindex="0"><div class="l-line" data-line="1"><span style="color: #f8f8f2;"># <span >*italic*</span></span>
+<pre class="lumis" style="color: #f8f8f2; background-color: #282a36;"><code class="language-markdown" translate="no" tabindex="0"><div class="l-line" data-line="1"><span style="color: #f8f8f2;"># *italic*</span>
 </div><div class="l-line" data-line="2"><span style="color: #f8f8f2;"></span>
 </div></code></pre>

--- a/fixtures/conformance/markdown-inline-basic/html-inline.html
+++ b/fixtures/conformance/markdown-inline-basic/html-inline.html
@@ -1,3 +1,3 @@
-<pre class="lumis" style="color: #f8f8f2; background-color: #282a36;"><code class="language-markdown" translate="no" tabindex="0"><div class="l-line" data-line="1"><span style="color: #f8f8f2;"># *italic*</span>
+<pre class="lumis" style="color: #f8f8f2; background-color: #282a36;"><code class="language-markdown" translate="no" tabindex="0"><div class="l-line" data-line="1"><span style="color: #f8f8f2;"># <span>*italic*</span></span>
 </div><div class="l-line" data-line="2"><span style="color: #f8f8f2;"></span>
 </div></code></pre>

--- a/packages/javascript/lumis/src/formatter/html-multi-themes.ts
+++ b/packages/javascript/lumis/src/formatter/html-multi-themes.ts
@@ -9,6 +9,7 @@ import {
   joinClasses,
   lineIsHighlighted,
   openCodeTag,
+  openSpanTag,
   openTag,
   spanMultiThemesAttrs,
   styleToCss,
@@ -140,7 +141,7 @@ export function formatHtmlMultiThemes(
 ): string {
   const theme = formatter.defaultTheme ? formatter.themes[formatter.defaultTheme] : undefined;
   const { lines } = formatHighlightIterLines(source, events, formatter.language, theme, {
-    openSpan: (span, _style) => openTag("span", spanAttrs(span, formatter)),
+    openSpan: (span, _style) => openSpanTag(spanAttrs(span, formatter)),
   });
 
   const pre = openTag("pre", {

--- a/packages/javascript/lumis/src/formatter/html.ts
+++ b/packages/javascript/lumis/src/formatter/html.ts
@@ -316,10 +316,6 @@ export function closeTag(name: string): string {
 
 /**
  * Open a `<span>` carrying the given attributes.
- *
- * A scope with no attributes still gets a bare `<span>`, so highlighted output
- * is byte-identical everywhere Lumis runs.
- *
  * ```ts
  * openSpanTag({ class: 'l-keyword' })  // '<span class="l-keyword">'
  * openSpanTag({})                      // '<span>'
@@ -493,10 +489,6 @@ export function spanInlineAttrs(options: SpanInlineOptions): HtmlAttrs {
 
 /**
  * Render an inline-styled `<span>` for a token.
- *
- * A scope that resolves to no style still gets a bare `<span>`, so a custom
- * formatter built on this helper produces the same markup as the built-in ones.
- *
  * ```ts
  * spanInline('const', { language: 'javascript', scope: 'keyword', theme: dracula })
  * // '<span style="color: #ff79c6;">const</span>'

--- a/packages/javascript/lumis/src/formatter/html.ts
+++ b/packages/javascript/lumis/src/formatter/html.ts
@@ -317,13 +317,18 @@ export function closeTag(name: string): string {
 /**
  * Open a `<span>` tag with the given attributes.
  *
+ * Returns an empty string when there are no attributes, so a scope that
+ * resolves to no style is not wrapped at all. See {@link spanInline}, which
+ * returns the bare text in the same situation.
+ *
  * ```ts
  * openSpanTag({ class: 'l-keyword' })  // '<span class="l-keyword">'
+ * openSpanTag({})                      // ''
  * ```
  */
 export function openSpanTag(attrs: HtmlAttrs = {}): string {
   const renderedAttrs = attrsToString(attrs);
-  return renderedAttrs.length > 0 ? `<span ${renderedAttrs}>` : `<span >`;
+  return renderedAttrs.length > 0 ? `<span ${renderedAttrs}>` : "";
 }
 
 /**
@@ -862,14 +867,22 @@ export function appendFragment(lines: string[], fragment: string): void {
   }
 }
 
+interface SpanStackEntry {
+  scope: string;
+  language: string;
+  /** False when `openSpan` produced nothing, so there is no tag to close or reopen. */
+  emitted: boolean;
+}
+
 function closeOpenSpans(
   lines: string[],
-  stack: Array<{ scope: string; language: string }>,
+  stack: SpanStackEntry[],
   closeSpan: (span: HighlightSpan, style: HighlightStyle | undefined) => string,
   theme: Theme | undefined,
 ): void {
   for (let i = stack.length - 1; i >= 0; i -= 1) {
     const entry = stack[i]!;
+    if (!entry.emitted) continue;
     const style = getSpanStyle(theme, entry.scope, entry.language);
     appendFragment(lines, closeSpan(emptySpan(entry.scope, entry.language), style));
   }
@@ -877,11 +890,12 @@ function closeOpenSpans(
 
 function reopenSpans(
   lines: string[],
-  stack: Array<{ scope: string; language: string }>,
+  stack: SpanStackEntry[],
   openSpan: (span: HighlightSpan, style: HighlightStyle | undefined) => string,
   theme: Theme | undefined,
 ): void {
   for (const entry of stack) {
+    if (!entry.emitted) continue;
     const style = getSpanStyle(theme, entry.scope, entry.language);
     appendFragment(lines, openSpan(emptySpan(entry.scope, entry.language), style));
   }
@@ -890,7 +904,7 @@ function reopenSpans(
 function renderSourceEvent(
   lines: string[],
   text: string,
-  stack: Array<{ scope: string; language: string }>,
+  stack: SpanStackEntry[],
   formatText: (text: string) => string,
   openSpan: (span: HighlightSpan, style: HighlightStyle | undefined) => string,
   closeSpan: (span: HighlightSpan, style: HighlightStyle | undefined) => string,
@@ -930,20 +944,25 @@ export function formatHighlightIterLines(
   const sourceBytes = encodeSource(source);
   const lines = [""];
   let language = languageRef ? languageId(languageRef) : "plaintext";
-  const stack: Array<{ scope: string; language: string }> = [];
+  const stack: SpanStackEntry[] = [];
 
   for (const event of events) {
     if (event.type === "start") {
       const style = getSpanStyle(theme, event.scope, event.language);
       const span = emptySpan(event.scope, event.language);
-      appendFragment(lines, options.openSpan(span, style));
-      stack.push({ scope: event.scope, language: event.language });
+      const open = options.openSpan(span, style);
+      appendFragment(lines, open);
+      stack.push({
+        scope: event.scope,
+        language: event.language,
+        emitted: open.length > 0,
+      });
       continue;
     }
 
     if (event.type === "end") {
       const top = stack.pop();
-      if (top) {
+      if (top?.emitted) {
         const style = getSpanStyle(theme, top.scope, top.language);
         const span = emptySpan(top.scope, top.language);
         appendFragment(lines, closeSpan(span, style));
@@ -962,8 +981,10 @@ export function formatHighlightIterLines(
     renderSourceEvent(lines, text, stack, formatText, options.openSpan, closeSpan, theme);
   }
 
-  while (stack.pop()) {
-    appendFragment(lines, closeSpan(emptySpan("", ""), undefined));
+  for (let entry = stack.pop(); entry; entry = stack.pop()) {
+    if (entry.emitted) {
+      appendFragment(lines, closeSpan(emptySpan("", ""), undefined));
+    }
   }
 
   return { lines, language };
@@ -971,6 +992,8 @@ export function formatHighlightIterLines(
 
 /**
  * Render highlight events into escaped HTML lines, reopening active spans across newlines.
+ *
+ * A scope for which `spanAttrs` returns nothing is not wrapped at all.
  *
  * ```ts
  * renderLinesFromEvents('a\nb', events, (scope) => `class="${scope}"`)
@@ -985,7 +1008,7 @@ export function renderLinesFromEvents(
   return formatHighlightIterLines(source, events, undefined, undefined, {
     openSpan: (span) => {
       const attrs = spanAttrs(span.scope, span.language);
-      return attrs.length > 0 ? `<span ${attrs}>` : "<span >";
+      return attrs.length > 0 ? `<span ${attrs}>` : "";
     },
   }).lines;
 }
@@ -1010,17 +1033,24 @@ export function renderEvents(
     renderedLength += fragment.length;
   };
 
+  const emittedStack: boolean[] = [];
+
   for (const event of events) {
     if (event.type === "start") {
-      push("<span ");
-      attributeCallback(event.scope, event.language, html);
-      renderedLength = html.join("").length;
-      push(">");
+      const attrs: string[] = [];
+      attributeCallback(event.scope, event.language, attrs);
+      const rendered = attrs.join("");
+      emittedStack.push(rendered.length > 0);
+      if (rendered.length > 0) {
+        push(`<span ${rendered}>`);
+      }
       continue;
     }
 
     if (event.type === "end") {
-      push("</span>");
+      if (emittedStack.pop()) {
+        push("</span>");
+      }
       continue;
     }
 

--- a/packages/javascript/lumis/src/formatter/html.ts
+++ b/packages/javascript/lumis/src/formatter/html.ts
@@ -315,20 +315,22 @@ export function closeTag(name: string): string {
 }
 
 /**
- * Open a `<span>` tag with the given attributes.
+ * Open a `<span>` carrying the given attributes.
  *
- * Returns an empty string when there are no attributes, so a scope that
- * resolves to no style is not wrapped at all. See {@link spanInline}, which
- * returns the bare text in the same situation.
+ * A scope with no attributes still gets a bare `<span>`, so highlighted output
+ * is byte-identical everywhere Lumis runs.
  *
  * ```ts
  * openSpanTag({ class: 'l-keyword' })  // '<span class="l-keyword">'
- * openSpanTag({})                      // ''
+ * openSpanTag({})                      // '<span>'
  * ```
  */
 export function openSpanTag(attrs: HtmlAttrs = {}): string {
-  const renderedAttrs = attrsToString(attrs);
-  return renderedAttrs.length > 0 ? `<span ${renderedAttrs}>` : "";
+  return openSpan(attrsToString(attrs));
+}
+
+function openSpan(attrs: string): string {
+  return attrs.length > 0 ? `<span ${attrs}>` : "<span>";
 }
 
 /**
@@ -492,16 +494,19 @@ export function spanInlineAttrs(options: SpanInlineOptions): HtmlAttrs {
 /**
  * Render an inline-styled `<span>` for a token.
  *
+ * A scope that resolves to no style still gets a bare `<span>`, so a custom
+ * formatter built on this helper produces the same markup as the built-in ones.
+ *
  * ```ts
  * spanInline('const', { language: 'javascript', scope: 'keyword', theme: dracula })
  * // '<span style="color: #ff79c6;">const</span>'
+ *
+ * spanInline('const', { language: 'javascript', scope: 'keyword', theme: undefined })
+ * // '<span>const</span>'
  * ```
  */
 export function spanInline(text: string, options: SpanInlineOptions): string {
-  const escaped = escape(text);
-  const attrs = spanInlineAttrs(options);
-  const rendered = attrsToString(attrs);
-  return rendered.length > 0 ? `<span ${rendered}>${escaped}</span>` : escaped;
+  return `${openSpanTag(spanInlineAttrs(options))}${escape(text)}</span>`;
 }
 
 /**
@@ -675,14 +680,7 @@ function applyDefaultMultiTheme(
  */
 export function spanMultiThemes(text: string, options: SpanMultiThemesOptions): string {
   const escaped = escape(text);
-
-  if (Object.keys(options.themes).length === 0) {
-    return escaped;
-  }
-
-  const attrs = spanMultiThemesAttrs(options);
-  const rendered = attrsToString(attrs);
-  return rendered.length > 0 ? `<span ${rendered}>${escaped}</span>` : escaped;
+  return `${openSpanTag(spanMultiThemesAttrs(options))}${escaped}</span>`;
 }
 
 function pushThemeCssVars(
@@ -870,7 +868,6 @@ export function appendFragment(lines: string[], fragment: string): void {
 interface SpanStackEntry {
   scope: string;
   language: string;
-  /** False when `openSpan` produced nothing, so there is no tag to close or reopen. */
   emitted: boolean;
 }
 
@@ -952,11 +949,7 @@ export function formatHighlightIterLines(
       const span = emptySpan(event.scope, event.language);
       const open = options.openSpan(span, style);
       appendFragment(lines, open);
-      stack.push({
-        scope: event.scope,
-        language: event.language,
-        emitted: open.length > 0,
-      });
+      stack.push({ scope: event.scope, language: event.language, emitted: open.length > 0 });
       continue;
     }
 
@@ -993,8 +986,6 @@ export function formatHighlightIterLines(
 /**
  * Render highlight events into escaped HTML lines, reopening active spans across newlines.
  *
- * A scope for which `spanAttrs` returns nothing is not wrapped at all.
- *
  * ```ts
  * renderLinesFromEvents('a\nb', events, (scope) => `class="${scope}"`)
  * // ['<span class="...">a</span>', '<span class="...">b</span>']
@@ -1006,10 +997,7 @@ export function renderLinesFromEvents(
   spanAttrs: (scope: string, language: string) => string,
 ): string[] {
   return formatHighlightIterLines(source, events, undefined, undefined, {
-    openSpan: (span) => {
-      const attrs = spanAttrs(span.scope, span.language);
-      return attrs.length > 0 ? `<span ${attrs}>` : "";
-    },
+    openSpan: (span) => openSpan(spanAttrs(span.scope, span.language)),
   }).lines;
 }
 
@@ -1033,24 +1021,16 @@ export function renderEvents(
     renderedLength += fragment.length;
   };
 
-  const emittedStack: boolean[] = [];
-
   for (const event of events) {
     if (event.type === "start") {
       const attrs: string[] = [];
       attributeCallback(event.scope, event.language, attrs);
-      const rendered = attrs.join("");
-      emittedStack.push(rendered.length > 0);
-      if (rendered.length > 0) {
-        push(`<span ${rendered}>`);
-      }
+      push(openSpan(attrs.join("")));
       continue;
     }
 
     if (event.type === "end") {
-      if (emittedStack.pop()) {
-        push("</span>");
-      }
+      push("</span>");
       continue;
     }
 

--- a/packages/javascript/lumis/test/formatter-shared.test.ts
+++ b/packages/javascript/lumis/test/formatter-shared.test.ts
@@ -117,6 +117,8 @@ describe("formatter shared helpers", () => {
     expect(closeCodeTag()).toBe("</code>");
     expect(closingTags()).toBe("</code></pre>");
     expect(openSpanTag({ class: "token" })).toBe('<span class="token">');
+    expect(openSpanTag()).toBe("");
+    expect(openSpanTag({ class: undefined })).toBe("");
     expect(openPreTag()).toBe('<pre class="lumis">');
     expect(openPreTag({ preClass: "custom" })).toBe('<pre class="lumis custom">');
     expect(openPreTag({ theme })).toBe(
@@ -222,6 +224,51 @@ describe("formatter shared helpers", () => {
     );
 
     expect(lines).toEqual(['<span class="string">a</span>', '<span class="string">b</span>']);
+  });
+
+  it("does not wrap a scope whose attrs come out empty", () => {
+    const lines = renderLinesFromEvents(
+      "ab",
+      [
+        { type: "start", scope: "string", language: "json" },
+        { type: "source", startByte: 0, endByte: 1 },
+        { type: "start", scope: "unstyled", language: "json" },
+        { type: "source", startByte: 1, endByte: 2 },
+        { type: "end" },
+        { type: "end" },
+      ],
+      (scope) => (scope === "unstyled" ? "" : `class="${scope}"`),
+    );
+
+    expect(lines).toEqual(['<span class="string">ab</span>']);
+  });
+
+  it("keeps tags balanced when a skipped span straddles a newline", () => {
+    const lines = renderLinesFromEvents(
+      "a\nb",
+      [
+        { type: "start", scope: "unstyled", language: "json" },
+        { type: "source", startByte: 0, endByte: 3 },
+        { type: "end" },
+      ],
+      () => "",
+    );
+
+    expect(lines).toEqual(["a", "b"]);
+  });
+
+  it("omits the span in renderEvents when the callback writes nothing", () => {
+    const [html] = renderEvents(
+      "ab",
+      [
+        { type: "start", scope: "unstyled", language: "json" },
+        { type: "source", startByte: 0, endByte: 2 },
+        { type: "end" },
+      ],
+      () => {},
+    );
+
+    expect(new TextDecoder().decode(html)).toBe("ab");
   });
 
   it("renders event HTML and slices it back into lines", () => {

--- a/packages/javascript/lumis/test/formatter-shared.test.ts
+++ b/packages/javascript/lumis/test/formatter-shared.test.ts
@@ -117,8 +117,8 @@ describe("formatter shared helpers", () => {
     expect(closeCodeTag()).toBe("</code>");
     expect(closingTags()).toBe("</code></pre>");
     expect(openSpanTag({ class: "token" })).toBe('<span class="token">');
-    expect(openSpanTag()).toBe("");
-    expect(openSpanTag({ class: undefined })).toBe("");
+    expect(openSpanTag()).toBe("<span>");
+    expect(openSpanTag({ class: undefined })).toBe("<span>");
     expect(openPreTag()).toBe('<pre class="lumis">');
     expect(openPreTag({ preClass: "custom" })).toBe('<pre class="lumis custom">');
     expect(openPreTag({ theme })).toBe(
@@ -206,6 +206,22 @@ describe("formatter shared helpers", () => {
     ]);
   });
 
+  it("keeps a deliberately omitted custom span balanced", () => {
+    const { lines } = formatHighlightIterLines(
+      "a\nb",
+      [
+        { type: "start", scope: "string", language: "json" },
+        { type: "source", startByte: 0, endByte: 3 },
+        { type: "end" },
+      ],
+      jsonLang,
+      undefined,
+      { openSpan: () => "" },
+    );
+
+    expect(lines).toEqual(["a", "b"]);
+  });
+
   it("escapes braces only through the framework helper", () => {
     expect(escapeBraces("fn() {}")).toBe("fn() &lbrace;&rbrace;");
     expect(escapeBraces("<div>{x}</div>")).toBe("<div>&lbrace;x&rbrace;</div>");
@@ -226,7 +242,7 @@ describe("formatter shared helpers", () => {
     expect(lines).toEqual(['<span class="string">a</span>', '<span class="string">b</span>']);
   });
 
-  it("does not wrap a scope whose attrs come out empty", () => {
+  it("opens a bare span for a scope whose attrs come out empty", () => {
     const lines = renderLinesFromEvents(
       "ab",
       [
@@ -240,10 +256,10 @@ describe("formatter shared helpers", () => {
       (scope) => (scope === "unstyled" ? "" : `class="${scope}"`),
     );
 
-    expect(lines).toEqual(['<span class="string">ab</span>']);
+    expect(lines).toEqual(['<span class="string">a<span>b</span></span>']);
   });
 
-  it("keeps tags balanced when a skipped span straddles a newline", () => {
+  it("reopens a bare span across a newline", () => {
     const lines = renderLinesFromEvents(
       "a\nb",
       [
@@ -254,10 +270,10 @@ describe("formatter shared helpers", () => {
       () => "",
     );
 
-    expect(lines).toEqual(["a", "b"]);
+    expect(lines).toEqual(["<span>a</span>", "<span>b</span>"]);
   });
 
-  it("omits the span in renderEvents when the callback writes nothing", () => {
+  it("opens a bare span in renderEvents when the callback writes nothing", () => {
     const [html] = renderEvents(
       "ab",
       [
@@ -268,7 +284,7 @@ describe("formatter shared helpers", () => {
       () => {},
     );
 
-    expect(new TextDecoder().decode(html)).toBe("ab");
+    expect(new TextDecoder().decode(html)).toBe("<span>ab</span>");
   });
 
   it("renders event HTML and slices it back into lines", () => {
@@ -322,9 +338,9 @@ describe("formatter shared helpers", () => {
     expect(html).toContain("#22ff22");
   });
 
-  it("returns plain escaped text when no style matches", () => {
+  it("opens a bare span around escaped text when no style matches", () => {
     const html = spanInline("<b>", { language: "json", scope: "string" });
-    expect(html).toBe("&lt;b&gt;");
+    expect(html).toBe("<span>&lt;b&gt;</span>");
   });
 
   it("generates linked span attrs", () => {
@@ -360,9 +376,9 @@ describe("formatter shared helpers", () => {
     expect(html).toContain("x");
   });
 
-  it("returns plain text for multi-themes with empty themes", () => {
+  it("opens a bare multi-themes span with empty themes", () => {
     const html = spanMultiThemes("<b>", { scope: "string", language: "json", themes: {} });
-    expect(html).toBe("&lt;b&gt;");
+    expect(html).toBe("<span>&lt;b&gt;</span>");
   });
 });
 


### PR DESCRIPTION
Follow-up to #1142, which flagged the attribute-less span disagreement.

## Contract

A highlighted scope still has a span even when its formatter resolves no attributes. Every HTML path now serializes that wrapper as `<span>`, never `<span >` and never bare text.

This preserves the highlight-event structure while making the output byte-identical across Rust, CLI, Elixir, native Node, and the browser/WASM runtime.

## What changed

- Rust's shared HTML renderer uses one private opening-tag helper for inline spans, multi-theme spans, line rendering, and event rendering.
- The public Rust helpers delegate token rendering to `lumis-core` instead of maintaining another copy of the behavior.
- JavaScript's existing `openSpanTag`, inline, multi-theme, line, and event helpers use the same `<span>` representation.
- Multi-theme helpers now follow the same rule even when their theme map is empty.
- A custom JavaScript formatter that deliberately returns no opening tag still does not receive an unmatched closing tag.
- The `markdown-inline-basic` conformance fixture now contains `<span>*italic*</span>`.

The linked formatter is unchanged because it always emits a class attribute.

## Verification

- `mise run fmt`
- `mise run conformance-regen markdown-inline-basic`
- `mise exec -- cargo test -p lumis-core -p lumis` — 210 Lumis tests, 63 core tests, and doctests passed
- focused JavaScript formatter suite — 37 passed
- `mise run test-conformance`
  - Rust: 162
  - CLI: 135
  - JavaScript native: 135
  - JavaScript WASM: 135
  - browser engines: 12
  - Elixir: 135
- `mise run lint`
