### PR TITLE
feat(javascript): prebuild the addon for musl and Windows arm64

### DIFF
--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -39,10 +39,22 @@ jobs:
             target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             library: liblumis_js_native.so
+          - package: linux-arm64-musl
+            target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            library: liblumis_js_native.so
           - package: linux-x64-gnu
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             library: liblumis_js_native.so
+          - package: linux-x64-musl
+            target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            library: liblumis_js_native.so
+          - package: win32-arm64-msvc
+            target: aarch64-pc-windows-msvc
+            os: windows-latest
+            library: lumis_js_native.dll
           - package: win32-x64-msvc
             target: x86_64-pc-windows-msvc
             os: windows-latest
@@ -57,7 +69,24 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # The Tree-sitter C sources need a musl compiler; `cc` would otherwise
+      # reach for the runner's glibc gcc and emit objects the musl link rejects.
+      # Each musl target builds on a runner of its own architecture, so the
+      # `musl-gcc` this installs is the native compiler in both cases.
+      - name: Install musl toolchain
+        if: endsWith(matrix.target, '-musl')
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y musl-tools
+
+      # Rust links musl targets against a static CRT by default, which cannot
+      # produce a loadable cdylib. Node on Alpine dlopens this, so the addon has
+      # to resolve musl's libc at load time like every other shared object.
       - name: Build native runtime
+        env:
+          RUSTFLAGS: ${{ endsWith(matrix.target, '-musl') && '-C target-feature=-crt-static' || '' }}
+          CC_x86_64_unknown_linux_musl: musl-gcc
+          CC_aarch64_unknown_linux_musl: musl-gcc
         run: >-
           cargo build --locked --release
           --target ${{ matrix.target }}
@@ -201,8 +230,8 @@ jobs:
             npm publish "$package_dir" --access public --provenance
             published=$((published + 1))
           done
-          if [ "$published" -ne 5 ]; then
-            echo "expected 5 platform packages, published $published" >&2
+          if [ "$published" -ne 8 ]; then
+            echo "expected 8 platform packages, published $published" >&2
             exit 1
           fi
         env:

--- a/.github/workflows/javascript-release.yml
+++ b/.github/workflows/javascript-release.yml
@@ -82,11 +82,15 @@ jobs:
       # Rust links musl targets against a static CRT by default, which cannot
       # produce a loadable cdylib. Node on Alpine dlopens this, so the addon has
       # to resolve musl's libc at load time like every other shared object.
