### PR TITLE
docs(elixir): add deployment guide

### DIFF
--- a/packages/elixir/lumis/README.md
+++ b/packages/elixir/lumis/README.md
@@ -70,12 +70,17 @@ global to the VM, so only the first process pays.
 Lumis.Languages.load(["elixir", "html", "javascript", "css"])
 ```
 
+## Deployment
+
+Cache parsers while building a Mix release so production does not download or
+compile them on the first request:
+
 ```sh
-# better: bake parsers into the image, so no request ever pays
 mix lumis.languages.cache elixir html javascript css
 ```
 
-Parsers live under `LUMIS_DATA_DIR`, or `config :lumis, data_dir:`.
+See the [deployment guide](https://lumis.hexdocs.pm/deployment.html) for the
+Dockerfile step, bundles, and custom cache directories.
 
 The NIF is precompiled. Set `LUMIS_BUILD=1` to build it from source instead, or
 `LUMIS_USE_LEGACY_ARTIFACTS=1` to take the legacy-CPU variant on a machine

--- a/packages/elixir/lumis/guides/deployment.md
+++ b/packages/elixir/lumis/guides/deployment.md
@@ -19,5 +19,6 @@ versions already in the cache.
 
 By default, the task writes parser metadata, verified WASM, and compiled modules
 to Lumis's `priv/lumis` directory. `mix release` includes that directory
-automatically. If you set `LUMIS_DATA_DIR` or `config :lumis, data_dir:`, copy
-that directory into the image and use the same path at runtime.
+automatically. If you set `config :lumis, data_dir: "/app/lumis"`, use an
+absolute path, copy that directory into the image, and keep the same
+configuration at runtime.

--- a/packages/elixir/lumis/guides/deployment.md
+++ b/packages/elixir/lumis/guides/deployment.md
@@ -1,0 +1,23 @@
+# Deployment
+
+Lumis downloads and compiles a parser the first time it is used. Cache the
+languages your application needs while building a Mix release so production
+does not pay that cost.
+
+Add the cache step after compilation and before `mix release`:
+
+```dockerfile
+RUN mix compile
+RUN mix lumis.languages.cache markdown elixir javascript rust css html comment
+RUN mix release
+```
+
+Include the root languages and any injected languages, such as the languages in
+Markdown code fences. The task accepts language names, bundles such as
+`bundle_web` and `bundle_system`, or `--all`. Use `--force` to refresh compatible
+versions already in the cache.
+
+By default, the task writes parser metadata, verified WASM, and compiled modules
+to Lumis's `priv/lumis` directory. `mix release` includes that directory
+automatically. If you set `LUMIS_DATA_DIR` or `config :lumis, data_dir:`, copy
+that directory into the image and use the same path at runtime.

--- a/packages/elixir/lumis/mix.exs
+++ b/packages/elixir/lumis/mix.exs
@@ -57,6 +57,7 @@ defmodule Lumis.MixProject do
         native/lumis_nif/Cross.toml
         priv/static/css
         examples
+        guides
         checksum-*.exs
         mix.exs
         README.md
@@ -75,6 +76,7 @@ defmodule Lumis.MixProject do
       source_url_pattern:
         "#{@source_url}/blob/hex-lumis/v#{@version}/packages/elixir/lumis/%{path}#L%{line}",
       extras: [
+        "guides/deployment.md",
         "CHANGELOG.md",
         "examples/bbcode_scoped.livemd",
         "examples/html_linked_scoped_css.livemd",


### PR DESCRIPTION
## Summary

- add a concise HexDocs guide for caching parser WASM and compiled modules in Mix/Docker releases
- document injected languages, bundles, refreshes, the default `priv/lumis` path, and custom data directories
- link the deployment guide from the Elixir package README

## Why

Dynamic parser loading works on demand, but release users should be able to bake the cache into their image so the first production request does not download or compile parsers.

## Validation

- `mise run docs-elixir`
- confirmed ExDoc generates `doc/deployment.html`
- `mise run lint-elixir`
- `git diff --check`