### PR TITLE
fix(javascript): validate boundary data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,10 @@ Rust is the reference implementation and must follow the Rust API Guidelines:
 
 Prefer guideline-compliant naming, error behavior, builder patterns, documentation, and trait usage. Do not introduce a Rust API shortcut that other runtimes cannot sensibly mirror.
 
+### Parse TypeScript boundaries into domain types
+
+`unknown` belongs at genuinely untrusted boundaries, not throughout the implementation. Do not widen a known structure to `Record<string, unknown>` or use assertions to make parsed JSON, TOML, dynamic imports, native data, or other external values look typed. Validate the input and construct a named or discriminated domain value before passing it inward. When another API already defines the shape, derive it with utilities such as `Parameters`, `ReturnType`, or `Pick` instead of recreating it as a generic property bag.
+
 ### Tree-sitter is the driver
 
 Lumis is a Tree-sitter-based syntax highlighter. Language behavior must respect Tree-sitter's design, mechanics, and query model rather than bypassing them with ad hoc text scanning.

--- a/docs/content/integrations/react.mdx
+++ b/docs/content/integrations/react.mdx
@@ -92,16 +92,19 @@ import githubLight from '@lumis-sh/themes/github_light'
 const highlighter = createHighlighter({languages: [bundledLanguages]})
 
 export function Example() {
-  const {content, isLoading} = useLumis({
+  const {content, error, isLoading} = useLumis({
     children: 'export const answer = 42',
     formatter: htmlInline({language: 'typescript', theme: githubLight}),
     highlighter,
   })
 
   if (isLoading) return <p>Loading syntax highlighter...</p>
+  if (error) return <p>{error.message}</p>
   return <>{content}</>
 }
 ```
+
+`error` is an `Error` when highlighting or language loading fails, and `undefined` otherwise.
 
 ## Server rendering
 

--- a/packages/javascript/lumis/scripts/build-langs.ts
+++ b/packages/javascript/lumis/scripts/build-langs.ts
@@ -9,6 +9,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { parse as parseToml } from "smol-toml";
+import { parseLanguagesToml, type LanguagesToml } from "./languages-toml.js";
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, "../../../..");
 const OUT_DIR = path.resolve(import.meta.dirname, "../langs");
@@ -32,28 +33,9 @@ function pinnedVersions(): Map<string, string> {
   return versions;
 }
 
-interface ParserEntry {
-  aliases?: string[];
-  emacs?: string[];
-  shebang?: string[];
-  wasm_name?: string;
-  display_name?: string;
-  variant?: string;
-  globs?: string[];
-}
-
-interface BundleEntry {
-  parsers: string[] | "all";
-}
-
-interface LanguagesToml {
-  parsers: Record<string, ParserEntry>;
-  bundles?: Record<string, BundleEntry>;
-}
-
 function readLanguagesToml(): LanguagesToml {
   const text = fs.readFileSync(LANGUAGES_TOML, "utf-8");
-  return parseToml(text) as unknown as LanguagesToml;
+  return parseLanguagesToml(parseToml(text));
 }
 
 function main() {

--- a/packages/javascript/lumis/scripts/languages-toml.ts
+++ b/packages/javascript/lumis/scripts/languages-toml.ts
@@ -1,0 +1,99 @@
+import type { TomlTableWithoutBigInt, TomlValueWithoutBigInt } from "smol-toml";
+
+export interface ParserEntry {
+  aliases?: string[];
+  emacs?: string[];
+  shebang?: string[];
+  wasm_name?: string;
+  display_name?: string;
+  variant?: string;
+  globs?: string[];
+}
+
+export interface BundleEntry {
+  parsers: string[] | "all";
+}
+
+export interface LanguagesToml {
+  parsers: Record<string, ParserEntry>;
+  bundles?: Record<string, BundleEntry>;
+}
+
+function invalid(path: string): never {
+  throw new Error(`Invalid languages.toml: ${path}`);
+}
+
+function requireTable(
+  value: TomlValueWithoutBigInt | undefined,
+  path: string,
+): TomlTableWithoutBigInt {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    value instanceof Date
+  ) {
+    return invalid(path);
+  }
+  return value;
+}
+
+function optionalString(
+  table: TomlTableWithoutBigInt,
+  key: string,
+  path: string,
+): string | undefined {
+  const value = table[key];
+  if (value === undefined || typeof value === "string") return value;
+  return invalid(`${path}.${key}`);
+}
+
+function optionalStringArray(
+  table: TomlTableWithoutBigInt,
+  key: string,
+  path: string,
+): string[] | undefined {
+  const value = table[key];
+  if (value === undefined) return undefined;
+  if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) return value;
+  return invalid(`${path}.${key}`);
+}
+
+function parseParser(value: TomlValueWithoutBigInt, id: string): ParserEntry {
+  const path = `parsers.${id}`;
+  const table = requireTable(value, path);
+  return {
+    aliases: optionalStringArray(table, "aliases", path),
+    emacs: optionalStringArray(table, "emacs", path),
+    shebang: optionalStringArray(table, "shebang", path),
+    wasm_name: optionalString(table, "wasm_name", path),
+    display_name: optionalString(table, "display_name", path),
+    variant: optionalString(table, "variant", path),
+    globs: optionalStringArray(table, "globs", path),
+  };
+}
+
+function parseBundle(value: TomlValueWithoutBigInt, name: string): BundleEntry {
+  const path = `bundles.${name}`;
+  const table = requireTable(value, path);
+  const parsers = table.parsers;
+  if (parsers === "all") return { parsers };
+  if (Array.isArray(parsers) && parsers.every((entry) => typeof entry === "string")) {
+    return { parsers };
+  }
+  return invalid(`${path}.parsers`);
+}
+
+export function parseLanguagesToml(document: TomlTableWithoutBigInt): LanguagesToml {
+  const parserTable = requireTable(document.parsers, "parsers");
+  const parsers = Object.fromEntries(
+    Object.entries(parserTable).map(([id, value]) => [id, parseParser(value, id)]),
+  );
+
+  if (document.bundles === undefined) return { parsers };
+  const bundleTable = requireTable(document.bundles, "bundles");
+  const bundles = Object.fromEntries(
+    Object.entries(bundleTable).map(([name, value]) => [name, parseBundle(value, name)]),
+  );
+  return { parsers, bundles };
+}

--- a/packages/javascript/lumis/scripts/languages-toml.ts
+++ b/packages/javascript/lumis/scripts/languages-toml.ts
@@ -23,6 +23,12 @@ function invalid(path: string): never {
   throw new Error(`Invalid languages.toml: ${path}`);
 }
 
+function requireSafeName(value: string, path: string): void {
+  if (value.length === 0 || value === "." || value === ".." || /[/\\]/.test(value)) {
+    invalid(path);
+  }
+}
+
 function requireTable(
   value: TomlValueWithoutBigInt | undefined,
   path: string,
@@ -87,13 +93,27 @@ function parseBundle(value: TomlValueWithoutBigInt, name: string): BundleEntry {
 export function parseLanguagesToml(document: TomlTableWithoutBigInt): LanguagesToml {
   const parserTable = requireTable(document.parsers, "parsers");
   const parsers = Object.fromEntries(
-    Object.entries(parserTable).map(([id, value]) => [id, parseParser(value, id)]),
+    Object.entries(parserTable).map(([id, value]) => {
+      requireSafeName(id, `parsers.${id}`);
+      return [id, parseParser(value, id)];
+    }),
   );
 
   if (document.bundles === undefined) return { parsers };
   const bundleTable = requireTable(document.bundles, "bundles");
   const bundles = Object.fromEntries(
-    Object.entries(bundleTable).map(([name, value]) => [name, parseBundle(value, name)]),
+    Object.entries(bundleTable).map(([name, value]) => {
+      const path = `bundles.${name}`;
+      requireSafeName(name, path);
+      const bundle = parseBundle(value, name);
+      if (
+        bundle.parsers !== "all" &&
+        bundle.parsers.some((id) => id !== "plaintext" && !Object.hasOwn(parsers, id))
+      ) {
+        return invalid(`${path}.parsers`);
+      }
+      return [name, bundle];
+    }),
   );
   return { parsers, bundles };
 }

--- a/packages/javascript/lumis/src/core/builtin-formatter.ts
+++ b/packages/javascript/lumis/src/core/builtin-formatter.ts
@@ -1,4 +1,11 @@
-import type { Formatter } from "../types.js";
+import type {
+  BBCodeScopedFormatter,
+  Formatter,
+  HtmlInlineFormatter,
+  HtmlLinkedFormatter,
+  HtmlMultiThemesFormatter,
+  TerminalFormatter,
+} from "../types.js";
 
 export const BUILTIN_FORMATTER = Symbol("lumis.builtin-formatter");
 
@@ -9,6 +16,13 @@ export type BuiltinFormatterKind =
   | "bbcode-scoped"
   | "terminal";
 
+type BuiltinFormatter =
+  | (HtmlInlineFormatter & { [BUILTIN_FORMATTER]: "html-inline" })
+  | (HtmlLinkedFormatter & { [BUILTIN_FORMATTER]: "html-linked" })
+  | (HtmlMultiThemesFormatter & { [BUILTIN_FORMATTER]: "html-multi-themes" })
+  | (BBCodeScopedFormatter & { [BUILTIN_FORMATTER]: "bbcode-scoped" })
+  | (TerminalFormatter & { [BUILTIN_FORMATTER]: "terminal" });
+
 export function markBuiltinFormatter<T extends Formatter>(
   formatter: T,
   kind: BuiltinFormatterKind,
@@ -17,8 +31,13 @@ export function markBuiltinFormatter<T extends Formatter>(
   return formatter;
 }
 
+export function getBuiltinFormatter(formatter: Formatter): BuiltinFormatter | undefined {
+  const candidate = formatter as Formatter & {
+    [BUILTIN_FORMATTER]?: BuiltinFormatterKind;
+  };
+  return candidate[BUILTIN_FORMATTER] === undefined ? undefined : (candidate as BuiltinFormatter);
+}
+
 export function builtinFormatterKind(formatter: Formatter): BuiltinFormatterKind | undefined {
-  return (formatter as Formatter & { [BUILTIN_FORMATTER]?: BuiltinFormatterKind })[
-    BUILTIN_FORMATTER
-  ];
+  return getBuiltinFormatter(formatter)?.[BUILTIN_FORMATTER];
 }

--- a/packages/javascript/lumis/src/core/highlighter.ts
+++ b/packages/javascript/lumis/src/core/highlighter.ts
@@ -303,16 +303,16 @@ async function runFormatterAsync(
   return runFormatter(runtime, source, fmt, detectedRef);
 }
 
-function isObjectLike(value: unknown): value is Record<string, unknown> {
+function isObjectLike(value: unknown): value is object {
   return (typeof value === "object" && value !== null) || typeof value === "function";
 }
 
-function isLanguageLike(value: unknown): value is Record<string, unknown> {
+function isLanguageLike(value: unknown): boolean {
   return isObjectLike(value) && LANGUAGE_SHAPE_FIELDS.some((field) => field in value);
 }
 
 function isLanguageDefinition(value: unknown): value is LanguageDefinition {
-  if (!isObjectLike(value)) return false;
+  if (!isObjectLike(value) || !("id" in value) || !("aliases" in value)) return false;
   return (
     typeof value.id === "string" &&
     value.id.length > 0 &&
@@ -347,7 +347,8 @@ function validateLanguageBoundary(value: unknown): void {
   if (!isLanguageDefinition(value)) throw malformedLanguageDefinition();
 
   for (const field of LANGUAGE_QUERY_FIELDS) {
-    if (field in value && typeof value[field] !== "string") {
+    const query: unknown = Reflect.get(value, field);
+    if (field in value && typeof query !== "string") {
       throw incompleteLanguageDefinition(value.id);
     }
   }

--- a/packages/javascript/lumis/src/core/languages.ts
+++ b/packages/javascript/lumis/src/core/languages.ts
@@ -252,51 +252,11 @@ export function parseLanguagePackage(
   if (!hasValidRawJsonProfile(json)) {
     throw new Error(`Invalid Lumis language package: ${expectedPackageName}`);
   }
-  const parsed = JSON.parse(json) as unknown;
+  const parsed: unknown = JSON.parse(json);
   if (!hasOnlyUnicodeScalarStrings(parsed)) {
     throw new Error(`Invalid Lumis language package: ${expectedPackageName}`);
   }
-  const value = parsed as LanguagePackage;
-  const languages =
-    typeof value.languages === "object" &&
-    value.languages !== null &&
-    !Array.isArray(value.languages)
-      ? Object.values(value.languages)
-      : [];
-  if (
-    value.packageName !== expectedPackageName ||
-    !isValidPackageName(expectedPackageName) ||
-    typeof value.version !== "string" ||
-    !isSafePackagePathSegment(value.version) ||
-    typeof value.definitionHash !== "string" ||
-    value.definitionHash.length === 0 ||
-    typeof value.parser?.name !== "string" ||
-    !isSafePackagePathSegment(value.parser.name) ||
-    typeof value.parser?.grammarName !== "string" ||
-    value.parser.grammarName.length === 0 ||
-    (value.parser.upstreamVersion !== undefined &&
-      value.parser.upstreamVersion !== null &&
-      typeof value.parser.upstreamVersion !== "string") ||
-    (value.parser.revision !== undefined &&
-      value.parser.revision !== null &&
-      typeof value.parser.revision !== "string") ||
-    typeof value.parser?.sha256 !== "string" ||
-    !/^[0-9a-f]{64}$/.test(value.parser.sha256) ||
-    !Number.isSafeInteger(value.parser?.size) ||
-    value.parser.size <= 0 ||
-    languages.length === 0 ||
-    languages.some(
-      (language) =>
-        !Array.isArray(language.aliases) ||
-        language.aliases.some((alias) => typeof alias !== "string") ||
-        typeof language.highlights !== "string" ||
-        (language.injections !== undefined && typeof language.injections !== "string") ||
-        (language.locals !== undefined && typeof language.locals !== "string") ||
-        (language.brackets !== undefined && typeof language.brackets !== "string"),
-    )
-  ) {
-    throw new Error(`Invalid Lumis language package: ${expectedPackageName}`);
-  }
+  const value = parseLanguagePackageValue(parsed, expectedPackageName);
   const owners = new Map<string, string>();
   for (const [id, language] of Object.entries(value.languages)) {
     const owner = normalizeLanguageName(id);
@@ -312,9 +272,108 @@ export function parseLanguagePackage(
       owners.set(normalizeLanguageName(alias), owner);
     }
   }
-  if (value.parser.upstreamVersion === null) delete value.parser.upstreamVersion;
-  if (value.parser.revision === null) delete value.parser.revision;
   return value;
+}
+
+function invalidLanguagePackage(expectedPackageName: string): never {
+  throw new Error(`Invalid Lumis language package: ${expectedPackageName}`);
+}
+
+function requireObject(value: unknown, expectedPackageName: string): object {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return invalidLanguagePackage(expectedPackageName);
+  }
+  return value;
+}
+
+function property(value: object, key: string): unknown {
+  const result: unknown = Reflect.get(value, key);
+  return result;
+}
+
+function requireString(value: unknown, expectedPackageName: string): string {
+  return typeof value === "string" ? value : invalidLanguagePackage(expectedPackageName);
+}
+
+function optionalString(value: unknown, expectedPackageName: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requireString(value, expectedPackageName);
+}
+
+function optionalNullableString(value: unknown, expectedPackageName: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  return requireString(value, expectedPackageName);
+}
+
+function requireStringArray(value: unknown, expectedPackageName: string): string[] {
+  if (!Array.isArray(value)) return invalidLanguagePackage(expectedPackageName);
+  return value.map((entry) => requireString(entry, expectedPackageName));
+}
+
+function parsePackagedLanguage(value: unknown, expectedPackageName: string): PackagedLanguage {
+  const language = requireObject(value, expectedPackageName);
+  return {
+    aliases: requireStringArray(property(language, "aliases"), expectedPackageName),
+    highlights: requireString(property(language, "highlights"), expectedPackageName),
+    injections: optionalString(property(language, "injections"), expectedPackageName),
+    locals: optionalString(property(language, "locals"), expectedPackageName),
+    brackets: optionalString(property(language, "brackets"), expectedPackageName),
+  };
+}
+
+function parseLanguagePackageValue(value: unknown, expectedPackageName: string): LanguagePackage {
+  const packageValue = requireObject(value, expectedPackageName);
+  const packageName = requireString(property(packageValue, "packageName"), expectedPackageName);
+  const version = requireString(property(packageValue, "version"), expectedPackageName);
+  const definitionHash = requireString(
+    property(packageValue, "definitionHash"),
+    expectedPackageName,
+  );
+  const parserValue = requireObject(property(packageValue, "parser"), expectedPackageName);
+  const parserName = requireString(property(parserValue, "name"), expectedPackageName);
+  const grammarName = requireString(property(parserValue, "grammarName"), expectedPackageName);
+  const sha256 = requireString(property(parserValue, "sha256"), expectedPackageName);
+  const size = property(parserValue, "size");
+  const languagesValue = requireObject(property(packageValue, "languages"), expectedPackageName);
+
+  if (
+    packageName !== expectedPackageName ||
+    !isValidPackageName(expectedPackageName) ||
+    !isSafePackagePathSegment(version) ||
+    definitionHash.length === 0 ||
+    !isSafePackagePathSegment(parserName) ||
+    grammarName.length === 0 ||
+    !/^[0-9a-f]{64}$/.test(sha256) ||
+    typeof size !== "number" ||
+    !Number.isSafeInteger(size) ||
+    size <= 0
+  ) {
+    return invalidLanguagePackage(expectedPackageName);
+  }
+
+  const languages: Record<string, PackagedLanguage> = Object.create(null);
+  for (const id of Object.keys(languagesValue)) {
+    languages[id] = parsePackagedLanguage(property(languagesValue, id), expectedPackageName);
+  }
+  if (Object.keys(languages).length === 0) return invalidLanguagePackage(expectedPackageName);
+
+  return {
+    packageName,
+    version,
+    definitionHash,
+    parser: {
+      name: parserName,
+      grammarName,
+      upstreamVersion: optionalNullableString(
+        property(parserValue, "upstreamVersion"),
+        expectedPackageName,
+      ),
+      revision: optionalNullableString(property(parserValue, "revision"), expectedPackageName),
+      sha256,
+      size,
+    },
+    languages,
+  };
 }
 
 // JSON.parse discards overwritten members and turns 1e400 into Infinity, so
@@ -860,10 +919,16 @@ export function createLanguagesModule(runtime: RuntimeEnvironment): LanguagesMod
       const bytes = await runtime.readFsCache(languagePackageCacheKey(packageName));
       if (!bytes) return undefined;
       try {
-        const cached = JSON.parse(decoder.decode(bytes)) as CachedLanguagePackage;
-        const serialized = encoder.encode(JSON.stringify(cached.package));
+        const value: unknown = JSON.parse(decoder.decode(bytes));
+        const cached = requireObject(value, packageName);
+        const checkedAt = property(cached, "checkedAt");
+        const serializedPackage = JSON.stringify(property(cached, "package"));
+        if (typeof checkedAt !== "number" || !Number.isFinite(checkedAt) || !serializedPackage) {
+          return undefined;
+        }
+        const serialized = encoder.encode(serializedPackage);
         return {
-          checkedAt: cached.checkedAt,
+          checkedAt,
           package: parseLanguagePackage(serialized, packageName),
         };
       } catch {
@@ -881,7 +946,7 @@ export function createLanguagesModule(runtime: RuntimeEnvironment): LanguagesMod
           /* @vite-ignore */
           packageName
         );
-        const base = mod.default as unknown;
+        const base: unknown = mod.default;
         if (!(base instanceof URL) && typeof base !== "string") return undefined;
         const source = new URL("./lumis.json", base instanceof URL ? base : new URL(base));
         const disk = await runtime.readResolvedWasmFromDisk(source);
@@ -977,7 +1042,7 @@ export function createLanguagesModule(runtime: RuntimeEnvironment): LanguagesMod
           /* @vite-ignore */
           ref.packageName
         );
-        const input = mod.default as unknown;
+        const input: unknown = mod.default;
         if (
           input instanceof Uint8Array ||
           input instanceof ArrayBuffer ||

--- a/packages/javascript/lumis/src/core/native-languages.ts
+++ b/packages/javascript/lumis/src/core/native-languages.ts
@@ -9,7 +9,7 @@ import type {
   LoadedLanguage,
   WasmRef,
 } from "../types.js";
-import { builtinFormatterKind } from "./builtin-formatter.js";
+import { BUILTIN_FORMATTER, getBuiltinFormatter } from "./builtin-formatter.js";
 import { warnUnresolvedInjection } from "../events.js";
 import { decodeNativeEvents } from "./native-event-codec.js";
 import { PLAINTEXT_LANG_ID } from "../types.js";
@@ -34,8 +34,30 @@ const PLAINTEXT_ALIASES = ["text", "txt", "plain"];
 const CATALOG_LANGUAGE_IDS = new Set(LANGUAGES.map(({ id }) => normalizeLanguageName(id)));
 const encoder = new TextEncoder();
 
-function isWasmRef(wasm: NonNullable<LoadLanguageOptions["wasm"]>): wasm is WasmRef {
-  return typeof wasm === "object" && wasm !== null && "sha256" in wasm && "packageName" in wasm;
+function isWasmRef(wasm: unknown): wasm is WasmRef {
+  return (
+    typeof wasm === "object" &&
+    wasm !== null &&
+    "packageName" in wasm &&
+    typeof wasm.packageName === "string" &&
+    "name" in wasm &&
+    typeof wasm.name === "string" &&
+    "version" in wasm &&
+    typeof wasm.version === "string" &&
+    "sha256" in wasm &&
+    typeof wasm.sha256 === "string" &&
+    /^[0-9a-f]{64}$/.test(wasm.sha256) &&
+    "size" in wasm &&
+    typeof wasm.size === "number" &&
+    Number.isSafeInteger(wasm.size) &&
+    wasm.size > 0
+  );
+}
+
+function parseWasmRef(json: string): WasmRef {
+  const value: unknown = JSON.parse(json);
+  if (!isWasmRef(value)) throw new Error("native runtime returned invalid parser metadata");
+  return value;
 }
 
 type RuntimeWasmInput = Exclude<NonNullable<LoadLanguageOptions["wasm"]>, WasmRef>;
@@ -149,7 +171,7 @@ export function createNativeLanguagesModule(
     const resolver = state.wasmResolver ?? globalWasmResolver ?? DEFAULT_RESOLVER;
     resolverCallbackDepth += 1;
     try {
-      return resolverSource(resolver(language, JSON.parse(wasmJson) as WasmRef));
+      return resolverSource(resolver(language, parseWasmRef(wasmJson)));
     } finally {
       resolverCallbackDepth -= 1;
     }
@@ -352,13 +374,13 @@ export function createNativeLanguagesModule(
       const id = opts.definition.id;
       if (!packageName) return undefined;
       try {
-        const module = (await import(
+        const module = await import(
           /* webpackIgnore: true */
           /* turbopackIgnore: true */
           /* @vite-ignore */
           packageName
-        )) as { default?: unknown };
-        const base = module.default;
+        );
+        const base: unknown = module.default;
         if (!(base instanceof URL) && typeof base !== "string") return undefined;
 
         const root = base instanceof URL ? base : new URL(base);
@@ -483,7 +505,8 @@ export function createNativeLanguagesModule(
       formatter: Formatter,
       canCallResolver: boolean,
     ): NativeFormatter | undefined {
-      const kind = builtinFormatterKind(formatter);
+      const builtin = getBuiltinFormatter(formatter);
+      const kind = builtin?.[BUILTIN_FORMATTER];
       // Rust names the `language-*` class from `lumis_core::Language`, which has
       // no variant for a language the caller defined. Highlighting still runs
       // natively; only the string assembly falls back to JavaScript, exactly as
@@ -499,15 +522,36 @@ export function createNativeLanguagesModule(
       ) {
         return undefined;
       }
-      const options = { ...formatter } as Record<string, unknown>;
-      delete options.format;
-      delete options.language;
-      delete options.rainbowBrackets;
-      return {
-        rainbowBrackets: formatter.rainbowBrackets,
-        kind,
-        options,
-      };
+      const rainbowBrackets = builtin.rainbowBrackets;
+      switch (kind) {
+        case "html-inline":
+          return {
+            rainbowBrackets,
+            kind,
+            options: {
+              theme: builtin.theme,
+              preClass: builtin.preClass,
+              italic: builtin.italic,
+              includeHighlights: builtin.includeHighlights,
+              highlightLines: builtin.highlightLines,
+              header: builtin.header,
+            },
+          };
+        case "html-linked":
+          return {
+            rainbowBrackets,
+            kind,
+            options: {
+              preClass: builtin.preClass,
+              highlightLines: builtin.highlightLines,
+              header: builtin.header,
+            },
+          };
+        case "bbcode-scoped":
+          return { rainbowBrackets, kind, options: null };
+        case "terminal":
+          return { rainbowBrackets, kind, options: { theme: builtin.theme } };
+      }
     }
   }
 

--- a/packages/javascript/lumis/src/native-binding.ts
+++ b/packages/javascript/lumis/src/native-binding.ts
@@ -1,10 +1,30 @@
 import { createRequire } from "node:module";
+import type { HtmlInlineOptions, HtmlLinkedOptions, TerminalOptions } from "./types.js";
 
-export interface NativeFormatter {
+type NativeHtmlInlineOptions = Pick<
+  HtmlInlineOptions,
+  "theme" | "preClass" | "italic" | "includeHighlights" | "highlightLines" | "header"
+>;
+type NativeHtmlLinkedOptions = Pick<HtmlLinkedOptions, "preClass" | "highlightLines" | "header">;
+type NativeTerminalOptions = Pick<TerminalOptions, "theme">;
+
+interface NativeFormatterBase {
   rainbowBrackets?: boolean;
-  kind: string;
-  options: Record<string, unknown>;
 }
+
+export type NativeFormatter = NativeFormatterBase &
+  (
+    | {
+        kind: "html-inline";
+        options: NativeHtmlInlineOptions;
+      }
+    | {
+        kind: "html-linked";
+        options: NativeHtmlLinkedOptions;
+      }
+    | { kind: "bbcode-scoped"; options: null }
+    | { kind: "terminal"; options: NativeTerminalOptions }
+  );
 
 export interface NativeLanguageSpec {
   id: string;

--- a/packages/javascript/lumis/src/runtime/browser.ts
+++ b/packages/javascript/lumis/src/runtime/browser.ts
@@ -5,7 +5,7 @@ import treeSitterWasmBinary from "../tree-sitter-wasm.js";
 const WASM_CACHE_NAME = "lumis-wasm-v1";
 const WASM_DATABASE_NAME = "lumis-wasm-v1";
 const WASM_DATABASE_STORE = "parsers";
-const cacheLocks = new Map<string, Promise<unknown>>();
+const cacheLocks = new Map<string, Promise<void>>();
 let wasmCache: Promise<Cache | undefined> | undefined;
 let wasmDatabase: Promise<IDBDatabase | undefined> | undefined;
 let indexedDbPreferred: boolean | undefined;
@@ -150,11 +150,15 @@ export const browserRuntime: RuntimeEnvironment = {
   async withFsCacheLock(key, operation) {
     const previous = cacheLocks.get(key);
     const pending = (previous ?? Promise.resolve()).catch(() => undefined).then(operation);
-    cacheLocks.set(key, pending);
+    const lock = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    cacheLocks.set(key, lock);
     try {
       return await pending;
     } finally {
-      if (cacheLocks.get(key) === pending) {
+      if (cacheLocks.get(key) === lock) {
         cacheLocks.delete(key);
       }
     }

--- a/packages/javascript/lumis/src/runtime/node-cache.ts
+++ b/packages/javascript/lumis/src/runtime/node-cache.ts
@@ -124,8 +124,20 @@ export function lockOwnerIsGone(owner: LockOwner | undefined, host: string): boo
 async function readLockOwner(lockPath: string): Promise<LockOwner | undefined> {
   const { readFile } = await import(nodeFsPromises);
   try {
-    const owner = JSON.parse(await readFile(lockPath, "utf8")) as LockOwner;
-    return typeof owner?.host === "string" && typeof owner?.pid === "number" ? owner : undefined;
+    const owner: unknown = JSON.parse(await readFile(lockPath, "utf8"));
+    if (
+      typeof owner !== "object" ||
+      owner === null ||
+      !("host" in owner) ||
+      typeof owner.host !== "string" ||
+      !("pid" in owner) ||
+      typeof owner.pid !== "number" ||
+      !Number.isInteger(owner.pid) ||
+      owner.pid <= 0
+    ) {
+      return undefined;
+    }
+    return { host: owner.host, pid: owner.pid };
   } catch {
     return undefined;
   }

--- a/packages/javascript/lumis/src/runtime/runtime.ts
+++ b/packages/javascript/lumis/src/runtime/runtime.ts
@@ -1,4 +1,7 @@
 import type { WasmRef } from "../types.js";
+import type { Parser } from "web-tree-sitter";
+
+type ParserInitOptions = Parameters<typeof Parser.init>[0];
 
 export interface RuntimeEnvironment {
   resolveWasm(
@@ -10,7 +13,7 @@ export interface RuntimeEnvironment {
   /** Read a file already under `$LUMIS_DATA_DIR/parsers`, where the runtime has one. */
   readStagedAsset?(filename: string): Promise<Uint8Array | undefined>;
   readResolvedWasmFromDisk(source: string | URL): Promise<Uint8Array | undefined>;
-  parserInitOptions?(): Promise<Record<string, unknown> | undefined>;
+  parserInitOptions?(): Promise<ParserInitOptions>;
 }
 
 export interface RuntimeEnvironmentResolver {

--- a/packages/javascript/lumis/test/languages-toml.test.ts
+++ b/packages/javascript/lumis/test/languages-toml.test.ts
@@ -35,6 +35,27 @@ describe("languages.toml parsing", () => {
     ["parser entry", 'parsers.javascript = "javascript"', "parsers.javascript"],
     ["parser field", "[parsers.javascript]\naliases = [1]", "parsers.javascript.aliases"],
     ["bundle field", "[parsers.javascript]\n[bundles.web]\nparsers = true", "bundles.web.parsers"],
+    ["empty parser ID", '[parsers.""]', "parsers."],
+    ["dot-segment parser ID", '[parsers.".."]', "parsers..."],
+    ["slash in parser ID", '[parsers."../outside"]', "parsers.../outside"],
+    ["backslash in parser ID", "[parsers.'outside\\parser']", "parsers.outside\\parser"],
+    ["empty bundle name", '[parsers.javascript]\n[bundles.""]\nparsers = []', "bundles."],
+    ["dot-segment bundle name", '[parsers.javascript]\n[bundles."."]\nparsers = []', "bundles.."],
+    [
+      "slash in bundle name",
+      '[parsers.javascript]\n[bundles."web/extra"]\nparsers = []',
+      "bundles.web/extra",
+    ],
+    [
+      "backslash in bundle name",
+      "[parsers.javascript]\n[bundles.'web\\extra']\nparsers = []",
+      "bundles.web\\extra",
+    ],
+    [
+      "unknown bundle parser",
+      '[parsers.javascript]\n[bundles.web]\nparsers = ["missing"]',
+      "bundles.web.parsers",
+    ],
   ])("rejects an invalid %s", (_name, text, path) => {
     expect(() => parseLanguagesToml(parseToml(text))).toThrow(`Invalid languages.toml: ${path}`);
   });

--- a/packages/javascript/lumis/test/languages-toml.test.ts
+++ b/packages/javascript/lumis/test/languages-toml.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { parse as parseToml } from "smol-toml";
+import { parseLanguagesToml } from "../scripts/languages-toml.js";
+
+describe("languages.toml parsing", () => {
+  it("constructs the generator fields from TOML", () => {
+    expect(
+      parseLanguagesToml(
+        parseToml(`
+          [parsers.javascript]
+          aliases = ["js"]
+          wasm_name = "tree-sitter-javascript"
+
+          [bundles.web]
+          parsers = ["javascript"]
+        `),
+      ),
+    ).toEqual({
+      parsers: {
+        javascript: {
+          aliases: ["js"],
+          emacs: undefined,
+          shebang: undefined,
+          wasm_name: "tree-sitter-javascript",
+          display_name: undefined,
+          variant: undefined,
+          globs: undefined,
+        },
+      },
+      bundles: { web: { parsers: ["javascript"] } },
+    });
+  });
+
+  it.each([
+    ["parser entry", 'parsers.javascript = "javascript"', "parsers.javascript"],
+    ["parser field", "[parsers.javascript]\naliases = [1]", "parsers.javascript.aliases"],
+    ["bundle field", "[parsers.javascript]\n[bundles.web]\nparsers = true", "bundles.web.parsers"],
+  ])("rejects an invalid %s", (_name, text, path) => {
+    expect(() => parseLanguagesToml(parseToml(text))).toThrow(`Invalid languages.toml: ${path}`);
+  });
+});

--- a/packages/javascript/markdown-it-lumis/dist/index.cjs
+++ b/packages/javascript/markdown-it-lumis/dist/index.cjs
@@ -24,21 +24,28 @@ function splitLanguages(entries) {
       refs.push(entry);
       continue;
     }
-    inputs.push(entry);
-    if (isLanguageRef(entry)) {
+    if (isLazyLanguage(entry)) {
+      inputs.push({ [entry.id]: entry });
       refs.push(entry);
+      continue;
     }
+    if (isLanguageDefinition(entry)) {
+      if (isLanguage(entry)) inputs.push(entry);
+      refs.push(entry);
+      continue;
+    }
+    inputs.push(entry);
   }
   return { inputs, refs };
 }
+function isLanguageDefinition(value) {
+  return typeof value === "object" && value !== null && "id" in value && typeof value.id === "string" && "aliases" in value && Array.isArray(value.aliases) && value.aliases.every((alias) => typeof alias === "string");
+}
 function isLanguage(value) {
-  return typeof value === "object" && value !== null && "id" in value && "highlights" in value && "wasm" in value;
+  return isLanguageDefinition(value) && (value.id === "plaintext" || "packageName" in value && typeof value.packageName === "string");
 }
 function isLazyLanguage(value) {
   return typeof value === "function" && "id" in value && "aliases" in value;
-}
-function isLanguageRef(value) {
-  return isLanguage(value) || isLazyLanguage(value);
 }
 function fromHighlighter(highlighter, options) {
   return function installMarkdownItLumis(md) {

--- a/packages/javascript/markdown-it-lumis/dist/index.cjs
+++ b/packages/javascript/markdown-it-lumis/dist/index.cjs
@@ -34,18 +34,24 @@ function splitLanguages(entries) {
       refs.push(entry);
       continue;
     }
+    if (hasLanguageMetadata(entry)) {
+      throw new TypeError("Invalid markdown-it-lumis language metadata");
+    }
     inputs.push(entry);
   }
   return { inputs, refs };
 }
 function isLanguageDefinition(value) {
-  return typeof value === "object" && value !== null && "id" in value && typeof value.id === "string" && "aliases" in value && Array.isArray(value.aliases) && value.aliases.every((alias) => typeof alias === "string");
+  return typeof value === "object" && value !== null && "id" in value && typeof value.id === "string" && value.id.length > 0 && "aliases" in value && Array.isArray(value.aliases) && value.aliases.every((alias) => typeof alias === "string");
 }
 function isLanguage(value) {
   return isLanguageDefinition(value) && (value.id === "plaintext" || "packageName" in value && typeof value.packageName === "string");
 }
 function isLazyLanguage(value) {
-  return typeof value === "function" && "id" in value && "aliases" in value;
+  return typeof value === "function" && "id" in value && typeof value.id === "string" && value.id.length > 0 && "aliases" in value && Array.isArray(value.aliases) && value.aliases.every((alias) => typeof alias === "string");
+}
+function hasLanguageMetadata(value) {
+  return (typeof value === "object" && value !== null || typeof value === "function") && ("id" in value || "aliases" in value);
 }
 function fromHighlighter(highlighter, options) {
   return function installMarkdownItLumis(md) {

--- a/packages/javascript/markdown-it-lumis/dist/index.js
+++ b/packages/javascript/markdown-it-lumis/dist/index.js
@@ -20,21 +20,28 @@ function splitLanguages(entries) {
       refs.push(entry);
       continue;
     }
-    inputs.push(entry);
-    if (isLanguageRef(entry)) {
+    if (isLazyLanguage(entry)) {
+      inputs.push({ [entry.id]: entry });
       refs.push(entry);
+      continue;
     }
+    if (isLanguageDefinition(entry)) {
+      if (isLanguage(entry)) inputs.push(entry);
+      refs.push(entry);
+      continue;
+    }
+    inputs.push(entry);
   }
   return { inputs, refs };
 }
+function isLanguageDefinition(value) {
+  return typeof value === "object" && value !== null && "id" in value && typeof value.id === "string" && "aliases" in value && Array.isArray(value.aliases) && value.aliases.every((alias) => typeof alias === "string");
+}
 function isLanguage(value) {
-  return typeof value === "object" && value !== null && "id" in value && "highlights" in value && "wasm" in value;
+  return isLanguageDefinition(value) && (value.id === "plaintext" || "packageName" in value && typeof value.packageName === "string");
 }
 function isLazyLanguage(value) {
   return typeof value === "function" && "id" in value && "aliases" in value;
-}
-function isLanguageRef(value) {
-  return isLanguage(value) || isLazyLanguage(value);
 }
 function fromHighlighter(highlighter, options) {
   return function installMarkdownItLumis(md) {

--- a/packages/javascript/markdown-it-lumis/dist/index.js
+++ b/packages/javascript/markdown-it-lumis/dist/index.js
@@ -30,18 +30,24 @@ function splitLanguages(entries) {
       refs.push(entry);
       continue;
     }
+    if (hasLanguageMetadata(entry)) {
+      throw new TypeError("Invalid markdown-it-lumis language metadata");
+    }
     inputs.push(entry);
   }
   return { inputs, refs };
 }
 function isLanguageDefinition(value) {
-  return typeof value === "object" && value !== null && "id" in value && typeof value.id === "string" && "aliases" in value && Array.isArray(value.aliases) && value.aliases.every((alias) => typeof alias === "string");
+  return typeof value === "object" && value !== null && "id" in value && typeof value.id === "string" && value.id.length > 0 && "aliases" in value && Array.isArray(value.aliases) && value.aliases.every((alias) => typeof alias === "string");
 }
 function isLanguage(value) {
   return isLanguageDefinition(value) && (value.id === "plaintext" || "packageName" in value && typeof value.packageName === "string");
 }
 function isLazyLanguage(value) {
-  return typeof value === "function" && "id" in value && "aliases" in value;
+  return typeof value === "function" && "id" in value && typeof value.id === "string" && value.id.length > 0 && "aliases" in value && Array.isArray(value.aliases) && value.aliases.every((alias) => typeof alias === "string");
+}
+function hasLanguageMetadata(value) {
+  return (typeof value === "object" && value !== null || typeof value === "function") && ("id" in value || "aliases" in value);
 }
 function fromHighlighter(highlighter, options) {
   return function installMarkdownItLumis(md) {

--- a/packages/javascript/markdown-it-lumis/src/index.ts
+++ b/packages/javascript/markdown-it-lumis/src/index.ts
@@ -2,6 +2,7 @@ import type MarkdownIt from "markdown-it";
 import type {
   Highlighter,
   Language,
+  LanguageDefinition,
   LanguageInput,
   LanguageRef,
   LazyLanguage,
@@ -45,32 +46,43 @@ function splitLanguages(entries: Array<LanguageInput | LanguageRef>): {
       refs.push(entry);
       continue;
     }
-
-    inputs.push(entry as LanguageInput);
-    if (isLanguageRef(entry)) {
+    if (isLazyLanguage(entry)) {
+      inputs.push({ [entry.id]: entry });
       refs.push(entry);
+      continue;
     }
+    if (isLanguageDefinition(entry)) {
+      if (isLanguage(entry)) inputs.push(entry);
+      refs.push(entry);
+      continue;
+    }
+    inputs.push(entry);
   }
 
   return { inputs, refs };
 }
 
-function isLanguage(value: unknown): value is Language {
+function isLanguageDefinition(value: LanguageInput | LanguageRef): value is LanguageDefinition {
   return (
     typeof value === "object" &&
     value !== null &&
     "id" in value &&
-    "highlights" in value &&
-    "wasm" in value
+    typeof value.id === "string" &&
+    "aliases" in value &&
+    Array.isArray(value.aliases) &&
+    value.aliases.every((alias) => typeof alias === "string")
   );
 }
 
-function isLazyLanguage(value: unknown): value is LazyLanguage {
-  return typeof value === "function" && "id" in value && "aliases" in value;
+function isLanguage(value: LanguageInput | LanguageRef): value is Language {
+  return (
+    isLanguageDefinition(value) &&
+    (value.id === "plaintext" || ("packageName" in value && typeof value.packageName === "string"))
+  );
 }
 
-function isLanguageRef(value: unknown): value is LanguageRef {
-  return isLanguage(value) || isLazyLanguage(value);
+function isLazyLanguage(value: LanguageInput | LanguageRef): value is LazyLanguage {
+  return typeof value === "function" && "id" in value && "aliases" in value;
 }
 
 export function fromHighlighter(highlighter: Highlighter, options: MarkdownItLumisOptions) {

--- a/packages/javascript/markdown-it-lumis/src/index.ts
+++ b/packages/javascript/markdown-it-lumis/src/index.ts
@@ -56,6 +56,9 @@ function splitLanguages(entries: Array<LanguageInput | LanguageRef>): {
       refs.push(entry);
       continue;
     }
+    if (hasLanguageMetadata(entry)) {
+      throw new TypeError("Invalid markdown-it-lumis language metadata");
+    }
     inputs.push(entry);
   }
 
@@ -68,6 +71,7 @@ function isLanguageDefinition(value: LanguageInput | LanguageRef): value is Lang
     value !== null &&
     "id" in value &&
     typeof value.id === "string" &&
+    value.id.length > 0 &&
     "aliases" in value &&
     Array.isArray(value.aliases) &&
     value.aliases.every((alias) => typeof alias === "string")
@@ -82,7 +86,22 @@ function isLanguage(value: LanguageInput | LanguageRef): value is Language {
 }
 
 function isLazyLanguage(value: LanguageInput | LanguageRef): value is LazyLanguage {
-  return typeof value === "function" && "id" in value && "aliases" in value;
+  return (
+    typeof value === "function" &&
+    "id" in value &&
+    typeof value.id === "string" &&
+    value.id.length > 0 &&
+    "aliases" in value &&
+    Array.isArray(value.aliases) &&
+    value.aliases.every((alias) => typeof alias === "string")
+  );
+}
+
+function hasLanguageMetadata(value: LanguageInput | LanguageRef): boolean {
+  return (
+    ((typeof value === "object" && value !== null) || typeof value === "function") &&
+    ("id" in value || "aliases" in value)
+  );
 }
 
 export function fromHighlighter(highlighter: Highlighter, options: MarkdownItLumisOptions) {

--- a/packages/javascript/markdown-it-lumis/test/index.test.ts
+++ b/packages/javascript/markdown-it-lumis/test/index.test.ts
@@ -58,6 +58,17 @@ describe("markdown-it-lumis", () => {
 
       expect(html).toMatch(/<pre class="lumis my-pre"/);
     });
+
+    it("loads an identifier-only reference from a registered bundle", async () => {
+      const plugin = await markdownItLumis({
+        formatter: (language) => htmlInline({ language, theme: dracula }),
+        languages: [bundledLanguages, { id: "javascript", aliases: ["js"] }],
+      });
+      const md = new MarkdownIt();
+      md.use(plugin);
+
+      expect(md.render(JS_SOURCE)).toContain('class="language-javascript"');
+    });
   });
 
   describe("htmlLinked formatter", () => {

--- a/packages/javascript/markdown-it-lumis/test/index.test.ts
+++ b/packages/javascript/markdown-it-lumis/test/index.test.ts
@@ -11,6 +11,7 @@ import {
   configureWasmResolver,
   createHighlighter,
 } from "@lumis-sh/lumis";
+import type { LanguageRef } from "@lumis-sh/lumis";
 import { htmlInline, htmlLinked, htmlMultiThemes, terminal } from "@lumis-sh/lumis/formatters";
 import { bundledLanguages } from "@lumis-sh/lumis/bundles/web";
 
@@ -67,7 +68,10 @@ describe("markdown-it-lumis", () => {
       const md = new MarkdownIt();
       md.use(plugin);
 
-      expect(md.render(JS_SOURCE)).toContain('class="language-javascript"');
+      const html = md.render(JS_SOURCE);
+
+      expect(html).toContain('class="language-javascript"');
+      expect(html).toMatch(/<span style="color: #[0-9a-f]+;">const<\/span>/);
     });
   });
 
@@ -133,6 +137,23 @@ describe("markdown-it-lumis", () => {
   });
 
   describe("language handling", () => {
+    it.each([
+      ["empty definition ID", { id: "", aliases: [] }],
+      ["non-string definition alias", { id: "javascript", aliases: [1] }],
+      ["empty lazy ID", Object.assign(async () => javascript, { id: "", aliases: [] })],
+      [
+        "non-string lazy alias",
+        Object.assign(async () => javascript, { id: "javascript", aliases: [1] }),
+      ],
+    ])("rejects %s at the adapter boundary", async (_name, language) => {
+      await expect(
+        markdownItLumis({
+          formatter: (name) => htmlInline({ language: name, theme: dracula }),
+          languages: [language as unknown as LanguageRef],
+        }),
+      ).rejects.toThrow("Invalid markdown-it-lumis language metadata");
+    });
+
     it("auto-detects unannotated fences", async () => {
       const plugin = await markdownItLumis({
         formatter: (language) => htmlInline({ language, theme: dracula }),

--- a/packages/javascript/react/src/CodeBlock.ts
+++ b/packages/javascript/react/src/CodeBlock.ts
@@ -4,19 +4,11 @@ import { useLumis } from "./useLumis.js";
 
 export type { CodeBlockProps } from "./clientShared.js";
 
-function throwRenderError(error: unknown): never {
-  if (error instanceof Error) {
-    throw error;
-  }
-
-  throw new Error("Failed to render code block", { cause: error });
-}
-
 export function CodeBlock(props: CodeBlockProps): ReactNode {
   const { content, error } = useLumis(props);
 
   if (error) {
-    throwRenderError(error);
+    throw error;
   }
 
   return content;

--- a/packages/javascript/react/src/useLumis.ts
+++ b/packages/javascript/react/src/useLumis.ts
@@ -15,13 +15,19 @@ export interface UseLumisOptions extends LumisOptions {}
 
 export interface UseLumisResult {
   content: ReactNode | null;
-  error: unknown;
+  error: Error | undefined;
   isLoading: boolean;
+}
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error
+    ? error
+    : new Error("Failed to render code block", { cause: error });
 }
 
 export function useLumis(options: UseLumisOptions): UseLumisResult {
   const [asyncContent, setAsyncContent] = useState<ReactNode>(undefined);
-  const [asyncError, setAsyncError] = useState<unknown>();
+  const [asyncError, setAsyncError] = useState<Error>();
   const highlighter = getHighlighter(options.highlighter);
 
   const syncState = useMemo(() => {
@@ -76,7 +82,7 @@ export function useLumis(options: UseLumisOptions): UseLumisResult {
 
       return {
         content: null,
-        error,
+        error: normalizeError(error),
         needsLoad: false,
       };
     }
@@ -102,7 +108,7 @@ export function useLumis(options: UseLumisOptions): UseLumisResult {
       })
       .catch((error) => {
         if (active) {
-          setAsyncError(error);
+          setAsyncError(normalizeError(error));
         }
       });
 

--- a/packages/javascript/react/test/index.test.tsx
+++ b/packages/javascript/react/test/index.test.tsx
@@ -83,7 +83,7 @@ function HookHarness({
     | Awaited<ReturnType<typeof createHighlighter>>
     | Promise<Awaited<ReturnType<typeof createHighlighter>>>;
 }) {
-  const { content, isLoading } = useLumis({
+  const { content, error, isLoading } = useLumis({
     children,
     formatter,
     highlighter,
@@ -91,6 +91,9 @@ function HookHarness({
 
   if (isLoading) {
     return <div data-state="loading" />;
+  }
+  if (error) {
+    return <div data-error={error.message} />;
   }
 
   return <>{content}</>;
@@ -289,6 +292,32 @@ describe("@lumis-sh/react", () => {
     await waitForHtml(container, 'class="lumis"');
     expect(container.innerHTML).toContain('class="lumis"');
     expect(container.innerHTML).toContain('class="language-javascript"');
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("normalizes non-Error failures returned by useLumis", async () => {
+    const highlighter = Promise.reject<Awaited<ReturnType<typeof createHighlighter>>>("boom");
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <HookHarness
+          highlighter={highlighter}
+          formatter={htmlInline({ language: "javascript", theme: dracula })}
+        >
+          {SOURCE}
+        </HookHarness>,
+      );
+    });
+
+    expect(container.querySelector("[data-error]")?.getAttribute("data-error")).toBe(
+      "Failed to render code block",
+    );
 
     await act(async () => {
       root.unmount();

--- a/packages/javascript/rehype-lumis/test/index.test.ts
+++ b/packages/javascript/rehype-lumis/test/index.test.ts
@@ -1,5 +1,6 @@
-import type { Element, Root } from "hast";
+import type { Element, Properties, Root } from "hast";
 import { describe, expect, it } from "vitest";
+import { visit } from "unist-util-visit";
 import dracula from "../../themes/dist/json/dracula.json";
 import githubLight from "../../themes/dist/json/github_light.json";
 import javascript from "../../lumis/langs/javascript.ts";
@@ -21,7 +22,7 @@ function codeBlockTree({
 }: {
   code?: string;
   codeClassName?: string[];
-  preProperties?: Record<string, unknown>;
+  preProperties?: Properties;
 } = {}): Root {
   return {
     type: "root",
@@ -45,29 +46,31 @@ function codeBlockTree({
 
 function findElements(root: Root, tagName: string): Element[] {
   const results: Element[] = [];
-  function walk(node: unknown) {
-    if (node && typeof node === "object" && "type" in node) {
-      const n = node as { type: string; tagName?: string; children?: unknown[] };
-      if (n.type === "element" && n.tagName === tagName) {
-        results.push(n as unknown as Element);
-      }
-      if (n.children) {
-        for (const child of n.children) {
-          walk(child);
-        }
-      }
-    }
-  }
-  walk(root);
+  visit(root, "element", (node) => {
+    if (node.tagName === tagName) results.push(node);
+  });
   return results;
+}
+
+function classNames(element: Element): string[] {
+  const value = element.properties.className;
+  expect(Array.isArray(value)).toBe(true);
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function style(element: Element): string {
+  const value = element.properties.style;
+  expect(typeof value).toBe("string");
+  return typeof value === "string" ? value : "";
 }
 
 function assertLumisPreElement(tree: Root) {
   const pres = findElements(tree, "pre");
   expect(pres.length).toBeGreaterThan(0);
   const pre = pres[0]!;
-  const classes = (pre.properties as Record<string, unknown>).className as string[];
-  expect(classes).toContain("lumis");
+  expect(classNames(pre)).toContain("lumis");
   return pre;
 }
 
@@ -120,19 +123,15 @@ describe("rehype-lumis", () => {
       await transform(tree);
 
       const pre = assertLumisPreElement(tree);
-      const style = (pre.properties as Record<string, unknown>).style as string;
-      expect(style).toMatch(/color: #[0-9a-f]+/);
-      expect(style).toMatch(/background-color: #[0-9a-f]+/);
+      expect(style(pre)).toMatch(/color: #[0-9a-f]+/);
+      expect(style(pre)).toMatch(/background-color: #[0-9a-f]+/);
 
       const spans = assertSpansExist(tree);
-      const spanWithStyle = spans.find(
-        (s) => typeof (s.properties as Record<string, unknown>).style === "string",
-      );
+      const spanWithStyle = spans.find((span) => typeof span.properties.style === "string");
       expect(spanWithStyle).toBeDefined();
 
       const codes = findElements(tree, "code");
-      const codeClasses = (codes[0]!.properties as Record<string, unknown>).className as string[];
-      expect(codeClasses).toContain("language-javascript");
+      expect(classNames(codes[0]!)).toContain("language-javascript");
     });
 
     it("applies preClass", async () => {
@@ -145,8 +144,7 @@ describe("rehype-lumis", () => {
       await transform(tree);
 
       const pre = assertLumisPreElement(tree);
-      const classes = (pre.properties as Record<string, unknown>).className as string[];
-      expect(classes).toContain("my-pre");
+      expect(classNames(pre)).toContain("my-pre");
     });
   });
 
@@ -168,9 +166,8 @@ describe("rehype-lumis", () => {
 
       // All spans should have class, none should have style
       for (const span of spans) {
-        const props = span.properties as Record<string, unknown>;
-        expect(props.className).toBeDefined();
-        expect(props.style).toBeUndefined();
+        expect(span.properties.className).toBeDefined();
+        expect(span.properties.style).toBeUndefined();
       }
     });
   });
@@ -191,15 +188,14 @@ describe("rehype-lumis", () => {
       await transform(tree);
 
       const pre = assertLumisPreElement(tree);
-      const classes = (pre.properties as Record<string, unknown>).className as string[];
-      expect(classes).toContain("lumis-themes");
+      expect(classNames(pre)).toContain("lumis-themes");
 
       // Spans should contain CSS custom properties for the non-default theme
       const spans = assertSpansExist(tree);
       const spanStyles = spans
-        .map((s) => (s.properties as Record<string, unknown>).style as string)
-        .filter(Boolean);
-      expect(spanStyles.some((s) => s.includes("--lumis-dark"))).toBe(true);
+        .map((span) => span.properties.style)
+        .filter((value): value is string => typeof value === "string");
+      expect(spanStyles.some((value) => value.includes("--lumis-dark"))).toBe(true);
     });
   });
 
@@ -233,8 +229,7 @@ describe("rehype-lumis", () => {
       await transform(tree);
 
       const codes = findElements(tree, "code");
-      const codeClasses = (codes[0]!.properties as Record<string, unknown>).className as string[];
-      expect(codeClasses).toContain("language-javascript");
+      expect(classNames(codes[0]!)).toContain("language-javascript");
     });
 
     it("reads language from pre element class", async () => {
@@ -293,8 +288,7 @@ describe("rehype-lumis", () => {
       await transform(tree);
 
       const codes = findElements(tree, "code");
-      const codeClasses = (codes[0]!.properties as Record<string, unknown>).className as string[];
-      expect(codeClasses).toContain("language-json");
+      expect(classNames(codes[0]!)).toContain("language-json");
     });
 
     it("ignores empty string language attributes", async () => {
@@ -429,8 +423,7 @@ describe("rehype-lumis", () => {
       const pres = findElements(tree, "pre");
       expect(pres.length).toBe(2);
       for (const pre of pres) {
-        const classes = (pre.properties as Record<string, unknown>).className as string[];
-        expect(classes).toContain("lumis");
+        expect(classNames(pre)).toContain("lumis");
       }
     });
 
@@ -519,8 +512,7 @@ describe("rehype-lumis", () => {
 
       const pres = findElements(tree, "pre");
       // First: highlighted
-      const firstClasses = (pres[0]!.properties as Record<string, unknown>).className as string[];
-      expect(firstClasses).toContain("lumis");
+      expect(classNames(pres[0]!)).toContain("lumis");
       // Second: preserved
       const secondCode = pres[1]!.children[0] as Element;
       expect(secondCode.tagName).toBe("code");

--- a/packages/javascript/scripts/build-wasm-bundles.ts
+++ b/packages/javascript/scripts/build-wasm-bundles.ts
@@ -2,32 +2,25 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { parse as parseToml } from "smol-toml";
+import {
+  parseLanguagesToml,
+  type BundleEntry,
+  type LanguagesToml,
+  type ParserEntry,
+} from "../lumis/scripts/languages-toml.js";
 
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, "../../..");
 const LANGUAGES_TOML = path.join(WORKSPACE_ROOT, "languages.toml");
 const LUMIS_PACKAGE_JSON = path.resolve(import.meta.dirname, "../lumis/package.json");
 const PACKAGES_DIR = path.join(WORKSPACE_ROOT, "packages", "javascript");
 
-interface ParserEntry {
-  wasm_name?: string;
-}
-
-interface BundleEntry {
-  parsers: string[] | "all";
-}
-
 interface BundlePackageJson {
   version?: string;
 }
 
-interface LanguagesToml {
-  parsers: Record<string, ParserEntry>;
-  bundles?: Record<string, BundleEntry>;
-}
-
 function readLanguagesToml(): LanguagesToml {
   const text = fs.readFileSync(LANGUAGES_TOML, "utf-8");
-  return parseToml(text) as unknown as LanguagesToml;
+  return parseLanguagesToml(parseToml(text));
 }
 
 function treeSitterCompatRange(): string {


### PR DESCRIPTION
## What changed

- parse `languages.toml`, language package manifests, filesystem cache envelopes, native parser metadata, and lock-owner files into validated domain values
- replace generic formatter and runtime option bags with discriminated or upstream-derived types
- normalize React hook failures to `Error` and document the contract
- fix Markdown-It registration for identifier-only language references
- remove remaining `Record<string, unknown>` use from authored JavaScript/TypeScript code, including loose HAST test casts

## Why

Several I/O boundaries asserted parsed data directly into domain types, while formatter plumbing widened known option shapes into generic records. That erased useful type information and allowed boundary data to look valid to TypeScript before it had been checked and constructed.

The Markdown-It adapter also used stale structural fields to distinguish language values, so an identifier-only reference backed by a registered bundle could be misclassified.

## Impact

Malformed external metadata is rejected at the boundary, internal formatter/runtime values retain their real shapes, React consumers receive a stable `Error | undefined` contract, and Markdown-It can resolve identifier-only language references from bundles.

## Validation

- `LUMIS_TEST_RUNTIME=wasm pnpm test` — 501 tests passed
- `LUMIS_TEST_RUNTIME=native pnpm test` — 501 tests passed
- Lumis build, native build, TypeScript check, and lint
- React build, lint, and 10 tests
- Markdown-It build, lint, and 15 tests
- Rehype build, lint, and 20 tests
- language and WASM bundle generators
- `pnpm --dir docs build`
- `mise run fmt-js -- --check`