+      # The target-specific linkers keep that dynamic link on musl instead of
+      # sending it through the Ubuntu runner's glibc `cc`.
       - name: Build native runtime
         env:
           RUSTFLAGS: ${{ endsWith(matrix.target, '-musl') && '-C target-feature=-crt-static' || '' }}
           CC_x86_64_unknown_linux_musl: musl-gcc
           CC_aarch64_unknown_linux_musl: musl-gcc
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
         run: >-
           cargo build --locked --release
           --target ${{ matrix.target }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Releases are prepared locally and published from tags.
 - Run `mise run release-needed` to list packages with non-chore path-scoped commits since their latest package tag.
 - Prepare each release with `mise run release-prepare <package> <version>`.
 - `mise run release-prepare` updates only the target package version file and prepends the next changelog entry.
-- If dependent manifests must move together, update them separately in the same release commit. `npm-lumis` is the exception: it also bumps the native crate, the `@lumis-sh/lumis-native` selector and all five platform packages, because the release workflow publishes them under the same version first.
+- If dependent manifests must move together, update them separately in the same release commit. `npm-lumis` is the exception: it also bumps the native crate, the `@lumis-sh/lumis-native` selector and all platform packages, because the release workflow publishes them under the same version first.
 - A `version` requirement on a lumis crate must equal that crate's version in this repository. `mise run release-prepare` keeps them in step, rewriting dependent manifests beyond the package being released, so review and commit every file it touches. `mise run check-crate-deps` reports drift and `--fix` repairs it. Apart from `crates/autumnus`, no build here resolves those requirements, so that check is the only thing that can catch them. See [Crate version requirements](RELEASE.md#crate-version-requirements).
 - Maintainers commit the release prep changes, then push package tags such as `cargo-lumis-cli/v0.2.0`.
 - Pushing a package tag triggers the publish workflows.
@@ -117,8 +117,8 @@ Unset, the CLI and both native addons call
 `lumis_wasm_runtime::store::default_data_dir`, which uses [`etcetera`]'s base
 strategy: `$XDG_DATA_HOME` or `~/.local/share` everywhere except Windows, where
 it is `%APPDATA%`. Node asks the addon for that same value through
-`defaultDataDir()`. Only a platform with no addon, such as musl Linux, falls back
-to the `platformDataDir()` port in `src/runtime/node-cache.ts`, and
+`defaultDataDir()`. A platform with no addon falls back to the
+`platformDataDir()` port in `src/runtime/node-cache.ts`, and
 `test/data-dir-parity.test.ts` pins that port against the addon so the two cannot
 drift.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -129,7 +129,7 @@ If multiple JS packages are part of the same release, use this order:
 
 After `npm-lumis` is published, the plugin packages, CLI package, and WASM bundle packages are independent. Keep the order above as the canonical release order.
 
-The `npm-lumis` workflow also publishes the five platform-specific `@lumis-sh/lumis-native-*` packages and then the `@lumis-sh/lumis-native` selector, before publishing `@lumis-sh/lumis` itself. All of them share the `npm-lumis` version and tag, and `mise run release-prepare npm-lumis <version>` bumps them together.
+The `npm-lumis` workflow also publishes all platform-specific `@lumis-sh/lumis-native-*` packages and then the `@lumis-sh/lumis-native` selector, before publishing `@lumis-sh/lumis` itself. All of them share the `npm-lumis` version and tag, and `mise run release-prepare npm-lumis <version>` bumps them together.
 
 That lockstep is not cosmetic. `@lumis-sh/lumis` depends on the platform packages with `workspace:*`, which pnpm replaces with the workspace version when it packs, so a main package bumped on its own would ship optional dependencies pointing at the previous release — and npm refuses to republish a version that already exists, so the workflow would fail before reaching the main package. `mise run lint` runs `mise run check-native-versions`, which fails if any of them drift.
 
@@ -217,4 +217,4 @@ mise run release-prepare cargo-lumis-cli 0.2.0
 
 If a release requires dependent manifests to move in lockstep, update those files separately and commit them with the release prep.
 
-`npm-lumis` is the one exception: it additionally bumps `native/Cargo.toml`, the `@lumis-sh/lumis-native` selector, and all five platform packages, because the release workflow publishes them under the same version before the main package. See [JavaScript packages](#javascript-packages).
+`npm-lumis` is the one exception: it additionally bumps `native/Cargo.toml`, the `@lumis-sh/lumis-native` selector, and all platform packages, because the release workflow publishes them under the same version before the main package. See [JavaScript packages](#javascript-packages).

--- a/docs/content/usage/javascript-runtime.mdx
+++ b/docs/content/usage/javascript-runtime.mdx
@@ -152,6 +152,8 @@ Useful for dropdowns, config validation, and docs tooling:
 - every runtime loads the same per-language parser WASM; what differs is the engine that runs it
 - on Node, `@lumis-sh/lumis` runs those parsers and the highlighting walk under Wasmtime in the same Rust code as the Lumis CLI and Elixir bindings; built-in formatters normally render there too, while custom formatters assemble events in JavaScript and an async call that may need a JavaScript resolver stays on the main thread
 - browsers, and any platform with no prebuilt addon, run them under the host's own WebAssembly through `web-tree-sitter`, and walk and format in JavaScript
+- the addon is prebuilt for macOS arm64 and x64, Linux arm64 and x64 against both glibc and musl, and Windows arm64 and x64; npm installs the one matching the host, so Alpine and other musl images get the same runtime as a glibc host
+- `runtimeKind()` returns `'native'` or `'wasm'` if you need to confirm which one an install resolved
 - the addon carries no parsers and downloads each on first use, so it costs about 4.7 MB of download on top of the Wasm runtime rather than one binary per language
 - the package uses conditional exports so Node and web-standard runtimes get the right entry point automatically
 - every language package contains matching queries plus an exact parser version, size, and SHA-256 digest

--- a/packages/javascript/lumis/native/npm/linux-arm64-musl/LICENSE
+++ b/packages/javascript/lumis/native/npm/linux-arm64-musl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Leandro Pereira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/javascript/lumis/native/npm/linux-arm64-musl/package.json
+++ b/packages/javascript/lumis/native/npm/linux-arm64-musl/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@lumis-sh/lumis-native-linux-arm64-musl",
+  "version": "0.6.1",
+  "description": "Native Lumis runtime for Linux arm64 musl",
+  "license": "MIT",
+  "repository": "github:leandrocp/lumis",
+  "main": "lumis-native.linux-arm64-musl.node",
+  "files": [
+    "LICENSE",
+    "lumis-native.linux-arm64-musl.node"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/javascript/lumis/native/npm/linux-x64-musl/LICENSE
+++ b/packages/javascript/lumis/native/npm/linux-x64-musl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Leandro Pereira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/javascript/lumis/native/npm/linux-x64-musl/package.json
+++ b/packages/javascript/lumis/native/npm/linux-x64-musl/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@lumis-sh/lumis-native-linux-x64-musl",
+  "version": "0.6.1",
+  "description": "Native Lumis runtime for Linux x64 musl",
+  "license": "MIT",
+  "repository": "github:leandrocp/lumis",
+  "main": "lumis-native.linux-x64-musl.node",
+  "files": [
+    "LICENSE",
+    "lumis-native.linux-x64-musl.node"
+  ],
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "libc": [
+    "musl"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/javascript/lumis/native/npm/meta/index.js
+++ b/packages/javascript/lumis/native/npm/meta/index.js
@@ -5,20 +5,26 @@ function linuxLibc() {
   return report?.header?.glibcVersionRuntime ? "gnu" : "musl";
 }
 
-function nativeTarget() {
-  if (process.platform === "darwin" && ["arm64", "x64"].includes(process.arch)) {
-    return `darwin-${process.arch}`;
+// Kept identical to `nativeTargetFor` in src/native-binding.ts; this package
+// ships alone and cannot import it. test/native-targets.test.ts pins them.
+function nativeTargetFor(platform, arch, libc) {
+  if (platform === "darwin" && ["arm64", "x64"].includes(arch)) {
+    return `darwin-${arch}`;
   }
-  if (process.platform === "linux" && ["arm64", "x64"].includes(process.arch)) {
-    return linuxLibc() === "gnu" ? `linux-${process.arch}-gnu` : undefined;
+  if (platform === "linux" && ["arm64", "x64"].includes(arch)) {
+    return `linux-${arch}-${libc}`;
   }
-  if (process.platform === "win32" && process.arch === "x64") {
-    return "win32-x64-msvc";
+  if (platform === "win32" && ["arm64", "x64"].includes(arch)) {
+    return `win32-${arch}-msvc`;
   }
   return undefined;
 }
 
-const target = nativeTarget();
+const target = nativeTargetFor(
+  process.platform,
+  process.arch,
+  process.platform === "linux" ? linuxLibc() : "gnu",
+);
 
 if (!target) {
   throw new Error(`The Lumis native runtime does not support ${process.platform}-${process.arch}`);

--- a/packages/javascript/lumis/native/npm/meta/package.json
+++ b/packages/javascript/lumis/native/npm/meta/package.json
@@ -17,7 +17,10 @@
     "@lumis-sh/lumis-native-darwin-arm64": "workspace:*",
     "@lumis-sh/lumis-native-darwin-x64": "workspace:*",
     "@lumis-sh/lumis-native-linux-arm64-gnu": "workspace:*",
+    "@lumis-sh/lumis-native-linux-arm64-musl": "workspace:*",
     "@lumis-sh/lumis-native-linux-x64-gnu": "workspace:*",
+    "@lumis-sh/lumis-native-linux-x64-musl": "workspace:*",
+    "@lumis-sh/lumis-native-win32-arm64-msvc": "workspace:*",
     "@lumis-sh/lumis-native-win32-x64-msvc": "workspace:*"
   },
   "engines": {

--- a/packages/javascript/lumis/native/npm/win32-arm64-msvc/LICENSE
+++ b/packages/javascript/lumis/native/npm/win32-arm64-msvc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Leandro Pereira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/javascript/lumis/native/npm/win32-arm64-msvc/package.json
+++ b/packages/javascript/lumis/native/npm/win32-arm64-msvc/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@lumis-sh/lumis-native-win32-arm64-msvc",
+  "version": "0.6.1",
+  "description": "Native Lumis runtime for Windows arm64",
+  "license": "MIT",
+  "repository": "github:leandrocp/lumis",
+  "main": "lumis-native.win32-arm64-msvc.node",
+  "files": [
+    "LICENSE",
+    "lumis-native.win32-arm64-msvc.node"
+  ],
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/javascript/lumis/package.json
+++ b/packages/javascript/lumis/package.json
@@ -110,7 +110,10 @@
     "@lumis-sh/lumis-native-darwin-arm64": "workspace:*",
     "@lumis-sh/lumis-native-darwin-x64": "workspace:*",
     "@lumis-sh/lumis-native-linux-arm64-gnu": "workspace:*",
+    "@lumis-sh/lumis-native-linux-arm64-musl": "workspace:*",
     "@lumis-sh/lumis-native-linux-x64-gnu": "workspace:*",
+    "@lumis-sh/lumis-native-linux-x64-musl": "workspace:*",
+    "@lumis-sh/lumis-native-win32-arm64-msvc": "workspace:*",
     "@lumis-sh/lumis-native-win32-x64-msvc": "workspace:*"
   },
   "engines": {

--- a/packages/javascript/lumis/src/native-binding.ts
+++ b/packages/javascript/lumis/src/native-binding.ts
@@ -91,17 +91,37 @@ function linuxLibc(): "gnu" | "musl" {
   return report?.header?.glibcVersionRuntime ? "gnu" : "musl";
 }
 
-function nativeTarget(): string | undefined {
-  if (process.platform === "darwin" && ["arm64", "x64"].includes(process.arch)) {
-    return `darwin-${process.arch}`;
+/**
+ * The platform package name for a host, or `undefined` where none is published.
+ *
+ * `native/npm/meta/index.js` repeats this for installs that resolve the addon
+ * through `@lumis-sh/lumis-native`, because that package ships alone and cannot
+ * import from here. `test/native-targets.test.ts` pins the two together and to
+ * the published set, so a new target has to be added in both places.
+ */
+export function nativeTargetFor(
+  platform: string,
+  arch: string,
+  libc: "gnu" | "musl",
+): string | undefined {
+  if (platform === "darwin" && ["arm64", "x64"].includes(arch)) {
+    return `darwin-${arch}`;
   }
-  if (process.platform === "linux" && ["arm64", "x64"].includes(process.arch)) {
-    return linuxLibc() === "gnu" ? `linux-${process.arch}-gnu` : undefined;
+  if (platform === "linux" && ["arm64", "x64"].includes(arch)) {
+    return `linux-${arch}-${libc}`;
   }
-  if (process.platform === "win32" && process.arch === "x64") {
-    return "win32-x64-msvc";
+  if (platform === "win32" && ["arm64", "x64"].includes(arch)) {
+    return `win32-${arch}-msvc`;
   }
   return undefined;
+}
+
+function nativeTarget(): string | undefined {
+  return nativeTargetFor(
+    process.platform,
+    process.arch,
+    process.platform === "linux" ? linuxLibc() : "gnu",
+  );
 }
 
 /**

--- a/packages/javascript/lumis/src/native-binding.ts
+++ b/packages/javascript/lumis/src/native-binding.ts
@@ -118,7 +118,7 @@ export function nativeTargetFor(
   return undefined;
 }
 
-function nativeTarget(): string | undefined {
+export function nativeTarget(): string | undefined {
   return nativeTargetFor(
     process.platform,
     process.arch,

--- a/packages/javascript/lumis/test/data-dir-parity.test.ts
+++ b/packages/javascript/lumis/test/data-dir-parity.test.ts
@@ -7,15 +7,12 @@
  * `~/Library/Application Support` on macOS while every Rust caller used XDG.
  */
 import { afterEach, describe, expect, it } from "vitest";
-import { loadAddon } from "../src/native-binding.js";
+import { loadAddon, nativeTarget } from "../src/native-binding.js";
 import { platformDataDir } from "../src/runtime/node-cache.js";
 
 // Asserted directly, so a run that selected the Wasm runtime still covers this.
 const binding = loadAddon();
-
-/** Every platform CI builds for. Elsewhere the Wasm runtime is the answer. */
-const PREBUILT = new Set(["darwin-arm64", "darwin-x64", "linux-x64", "linux-arm64", "win32-x64"]);
-const platform = `${process.platform}-${process.arch}`;
+const hasPrebuiltAddon = nativeTarget() !== undefined;
 
 const XDG = "XDG_DATA_HOME";
 const original = process.env[XDG];
@@ -40,10 +37,10 @@ describe("default data directory", () => {
    * runtime is the sole reader of the directory, so nothing can disagree.
    */
   it("has an addon to pin the port against wherever one is built", () => {
-    if (PREBUILT.has(platform) && !binding) {
+    if (hasPrebuiltAddon && !binding) {
       throw new Error("run `pnpm build:native` (or `mise run test-javascript`) first");
     }
-    expect(binding !== undefined).toBe(PREBUILT.has(platform));
+    expect(binding !== undefined).toBe(hasPrebuiltAddon);
   });
 
   // `process.env` writes reach `std::env::var_os`, so the addon re-reads each of

--- a/packages/javascript/lumis/test/native-runtime.test.ts
+++ b/packages/javascript/lumis/test/native-runtime.test.ts
@@ -29,18 +29,15 @@ process.env.LUMIS_DATA_DIR ??= existsSync(stagedParsers)
   ? stagedParsers
   : mkdtempSync(join(tmpdir(), "lumis-native-test-"));
 
-const { loadAddon } = await import("../src/native-binding.js");
+const { loadAddon, nativeTarget } = await import("../src/native-binding.js");
 
 // Asserted directly, so a run that selected the Wasm runtime still covers this.
 const binding = loadAddon();
-
-/** Every platform CI builds for. Elsewhere the Wasm runtime is the answer. */
-const PREBUILT = new Set(["darwin-arm64", "darwin-x64", "linux-x64", "linux-arm64", "win32-x64"]);
-const platform = `${process.platform}-${process.arch}`;
+const hasPrebuiltAddon = nativeTarget() !== undefined;
 
 describe("native runtime", () => {
   it("is present wherever an addon is built", () => {
-    if (!PREBUILT.has(platform)) {
+    if (!hasPrebuiltAddon) {
       expect(binding).toBeUndefined();
       return;
     }

--- a/packages/javascript/lumis/test/native-targets.test.ts
+++ b/packages/javascript/lumis/test/native-targets.test.ts
@@ -9,10 +9,17 @@
  * published package, silently drops those hosts onto `web-tree-sitter`. Nothing
  * else in the suite would notice, because CI runs on hosts the addon covers.
  */
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { readFileSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { createRequire } from "node:module";
+import {
+  Language as TSLanguage,
+  Parser,
+  Query,
+  type Node as TSNode,
+  type QueryMatch,
+} from "web-tree-sitter";
 import { nativeTargetFor } from "../src/native-binding.js";
 
 const packageDir = resolve(import.meta.dirname, "..");
@@ -21,6 +28,53 @@ const nativeNpmDir = join(packageDir, "native", "npm");
 const PLATFORMS = ["darwin", "linux", "win32", "freebsd", "openbsd", "sunos", "aix", "android"];
 const ARCHS = ["arm64", "x64", "ia32", "arm", "riscv64", "ppc64", "s390x", "loong64"];
 const LIBCS = ["gnu", "musl"] as const;
+const EXPECTED_NATIVE_TARGETS = [
+  "darwin-arm64",
+  "darwin-x64",
+  "linux-arm64-gnu",
+  "linux-arm64-musl",
+  "linux-x64-gnu",
+  "linux-x64-musl",
+  "win32-arm64-msvc",
+  "win32-x64-msvc",
+];
+
+const SELECTOR_BRANCH_QUERY = String.raw`
+(function_declaration
+  name: (identifier) @function.name
+  body: (statement_block
+    (if_statement
+      condition: (parenthesized_expression
+        (binary_expression
+          left: (binary_expression
+            left: (identifier) @platform.variable
+            operator: "==="
+            right: (string (string_fragment) @platform.value))
+          operator: "&&"
+          right: (call_expression
+            function: (member_expression
+              object: (array
+                (string (string_fragment) @arch.value)+)
+              property: (property_identifier) @includes)
+            arguments: (arguments (identifier) @arch.variable))))
+      consequence: (statement_block
+        (return_statement (template_string) @branch.target))) @branch)
+  (#eq? @function.name "nativeTargetFor")
+  (#eq? @platform.variable "platform")
+  (#eq? @includes "includes")
+  (#eq? @arch.variable "arch"))
+`;
+
+type SelectorVariable = "platform" | "arch" | "libc";
+type TemplatePart =
+  | { kind: "literal"; value: string }
+  | { kind: "variable"; name: SelectorVariable };
+
+interface SelectorRule {
+  platform: string;
+  arch: string;
+  target: TemplatePart[];
+}
 
 function targetsFrom(fn: typeof nativeTargetFor): string[] {
   const found = new Set<string>();
@@ -35,32 +89,97 @@ function targetsFrom(fn: typeof nativeTargetFor): string[] {
   return [...found].sort();
 }
 
-/**
- * The selector's copy, loaded without running its `require` of the resolved
- * platform package, which is not installed for most of the matrix below.
- */
-function selectorNativeTargetFor(): typeof nativeTargetFor {
+function capture(match: QueryMatch, name: string): TSNode {
+  const node = match.captures.find((candidate) => candidate.name === name)?.node;
+  if (!node) throw new Error(`native selector query did not capture ${name}`);
+  return node;
+}
+
+function selectorVariable(node: TSNode): SelectorVariable {
+  if (node.text === "platform" || node.text === "arch" || node.text === "libc") {
+    return node.text;
+  }
+  throw new Error(`native selector target uses unsupported variable ${node.text}`);
+}
+
+function templateParts(node: TSNode): TemplatePart[] {
+  return node.namedChildren.map((child): TemplatePart => {
+    if (child.type === "string_fragment") return { kind: "literal", value: child.text };
+    const variable = child.type === "template_substitution" ? child.firstNamedChild : null;
+    if (variable?.type !== "identifier") {
+      throw new Error(`native selector target contains unsupported ${child.type}`);
+    }
+    return { kind: "variable", name: selectorVariable(variable) };
+  });
+}
+
+/** Read the shipped selector as syntax without executing its package-loading entrypoint. */
+async function selectorNativeTargetFor(): Promise<typeof nativeTargetFor> {
   const source = readFileSync(join(nativeNpmDir, "meta", "index.js"), "utf8");
-  const start = source.indexOf("function nativeTargetFor(");
-  expect(start, "native/npm/meta/index.js declares nativeTargetFor").toBeGreaterThan(-1);
-  const end = source.indexOf("\n}\n", start);
-  expect(end, "nativeTargetFor is terminated").toBeGreaterThan(start);
-  const body = source.slice(start, end + 3);
-  // oxlint-disable-next-line typescript-eslint/no-implied-eval -- running the shipped selector's own source is the point; importing it would resolve a platform package this host does not have
-  return new Function(`${body}; return nativeTargetFor;`)() as typeof nativeTargetFor;
+  await Parser.init();
+  const language = await TSLanguage.load(
+    new Uint8Array(
+      readFileSync(new URL("./fixtures/wasm/tree-sitter-javascript.wasm", import.meta.url)),
+    ),
+  );
+  const parser = new Parser();
+  parser.setLanguage(language);
+  const tree = parser.parse(source);
+  if (!tree) throw new Error("native selector JavaScript did not parse");
+
+  const query = new Query(language, SELECTOR_BRANCH_QUERY);
+  const rules: SelectorRule[] = query.matches(tree.rootNode).map((match) => ({
+    platform: capture(match, "platform.value").text,
+    arch: capture(match, "arch.value").text,
+    target: templateParts(capture(match, "branch.target")),
+  }));
+  query.delete();
+  tree.delete();
+  parser.delete();
+
+  return (platform, arch, libc) => {
+    const rule = rules.find(
+      (candidate) => candidate.platform === platform && candidate.arch === arch,
+    );
+    if (!rule) return undefined;
+    const variables: Record<SelectorVariable, string> = { platform, arch, libc };
+    return rule.target
+      .map((part) => (part.kind === "literal" ? part.value : variables[part.name]))
+      .join("");
+  };
+}
+
+function expectCompleteTargetCorpus(targets: readonly string[]): void {
+  expect(targets).toHaveLength(EXPECTED_NATIVE_TARGETS.length);
+  expect(targets).toEqual(EXPECTED_NATIVE_TARGETS);
 }
 
 const publishedTargets = readdirSync(nativeNpmDir)
   .filter((entry) => entry !== "meta")
   .sort();
+let selectorTargetFor: typeof nativeTargetFor;
+
+beforeAll(async () => {
+  selectorTargetFor = await selectorNativeTargetFor();
+});
 
 describe("native target selection", () => {
   it("covers every published platform package", () => {
-    expect(targetsFrom(nativeTargetFor)).toEqual(publishedTargets);
+    expectCompleteTargetCorpus(targetsFrom(nativeTargetFor));
+    expectCompleteTargetCorpus(publishedTargets);
   });
 
   it("agrees with the @lumis-sh/lumis-native selector", () => {
-    expect(targetsFrom(selectorNativeTargetFor())).toEqual(targetsFrom(nativeTargetFor));
+    const selectorTargets = targetsFrom(selectorTargetFor);
+    expectCompleteTargetCorpus(selectorTargets);
+    expect(selectorTargets).toEqual(targetsFrom(nativeTargetFor));
+  });
+
+  it("rejects an incomplete native-target corpus", () => {
+    const withoutWindowsArm64 = EXPECTED_NATIVE_TARGETS.filter(
+      (target) => target !== "win32-arm64-msvc",
+    );
+    expect(() => expectCompleteTargetCorpus(withoutWindowsArm64)).toThrow();
   });
 
   it("resolves each host to the package that declares it", () => {

--- a/packages/javascript/lumis/test/native-targets.test.ts
+++ b/packages/javascript/lumis/test/native-targets.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The addon is selected by two copies of the same function: `nativeTargetFor`
+ * in src/native-binding.ts, used when `@lumis-sh/lumis` resolves the addon
+ * itself, and the copy in native/npm/meta/index.js, used when an install goes
+ * through the `@lumis-sh/lumis-native` selector. That package ships alone, so
+ * it cannot import the first one.
+ *
+ * A target added to one copy and not the other, or to both but with no
+ * published package, silently drops those hosts onto `web-tree-sitter`. Nothing
+ * else in the suite would notice, because CI runs on hosts the addon covers.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { nativeTargetFor } from "../src/native-binding.js";
+
+const packageDir = resolve(import.meta.dirname, "..");
+const nativeNpmDir = join(packageDir, "native", "npm");
+
+const PLATFORMS = ["darwin", "linux", "win32", "freebsd", "openbsd", "sunos", "aix", "android"];
+const ARCHS = ["arm64", "x64", "ia32", "arm", "riscv64", "ppc64", "s390x", "loong64"];
+const LIBCS = ["gnu", "musl"] as const;
+
+function targetsFrom(fn: typeof nativeTargetFor): string[] {
+  const found = new Set<string>();
+  for (const platform of PLATFORMS) {
+    for (const arch of ARCHS) {
+      for (const libc of LIBCS) {
+        const target = fn(platform, arch, libc);
+        if (target) found.add(target);
+      }
+    }
+  }
+  return [...found].sort();
+}
+
+/**
+ * The selector's copy, loaded without running its `require` of the resolved
+ * platform package, which is not installed for most of the matrix below.
+ */
+function selectorNativeTargetFor(): typeof nativeTargetFor {
+  const source = readFileSync(join(nativeNpmDir, "meta", "index.js"), "utf8");
+  const start = source.indexOf("function nativeTargetFor(");
+  expect(start, "native/npm/meta/index.js declares nativeTargetFor").toBeGreaterThan(-1);
+  const end = source.indexOf("\n}\n", start);
+  expect(end, "nativeTargetFor is terminated").toBeGreaterThan(start);
+  const body = source.slice(start, end + 3);
+  // oxlint-disable-next-line typescript-eslint/no-implied-eval -- running the shipped selector's own source is the point; importing it would resolve a platform package this host does not have
+  return new Function(`${body}; return nativeTargetFor;`)() as typeof nativeTargetFor;
+}
+
+const publishedTargets = readdirSync(nativeNpmDir)
+  .filter((entry) => entry !== "meta")
+  .sort();
+
+describe("native target selection", () => {
+  it("covers every published platform package", () => {
+    expect(targetsFrom(nativeTargetFor)).toEqual(publishedTargets);
+  });
+
+  it("agrees with the @lumis-sh/lumis-native selector", () => {
+    expect(targetsFrom(selectorNativeTargetFor())).toEqual(targetsFrom(nativeTargetFor));
+  });
+
+  it("resolves each host to the package that declares it", () => {
+    const require = createRequire(import.meta.url);
+    for (const target of publishedTargets) {
+      const manifest = require(join(nativeNpmDir, target, "package.json")) as {
+        name: string;
+        os: string[];
+        cpu: string[];
+        libc?: string[];
+      };
+      expect(manifest.name).toBe(`@lumis-sh/lumis-native-${target}`);
+
+      const platform = manifest.os[0];
+      const arch = manifest.cpu[0];
+      const libc = manifest.libc?.[0] === "musl" ? "musl" : "gnu";
+      expect(nativeTargetFor(platform, arch, libc), `${platform}-${arch}-${libc}`).toBe(target);
+    }
+  });
+
+  it("leaves platforms with no addon on the Wasm runtime", () => {
+    expect(nativeTargetFor("freebsd", "x64", "gnu")).toBeUndefined();
+    expect(nativeTargetFor("android", "arm64", "gnu")).toBeUndefined();
+    expect(nativeTargetFor("linux", "riscv64", "gnu")).toBeUndefined();
+    expect(nativeTargetFor("win32", "ia32", "gnu")).toBeUndefined();
+  });
+
+  it("keeps glibc and musl on separate packages", () => {
+    expect(nativeTargetFor("linux", "x64", "gnu")).toBe("linux-x64-gnu");
+    expect(nativeTargetFor("linux", "x64", "musl")).toBe("linux-x64-musl");
+    expect(nativeTargetFor("linux", "arm64", "gnu")).toBe("linux-arm64-gnu");
+    expect(nativeTargetFor("linux", "arm64", "musl")).toBe("linux-arm64-musl");
+  });
+});

--- a/packages/javascript/scripts/check-native-versions.mjs
+++ b/packages/javascript/scripts/check-native-versions.mjs
@@ -17,7 +17,10 @@ const PLATFORM_DIRS = [
   "darwin-arm64",
   "darwin-x64",
   "linux-arm64-gnu",
+  "linux-arm64-musl",
   "linux-x64-gnu",
+  "linux-x64-musl",
+  "win32-arm64-msvc",
   "win32-x64-msvc",
 ];
 const SELECTOR_DIR = "meta";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,9 +179,18 @@ importers:
       '@lumis-sh/lumis-native-linux-arm64-gnu':
         specifier: workspace:*
         version: link:native/npm/linux-arm64-gnu
+      '@lumis-sh/lumis-native-linux-arm64-musl':
+        specifier: workspace:*
+        version: link:native/npm/linux-arm64-musl
       '@lumis-sh/lumis-native-linux-x64-gnu':
         specifier: workspace:*
         version: link:native/npm/linux-x64-gnu
+      '@lumis-sh/lumis-native-linux-x64-musl':
+        specifier: workspace:*
+        version: link:native/npm/linux-x64-musl
+      '@lumis-sh/lumis-native-win32-arm64-msvc':
+        specifier: workspace:*
+        version: link:native/npm/win32-arm64-msvc
       '@lumis-sh/lumis-native-win32-x64-msvc':
         specifier: workspace:*
         version: link:native/npm/win32-x64-msvc
@@ -192,7 +201,11 @@ importers:
 
   packages/javascript/lumis/native/npm/linux-arm64-gnu: {}
 
+  packages/javascript/lumis/native/npm/linux-arm64-musl: {}
+
   packages/javascript/lumis/native/npm/linux-x64-gnu: {}
+
+  packages/javascript/lumis/native/npm/linux-x64-musl: {}
 
   packages/javascript/lumis/native/npm/meta:
     optionalDependencies:
@@ -205,12 +218,23 @@ importers:
       '@lumis-sh/lumis-native-linux-arm64-gnu':
         specifier: workspace:*
         version: link:../linux-arm64-gnu
+      '@lumis-sh/lumis-native-linux-arm64-musl':
+        specifier: workspace:*
+        version: link:../linux-arm64-musl
       '@lumis-sh/lumis-native-linux-x64-gnu':
         specifier: workspace:*
         version: link:../linux-x64-gnu
+      '@lumis-sh/lumis-native-linux-x64-musl':
+        specifier: workspace:*
+        version: link:../linux-x64-musl
+      '@lumis-sh/lumis-native-win32-arm64-msvc':
+        specifier: workspace:*
+        version: link:../win32-arm64-msvc
       '@lumis-sh/lumis-native-win32-x64-msvc':
         specifier: workspace:*
         version: link:../win32-x64-msvc
+
+  packages/javascript/lumis/native/npm/win32-arm64-msvc: {}
 
   packages/javascript/lumis/native/npm/win32-x64-msvc: {}
 


### PR DESCRIPTION
## Why

The Node addon shipped five targets — `darwin-{arm64,x64}`, `linux-{arm64,x64}-gnu`, `win32-x64-msvc`. Everything else fell back to `web-tree-sitter`:

- musl Linux — Alpine and most Docker images
- Windows on ARM
- any install where the optional dependency did not resolve (`--no-optional`, restricted registries, PnP)

That fallback is the browser implementation, and per `ARCHITECTURE.md` it cannot load an injected language during the walk that discovers it. So those hosts lost single-pass highlighting as well as native speed, silently — `loadAddon()` swallows the failure by design.

## What

Adds three targets, taking the matrix from 5 to 8:

| package | target | runner |
| --- | --- | --- |
| `linux-x64-musl` | `x86_64-unknown-linux-musl` | `ubuntu-latest` |
| `linux-arm64-musl` | `aarch64-unknown-linux-musl` | `ubuntu-24.04-arm` |
| `win32-arm64-msvc` | `aarch64-pc-windows-msvc` | `windows-latest` |

None of this is new ground for the Rust side:

- the Elixir NIF already ships `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` from the same `lumis-core` + `lumis-wasm-runtime` (Wasmtime, Tree-sitter C) crates
- `.cargo/config.toml` already carries `CFLAGS_*` for both musl targets
- `cli-binary-release.yml` already builds `aarch64-pc-windows-msvc`

Only the napi packaging was missing.

Two build details that are not obvious:

- musl targets link a static CRT by default, which cannot produce a loadable `cdylib`. Node on Alpine `dlopen`s this, so the build sets `-C target-feature=-crt-static`.
- `CC_*_unknown_linux_musl=musl-gcc`, otherwise `cc` reaches for the runner's glibc gcc for the Tree-sitter C sources.

## Deduplication

Host selection was duplicated between `src/native-binding.ts` and `native/npm/meta/index.js` — the `@lumis-sh/lumis-native` selector ships alone and cannot import from the package. Widening the matrix makes divergence between them more likely, and `AGENTS.md` requires two copies of an algorithm to be pinned by a test.

Both are now pure functions over `(platform, arch, libc)`, and `test/native-targets.test.ts` asserts:

- both copies produce the same target set across a platform/arch/libc matrix
- that set equals the published `native/npm/` directories exactly — no target without a package, no package without a target
- each platform manifest's own `os`/`cpu`/`libc` resolves back to its directory
- unsupported hosts still return `undefined`

Per `AGENTS.md`, the guard was proven to fail: reverting `win32-arm64` in the selector alone turns the parity test red.

## Verification

- `mise run lint-workflows` (actionlint) — clean
- `mise run fmt-js --check`, `oxlint --type-aware --deny-warnings` — clean
- `mise run check-native-versions` — 10 manifests in lockstep at 0.6.1
- `mise run check-crate-deps` — clean
- native suite on darwin-arm64: 518 passed, incl. `native-runtime.test.ts` against a freshly built addon
- wasm suite: 532 tests, same 2 failures as the base commit (`tree-sitter-json` WASM size skew from a stale local `@lumis-sh/wasm-bundle-full`), verified pre-existing by re-running against unmodified source

The new targets themselves are built by the release workflow, so they are exercised on the next `npm-lumis/v*` tag rather than in PR CI.

## Not included

FreeBSD (no GitHub-hosted runner), and `linux-riscv64` / `linux-armv7` — the Elixir NIF ships those via `cross`, but they are niche for Node and would need a different build path than the matrix above.