### PR TITLE
feat!: one vocabulary for the language and theme catalog, in every runtime

### DIFF
--- a/crates/lumis-cli/README.md
+++ b/crates/lumis-cli/README.md
@@ -36,7 +36,7 @@ lumis dump tree          Print configurable Tree-sitter syntax trees
 lumis dump events        Print raw highlight events as JSON
 lumis languages list     List supported language ids and file patterns
 lumis languages show     Print what the catalog knows about one language
-lumis languages cache    Download and verify parsers so later runs skip the download
+lumis languages cache    Download and compile parsers so later runs skip both
 lumis themes list        List built-in themes and custom themes in the data dir
 lumis themes show        Print one theme's appearance and colors
 lumis themes generate    Extract a theme JSON file from a Neovim colorscheme repo

--- a/crates/lumis-cli/README.md
+++ b/crates/lumis-cli/README.md
@@ -35,9 +35,11 @@ lumis highlight          Highlight a file or stdin
 lumis dump tree          Print configurable Tree-sitter syntax trees
 lumis dump events        Print raw highlight events as JSON
 lumis languages list     List supported language ids and file patterns
+lumis languages show     Print what the catalog knows about one language
+lumis languages cache    Download and verify parsers so later runs skip the download
 lumis themes list        List built-in themes and custom themes in the data dir
+lumis themes show        Print one theme's appearance and colors
 lumis themes generate    Extract a theme JSON file from a Neovim colorscheme repo
-lumis parsers cache      Cache parser WASMs so later runs skip the download
 ```
 
 ## Usage
@@ -52,7 +54,7 @@ Terminal output is the default. The language comes from the filename; `-l` is
 only needed when reading stdin.
 
 Parsers download on demand into the data directory (`LUMIS_DATA_DIR`, otherwise
-the platform default) and are verified before use. `lumis parsers cache` fetches
+the platform default) and are verified before use. `lumis languages cache` fetches
 and compiles them ahead of time, and every Lumis runtime reads that same
 directory, so a cache prepared here also starts Elixir and Node warm.
 

--- a/crates/lumis-cli/src/main.rs
+++ b/crates/lumis-cli/src/main.rs
@@ -297,6 +297,13 @@ enum DumpCommands {
 enum LanguagesCommands {
     /// Print supported languages and their file patterns
     List,
+
+    /// Print what the catalog knows about one language
+    #[command(after_help = "Examples:\n  lumis languages show elixir\n  lumis languages show js")]
+    Show {
+        /// Language id or alias, e.g. elixir, js
+        language: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -318,6 +325,15 @@ enum FormattersCommands {
 enum ThemesCommands {
     /// Print available themes (built-in and from --data-dir)
     List,
+
+    /// Print one theme's appearance and colors
+    #[command(
+        after_help = "Examples:\n  lumis themes show dracula\n  lumis themes show github_light"
+    )]
+    Show {
+        /// Theme name, e.g. dracula
+        theme: String,
+    },
 
     /// Extract a theme from a Neovim colorscheme Git repo
     #[command(
@@ -484,9 +500,11 @@ fn main() -> Result<()> {
         }
         Commands::Languages { command } => match command {
             LanguagesCommands::List => list_languages(),
+            LanguagesCommands::Show { language } => show_language(&language),
         },
         Commands::Themes { command } => match command {
             ThemesCommands::List => list_themes(&data_dir),
+            ThemesCommands::Show { theme } => show_theme(&theme, &data_dir),
             ThemesCommands::Generate {
                 url,
                 colorscheme,
@@ -587,6 +605,42 @@ fn show_formatter(formatter: Formatter) -> Result<()> {
         println!("  {flag}");
     }
     println!("\nRun `lumis highlight --help` for descriptions.");
+    Ok(())
+}
+
+fn print_field(label: &str, values: &[&str]) {
+    if !values.is_empty() {
+        println!("  {label}: {}", values.join(", "));
+    }
+}
+
+fn show_language(name: &str) -> Result<()> {
+    let language: Language = name
+        .parse()
+        .map_err(|_| anyhow::anyhow!("unknown language: {name}"))?;
+    let info = language.info();
+
+    println!("{}: {}\n", info.id, info.name);
+    print_field("aliases", info.aliases);
+    print_field("extensions", &info.extensions);
+    print_field("globs", info.globs);
+    print_field("emacs modes", info.emacs_modes);
+    print_field("shebangs", info.shebangs);
+    Ok(())
+}
+
+fn show_theme(name: &str, data_dir: &Path) -> Result<()> {
+    let theme = resolve_theme(Some(name.to_string()), Some(data_dir), false)
+        .ok_or_else(|| anyhow::anyhow!("unknown theme: {name}"))?;
+
+    println!("{}: {}\n", theme.name, theme.appearance);
+    if let Some(fg) = theme.fg() {
+        println!("  foreground: {fg}");
+    }
+    if let Some(bg) = theme.bg() {
+        println!("  background: {bg}");
+    }
+    println!("  highlights: {}", theme.highlights.len());
     Ok(())
 }
 

--- a/crates/lumis-cli/src/main.rs
+++ b/crates/lumis-cli/src/main.rs
@@ -299,7 +299,7 @@ enum LanguagesCommands {
         language: String,
     },
 
-    /// Download and verify parsers so later runs skip the download
+    /// Download and compile parsers so later runs skip both
     #[command(
         after_help = "Examples:\n  lumis languages cache rust javascript\n  lumis languages cache bundle-web\n  lumis languages cache --all\n  lumis languages cache rust --force\n  lumis --data-dir /app/lumis languages cache rust"
     )]

--- a/crates/lumis-cli/src/main.rs
+++ b/crates/lumis-cli/src/main.rs
@@ -87,12 +87,6 @@ enum Commands {
         #[command(subcommand)]
         command: ThemesCommands,
     },
-
-    /// Manage Tree-sitter WASM parsers
-    Parsers {
-        #[command(subcommand)]
-        command: ParsersCommands,
-    },
 }
 
 #[derive(clap::Args)]
@@ -304,6 +298,23 @@ enum LanguagesCommands {
         /// Language id or alias, e.g. elixir, js
         language: String,
     },
+
+    /// Download and verify parsers so later runs skip the download
+    #[command(
+        after_help = "Examples:\n  lumis languages cache rust javascript\n  lumis languages cache bundle-web\n  lumis languages cache --all\n  lumis languages cache rust --force\n  lumis --data-dir /app/lumis languages cache rust"
+    )]
+    Cache {
+        /// Language names, or a bundle such as bundle-web (e.g. rust javascript elixir)
+        languages: Vec<String>,
+
+        /// Cache every language in the catalog
+        #[arg(long)]
+        all: bool,
+
+        /// Resolve compatible packages again and replace valid cached parsers
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -359,26 +370,6 @@ enum ThemesCommands {
         /// light or dark [default: dark]
         #[arg(short = 'a', long)]
         appearance: Option<String>,
-    },
-}
-
-#[derive(Subcommand)]
-enum ParsersCommands {
-    /// Cache parser WASMs so later runs skip the download
-    #[command(
-        after_help = "Examples:\n  lumis parsers cache rust javascript\n  lumis parsers cache bundle-web\n  lumis parsers cache --all\n  lumis parsers cache rust --force\n  lumis --data-dir /app/lumis parsers cache rust"
-    )]
-    Cache {
-        /// Language names, or a bundle such as bundle-web (e.g. rust javascript elixir)
-        languages: Vec<String>,
-
-        /// Cache all supported parsers
-        #[arg(long)]
-        all: bool,
-
-        /// Resolve compatible packages again and replace valid cached parsers
-        #[arg(long)]
-        force: bool,
     },
 }
 
@@ -501,6 +492,14 @@ fn main() -> Result<()> {
         Commands::Languages { command } => match command {
             LanguagesCommands::List => list_languages(),
             LanguagesCommands::Show { language } => show_language(&language),
+            LanguagesCommands::Cache {
+                languages,
+                all,
+                force,
+            } => {
+                let reg = registry::Registry::new(data_dir)?;
+                cache_languages(&reg, &languages, all, force, verbose)
+            }
         },
         Commands::Themes { command } => match command {
             ThemesCommands::List => list_themes(&data_dir),
@@ -518,16 +517,6 @@ fn main() -> Result<()> {
                 output.as_deref(),
                 appearance.as_deref(),
             ),
-        },
-        Commands::Parsers { command } => match command {
-            ParsersCommands::Cache {
-                languages,
-                all,
-                force,
-            } => {
-                let reg = registry::Registry::new(data_dir)?;
-                cache_parsers(&reg, &languages, all, force, verbose)
-            }
         },
     }
 }
@@ -644,7 +633,7 @@ fn show_theme(name: &str, data_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-fn cache_parsers(
+fn cache_languages(
     reg: &registry::Registry,
     languages: &[String],
     all: bool,

--- a/crates/lumis-cli/src/registry.rs
+++ b/crates/lumis-cli/src/registry.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tree_sitter::Tree;
 
 /// The CLI's view of [`Runtime`]: the same one-pass highlighting Elixir and Node
-/// use, plus the paths and cache reporting `lumis parsers` prints.
+/// use, plus the paths and cache reporting `lumis languages cache` prints.
 pub struct Registry {
     data_dir: PathBuf,
     runtime: Runtime,

--- a/crates/lumis-cli/tests/cli.rs
+++ b/crates/lumis-cli/tests/cli.rs
@@ -176,6 +176,103 @@ fn list_themes_uses_data_dir_from_env() {
         .stdout(predicate::str::contains("custom (file)"));
 }
 
+/// The format was unpinned, so nothing would have noticed it changing. One
+/// language and one theme are enough to hold the shape of each.
+#[test]
+fn list_languages_prints_an_id_then_its_globs() {
+    let output = cmd().args(["languages", "list"]).assert().success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+
+    let elixir = stdout
+        .lines()
+        .position(|line| line == "elixir")
+        .expect("elixir is listed on a line of its own");
+    assert_eq!(stdout.lines().nth(elixir + 1).unwrap(), "  *.ex  *.exs");
+}
+
+#[test]
+fn list_themes_prints_one_sorted_name_per_line() {
+    let output = cmd().args(["themes", "list"]).assert().success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let names: Vec<&str> = stdout.lines().collect();
+
+    assert!(
+        names.len() > 200,
+        "expected the full corpus, got {}",
+        names.len()
+    );
+    assert!(names.contains(&"dracula"));
+
+    let mut sorted = names.clone();
+    sorted.sort_unstable();
+    assert_eq!(names, sorted);
+}
+
+#[test]
+fn languages_show_prints_what_the_catalog_knows() {
+    cmd()
+        .args(["languages", "show", "elixir"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("elixir: Elixir"))
+        .stdout(predicate::str::contains("extensions: *.ex, *.exs"))
+        .stdout(predicate::str::contains("emacs modes: elixir"));
+}
+
+#[test]
+fn languages_show_resolves_an_alias() {
+    cmd()
+        .args(["languages", "show", "js"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("javascript: JavaScript"))
+        .stdout(predicate::str::contains("aliases: js, jsx"));
+}
+
+#[test]
+fn languages_show_rejects_an_unknown_language() {
+    cmd()
+        .args(["languages", "show", "not-a-language"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown language: not-a-language"));
+}
+
+#[test]
+fn themes_show_prints_appearance_and_colors() {
+    cmd()
+        .args(["themes", "show", "dracula"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("dracula: dark"))
+        .stdout(predicate::str::contains("background: #282a36"));
+}
+
+#[test]
+fn themes_show_finds_a_theme_from_the_data_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_file(
+        &tmp.path().join("themes/custom.json"),
+        r#"{"name":"custom","appearance":"dark","revision":"test","highlights":{}}"#,
+    );
+
+    cmd()
+        .env("LUMIS_DATA_DIR", tmp.path())
+        .args(["themes", "show", "custom"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("custom: dark"));
+}
+
+#[test]
+fn themes_show_rejects_an_unknown_theme() {
+    cmd()
+        .args(["themes", "show", "not-a-theme"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown theme: not-a-theme"));
+}
+
 #[test]
 fn highlight_nonexistent_file() {
     cmd()

--- a/crates/lumis-cli/tests/cli.rs
+++ b/crates/lumis-cli/tests/cli.rs
@@ -1199,12 +1199,18 @@ fn themes_generate_supports_output_setup_and_appearance_options() {
     assert!(themes_lua.contains("vim.g.test_setup = true"));
 }
 
-// -- parsers cache --
+// -- languages cache --
 
+/// clap prints each env-backed option's current value, so `$LUMIS_DATA_DIR` and
+/// `$LUMIS_CONFIG` land in this output. A checkout under a path containing
+/// "fetch" or "update" would fail the assertions below on the paths rather than
+/// on the wording, so both are cleared.
 #[test]
-fn parsers_help_uses_cache_terminology() {
+fn languages_help_uses_cache_terminology() {
     cmd()
-        .args(["parsers", "--help"])
+        .env("LUMIS_DATA_DIR", "")
+        .env("LUMIS_CONFIG", "")
+        .args(["languages", "--help"])
         .assert()
         .success()
         .stdout(predicate::str::contains("cache"))
@@ -1213,9 +1219,9 @@ fn parsers_help_uses_cache_terminology() {
 }
 
 #[test]
-fn cache_parsers_no_args_fails() {
+fn cache_languages_no_args_fails() {
     cmd()
-        .args(["parsers", "cache"])
+        .args(["languages", "cache"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -1224,18 +1230,18 @@ fn cache_parsers_no_args_fails() {
 }
 
 #[test]
-fn cache_parsers_rejects_an_unknown_bundle() {
+fn cache_languages_rejects_an_unknown_bundle() {
     cmd()
-        .args(["parsers", "cache", "bundle-nope"])
+        .args(["languages", "cache", "bundle-nope"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unknown bundle 'bundle-nope'"));
 }
 
 #[test]
-fn cache_parsers_rejects_languages_with_all() {
+fn cache_languages_rejects_languages_with_all() {
     cmd()
-        .args(["parsers", "cache", "rust", "--all"])
+        .args(["languages", "cache", "rust", "--all"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -1244,38 +1250,38 @@ fn cache_parsers_rejects_languages_with_all() {
 }
 
 #[test]
-fn cache_parsers_already_cached() {
+fn cache_languages_already_cached() {
     // The fixtures dir already has the diff package cached — silent without -v.
     cmd()
         .arg("--data-dir")
         .arg(fixtures_dir())
-        .args(["parsers", "cache", "diff"])
+        .args(["languages", "cache", "diff"])
         .assert()
         .success();
 }
 
 #[test]
-fn cache_parsers_already_cached_verbose() {
+fn cache_languages_already_cached_verbose() {
     // With -V it shows the cached path
     cmd()
         .arg("--data-dir")
         .arg(fixtures_dir())
         .arg("-v")
-        .args(["parsers", "cache", "diff"])
+        .args(["languages", "cache", "diff"])
         .assert()
         .success()
         .stderr(predicate::str::contains("tree-sitter-diff-"));
 }
 
 #[test]
-fn cache_parsers_skips_plaintext_aliases() {
+fn cache_languages_skips_plaintext_aliases() {
     let tmp = tempfile::tempdir().unwrap();
 
     cmd()
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("-v")
-        .args(["parsers", "cache", "plaintext", "text", "txt", "plain"])
+        .args(["languages", "cache", "plaintext", "text", "txt", "plain"])
         .assert()
         .success()
         .stderr(predicate::str::contains("compiled 0 parser(s)"));
@@ -1291,7 +1297,7 @@ fn cache_parsers_skips_plaintext_aliases() {
 /// lumis.languages.cache` does the same, so the two cannot prepare different
 /// things.
 #[test]
-fn cache_parsers_compiles_what_it_downloads() {
+fn cache_languages_compiles_what_it_downloads() {
     // Building a runtime at all compiles Tree-sitter's own module, so a
     // non-empty cache proves nothing. Each additional parser adds an entry
     // beside it, and only compiling produces that.
@@ -1312,7 +1318,7 @@ fn cache_parsers_compiles_what_it_downloads() {
     cmd()
         .arg("--data-dir")
         .arg(one.path())
-        .args(["parsers", "cache", "json"])
+        .args(["languages", "cache", "json"])
         .assert()
         .success();
 
@@ -1320,7 +1326,7 @@ fn cache_parsers_compiles_what_it_downloads() {
     cmd()
         .arg("--data-dir")
         .arg(two.path())
-        .args(["parsers", "cache", "json", "css"])
+        .args(["languages", "cache", "json", "css"])
         .assert()
         .success();
 
@@ -1332,7 +1338,7 @@ fn cache_parsers_compiles_what_it_downloads() {
     );
 }
 
-/// A store directory holding the committed fixtures, so `parsers cache` can be
+/// A store directory holding the committed fixtures, so `languages cache` can be
 /// exercised without a download. Caching into an empty directory needs the
 /// network by construction; there is no second directory to copy from.
 fn seeded_store() -> tempfile::TempDir {
@@ -1349,12 +1355,12 @@ fn seeded_store() -> tempfile::TempDir {
 }
 
 #[test]
-fn cache_parsers_to_temp_dir() {
+fn cache_languages_to_temp_dir() {
     let tmp = seeded_store();
     cmd()
         .arg("--data-dir")
         .arg(tmp.path())
-        .args(["parsers", "cache", "json"])
+        .args(["languages", "cache", "json"])
         .assert()
         .success();
 
@@ -1369,13 +1375,13 @@ fn cache_parsers_to_temp_dir() {
 }
 
 #[test]
-fn cache_parsers_to_temp_dir_verbose() {
+fn cache_languages_to_temp_dir_verbose() {
     let tmp = seeded_store();
     cmd()
         .arg("-v")
         .arg("--data-dir")
         .arg(tmp.path())
-        .args(["parsers", "cache", "json"])
+        .args(["languages", "cache", "json"])
         .assert()
         .success()
         .stderr(predicate::str::contains("tree-sitter-json-"));
@@ -1390,14 +1396,14 @@ fn cache_parsers_to_temp_dir_verbose() {
 }
 
 #[test]
-fn cache_parsers_reuses_an_existing_file() {
+fn cache_languages_reuses_an_existing_file() {
     let tmp = seeded_store();
 
     // Cache once.
     cmd()
         .arg("--data-dir")
         .arg(tmp.path())
-        .args(["parsers", "cache", "json"])
+        .args(["languages", "cache", "json"])
         .assert()
         .success();
 
@@ -1406,21 +1412,21 @@ fn cache_parsers_reuses_an_existing_file() {
         .arg("-v")
         .arg("--data-dir")
         .arg(tmp.path())
-        .args(["parsers", "cache", "json"])
+        .args(["languages", "cache", "json"])
         .assert()
         .success()
         .stderr(predicate::str::contains("tree-sitter-json-"));
 }
 
 #[test]
-fn cache_parsers_then_highlight() {
+fn cache_languages_then_highlight() {
     let tmp = seeded_store();
 
     // Cache the parser first.
     cmd()
         .arg("--data-dir")
         .arg(tmp.path())
-        .args(["parsers", "cache", "json"])
+        .args(["languages", "cache", "json"])
         .assert()
         .success();
 
@@ -1437,7 +1443,7 @@ fn cache_parsers_then_highlight() {
 
 /// Highlighting an HTML document loads JavaScript for its `<script>` block
 /// during the same pass, from a data directory that has never held either
-/// parser. Before this, the block stayed plain until `parsers cache javascript`
+/// parser. Before this, the block stayed plain until `languages cache javascript`
 /// had been run.
 /// One pass: nothing names javascript, so the walk had to discover the `<script>`
 /// injection and load it mid-walk. Whether the parser was already on disk is a

--- a/crates/lumis-core/build.rs
+++ b/crates/lumis-core/build.rs
@@ -184,7 +184,7 @@ fn themes() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("theme_data.rs");
 
-    let theme_names: Vec<String> = fs::read_dir(&themes_dir)
+    let mut theme_names: Vec<String> = fs::read_dir(&themes_dir)
         .unwrap()
         .filter_map(|entry| {
             let entry = entry.ok()?;
@@ -196,6 +196,9 @@ fn themes() {
             }
         })
         .collect();
+
+    // `read_dir` yields filesystem order, which differs per machine.
+    theme_names.sort();
 
     let theme_constants = theme_names.iter().map(|name| {
         let constant_name = format_ident!("{}", name.to_uppercase());

--- a/crates/lumis-core/src/themes.rs
+++ b/crates/lumis-core/src/themes.rs
@@ -830,6 +830,26 @@ mod tests {
     }
 
     #[test]
+    fn available_themes_is_sorted_by_name() {
+        let names: Vec<&str> = available_themes()
+            .map(|theme| theme.name.as_str())
+            .collect();
+
+        assert!(
+            names.len() > 200,
+            "expected the full theme corpus, got {}",
+            names.len()
+        );
+
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            names, sorted,
+            "available_themes() must not depend on filesystem order"
+        );
+    }
+
+    #[test]
     fn test_load_all_themes() {
         for theme in ALL_THEMES.iter() {
             assert!(!theme.name.is_empty());

--- a/crates/lumis-wasm-runtime/src/store.rs
+++ b/crates/lumis-wasm-runtime/src/store.rs
@@ -304,7 +304,7 @@ impl LanguageStore {
 
     /// Download and cache `name` and its parser without loading either.
     ///
-    /// Caching is pure I/O, so it needs no Wasmtime runtime: `lumis parsers
+    /// Caching is pure I/O, so it needs no Wasmtime runtime: `lumis languages
     /// cache` and `mix lumis.languages.cache` both land here.
     ///
     /// # Errors
@@ -1260,7 +1260,7 @@ mod tests {
         );
     }
 
-    /// `lumis parsers cache` and `mix lumis.languages.cache` land here. A parser
+    /// `lumis languages cache` and `mix lumis.languages.cache` land here. A parser
     /// already in the store is left alone, so the command is idempotent and
     /// needs no network once the store holds what was asked for.
     #[test]

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -37,7 +37,7 @@ These flags work with any subcommand:
 | `lumis formatters show` | List the options one formatter accepts |
 | `lumis languages list` | List supported languages and file patterns |
 | `lumis languages show` | Print what the catalog knows about one language |
-| `lumis languages cache` | Download and verify parsers so later runs skip the download |
+| `lumis languages cache` | Download and compile parsers so later runs skip both |
 | `lumis themes list` | List built-in and local themes |
 | `lumis themes show` | Print one theme's appearance and colors |
 | `lumis themes generate` | Generate a theme from a Neovim colorscheme repo |

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -36,7 +36,9 @@ These flags work with any subcommand:
 | `lumis formatters list` | List output formatters |
 | `lumis formatters show` | List the options one formatter accepts |
 | `lumis languages list` | List supported languages and file patterns |
+| `lumis languages show` | Print what the catalog knows about one language |
 | `lumis themes list` | List built-in and local themes |
+| `lumis themes show` | Print one theme's appearance and colors |
 | `lumis themes generate` | Generate a theme from a Neovim colorscheme repo |
 | `lumis parsers cache` | Cache parser WASMs so later runs skip the download |
 
@@ -256,6 +258,17 @@ lumis languages list
 
 Prints all supported languages with their file extensions and patterns.
 
+## `lumis languages show`
+
+```bash
+lumis languages show elixir
+lumis languages show js
+```
+
+Prints one language's id, name, aliases, extensions, globs, Emacs modes and
+shebangs. Aliases resolve the way highlighting resolves them, so `js` finds
+JavaScript. Exits non-zero on an unknown name.
+
 ## `lumis themes list`
 
 ```bash
@@ -263,6 +276,16 @@ lumis themes list
 ```
 
 Lists built-in themes and any custom themes found in the data directory.
+
+## `lumis themes show`
+
+```bash
+lumis themes show dracula
+```
+
+Prints a theme's appearance, foreground, background and how many highlight
+scopes it defines. Finds themes in the data directory as well as built-in ones.
+Exits non-zero on an unknown name.
 
 ## `lumis themes generate`
 

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -3,12 +3,12 @@ sidebar_position: 1
 slug: /cli/commands
 title: CLI Commands
 description: >-
-  Highlight files, inspect Tree-sitter output, manage parsers, and generate
+  Highlight files, inspect Tree-sitter output, manage languages, and generate
   themes with the Lumis CLI.
 keywords:
   - lumis cli
   - themes generate
-  - parsers cache
+  - languages cache
   - highlight command
 ---
 
@@ -37,10 +37,10 @@ These flags work with any subcommand:
 | `lumis formatters show` | List the options one formatter accepts |
 | `lumis languages list` | List supported languages and file patterns |
 | `lumis languages show` | Print what the catalog knows about one language |
+| `lumis languages cache` | Download and verify parsers so later runs skip the download |
 | `lumis themes list` | List built-in and local themes |
 | `lumis themes show` | Print one theme's appearance and colors |
 | `lumis themes generate` | Generate a theme from a Neovim colorscheme repo |
-| `lumis parsers cache` | Cache parser WASMs so later runs skip the download |
 
 ## `lumis highlight`
 
@@ -269,6 +269,36 @@ Prints one language's id, name, aliases, extensions, globs, Emacs modes and
 shebangs. Aliases resolve the way highlighting resolves them, so `js` finds
 JavaScript. Exits non-zero on an unknown name.
 
+## `lumis languages cache`
+
+Download exact, integrity-checked parser WASM files ahead of time, and compile
+them. Highlighting does both anyway; this moves them off the first run.
+
+A cold parser costs a download and then a Wasmtime compile, and the compile is
+the larger half, so each parser is loaded once here and its compiled form is
+written beside it. `mix lumis.languages.cache` prepares the identical directory,
+and every runtime reads it: cache with the CLI, and Elixir or Node start warm.
+
+```bash title="Selected parsers"
+lumis languages cache rust javascript elixir
+```
+
+```bash title="A bundle"
+lumis languages cache bundle-web
+```
+
+The `bundle-*` names cover the same languages as the matching
+`@lumis-sh/wasm-bundle-*` package, and `Lumis.Languages.cache/2` and
+`lumis-languages-cache` accept them too.
+
+```bash title="All parsers"
+lumis languages cache --all
+```
+
+```bash title="Replace valid cached parsers"
+lumis languages cache rust javascript --force
+```
+
 ## `lumis themes list`
 
 ```bash
@@ -312,36 +342,6 @@ lumis themes generate \
   -c github_light \
   -a light \
   -o github-light.json
-```
-
-## `lumis parsers cache`
-
-Download exact, integrity-checked parser WASM files ahead of time, and compile
-them. Highlighting does both anyway; this moves them off the first run.
-
-A cold parser costs a download and then a Wasmtime compile, and the compile is
-the larger half, so each parser is loaded once here and its compiled form is
-written beside it. `mix lumis.languages.cache` prepares the identical directory,
-and every runtime reads it: cache with the CLI, and Elixir or Node start warm.
-
-```bash title="Selected parsers"
-lumis parsers cache rust javascript elixir
-```
-
-```bash title="A bundle"
-lumis parsers cache bundle-web
-```
-
-The `bundle-*` names cover the same languages as the matching
-`@lumis-sh/wasm-bundle-*` package, and `Lumis.Languages.cache/2` and
-`lumis-wasm-cache` accept them too.
-
-```bash title="All parsers"
-lumis parsers cache --all
-```
-
-```bash title="Replace valid cached parsers"
-lumis parsers cache rust javascript --force
 ```
 
 ## Configuration

--- a/docs/content/installation.mdx
+++ b/docs/content/installation.mdx
@@ -98,6 +98,6 @@ The installed binary is `lumis`. Rust users can also install from crates.io with
 ## Notes
 
 - Highlighting loads the parsers a document needs, including languages injected inside it, and caches the verified bytes. See [WASM and CDN](/advanced/wasm-and-cdn).
-- `Lumis.Languages.load/1` and `mix lumis.languages.cache` in Elixir, `lumis parsers cache` for the CLI, and `npx lumis-wasm-cache` for Node all move that download ahead of the first request.
+- `Lumis.Languages.load/1` and `mix lumis.languages.cache` in Elixir, `lumis languages cache` for the CLI, and `npx lumis-languages-cache` for Node all move that download ahead of the first request.
 - For local JavaScript parser assets from npm, install per-language packages such as `@lumis-sh/wasm-rust` or bundle packages such as `@lumis-sh/wasm-bundle-web`.
 - The CLI stores verified, content-addressed parsers and custom themes in a local data directory.

--- a/docs/content/recipes/cache-parsers-cli.mdx
+++ b/docs/content/recipes/cache-parsers-cli.mdx
@@ -8,5 +8,5 @@ description: Cache parser WASM files ahead of time for CLI use.
 # Cache parsers (CLI)
 
 ```bash
-lumis parsers cache rust javascript elixir
+lumis languages cache rust javascript elixir
 ```

--- a/docs/content/recipes/list-languages-and-themes.mdx
+++ b/docs/content/recipes/list-languages-and-themes.mdx
@@ -76,7 +76,10 @@ lumis themes list
 ## Look one up by name
 
 Aliases resolve the way highlighting resolves them, so `js` finds JavaScript.
-An unknown name comes back empty rather than raising.
+
+How an unknown name is reported follows each host's convention: JavaScript
+returns `undefined` and Elixir returns `nil`, both without raising, while Rust
+returns a `Result` and the CLI exits non-zero.
 
 <Tabs groupId="runtime" queryString="lang" defaultValue="javascript">
   <TabItem value="javascript" label="JavaScript">
@@ -169,6 +172,12 @@ Loading is global to the VM, so this is the same list in every process.
 
   </TabItem>
   <TabItem value="cli" label="CLI">
+
+There is nothing to list. Each invocation is a fresh process that loads what
+the document needs and exits, so nothing stays loaded between runs.
+
+What does persist is the parser cache on disk, which `lumis parsers cache`
+fills so later runs skip the download:
 
 ```bash
 lumis parsers cache rust javascript

--- a/docs/content/recipes/list-languages-and-themes.mdx
+++ b/docs/content/recipes/list-languages-and-themes.mdx
@@ -176,11 +176,11 @@ Loading is global to the VM, so this is the same list in every process.
 There is nothing to list. Each invocation is a fresh process that loads what
 the document needs and exits, so nothing stays loaded between runs.
 
-What does persist is the parser cache on disk, which `lumis parsers cache`
+What does persist is the parser cache on disk, which `lumis languages cache`
 fills so later runs skip the download:
 
 ```bash
-lumis parsers cache rust javascript
+lumis languages cache rust javascript
 ```
 
   </TabItem>

--- a/docs/content/recipes/list-languages-and-themes.mdx
+++ b/docs/content/recipes/list-languages-and-themes.mdx
@@ -17,7 +17,7 @@ Themes differ by what each runtime can return cheaply. Rust hands back the whole
 `Theme`, colours included, because they are already in the binary. Elixir and
 JavaScript return `name` and `appearance`, because sending every theme's
 highlights across the NIF or the wire would cost far more than the call is
-worth. Use `Theme.get` / `Lumis.Theme.get` to fetch one in full.
+worth. Reach for one in full with `themes::get` or `Lumis.Theme.get/2`.
 
 <Tabs groupId="runtime" queryString="lang" defaultValue="javascript">
   <TabItem value="javascript" label="JavaScript">
@@ -62,14 +62,116 @@ for theme <- Lumis.available_themes() do
 end
 ```
 
-`Lumis.available_theme_names/0` returns just the names.
-
   </TabItem>
   <TabItem value="cli" label="CLI">
 
 ```bash
 lumis languages list
 lumis themes list
+```
+
+  </TabItem>
+</Tabs>
+
+## Look one up by name
+
+Aliases resolve the way highlighting resolves them, so `js` finds JavaScript.
+An unknown name comes back empty rather than raising.
+
+<Tabs groupId="runtime" queryString="lang" defaultValue="javascript">
+  <TabItem value="javascript" label="JavaScript">
+
+```js
+import {getLanguage} from '@lumis-sh/lumis'
+
+getLanguage('js')    // { id: 'javascript', name: 'JavaScript', ... }
+getLanguage('nope')  // undefined
+```
+
+Themes are separate modules, so import the one you want:
+
+```js
+import dracula from '@lumis-sh/themes/dracula'
+```
+
+  </TabItem>
+  <TabItem value="rust" label="Rust">
+
+```rust
+use lumis::{languages::Language, themes};
+
+let language: Language = "js".parse()?;
+println!("{:?}", language.info().extensions);
+
+let theme = themes::get("dracula")?;
+println!("{} {}", theme.name, theme.appearance);
+```
+
+  </TabItem>
+  <TabItem value="elixir" label="Elixir">
+
+```elixir
+Lumis.Languages.get("js")
+# %{id: "javascript", name: "JavaScript", ...}
+
+Lumis.Languages.get("nope")
+# nil
+
+Lumis.Theme.get("dracula")
+# %Lumis.Theme{name: "dracula", appearance: "dark", ...}
+```
+
+  </TabItem>
+  <TabItem value="cli" label="CLI">
+
+```bash
+lumis languages show js
+lumis themes show dracula
+```
+
+  </TabItem>
+</Tabs>
+
+## What is loaded right now
+
+The catalog lists what Lumis knows about. This lists what can be highlighted
+without a download, which is a smaller set — highlighting loads what a document
+turns out to need.
+
+Themes have no equivalent: every theme is compiled in, so there is nothing to
+load and nothing that could be missing.
+
+<Tabs groupId="runtime" queryString="lang" defaultValue="javascript">
+  <TabItem value="javascript" label="JavaScript">
+
+```js
+import {loadedLanguages} from '@lumis-sh/lumis'
+
+loadedLanguages() // ['json', 'rust']
+```
+
+  </TabItem>
+  <TabItem value="rust" label="Rust">
+
+Languages are compiled in behind `lang-*` features, so everything in
+`available_languages()` is ready to use.
+
+  </TabItem>
+  <TabItem value="elixir" label="Elixir">
+
+```elixir
+Lumis.Languages.load("elixir")
+Lumis.loaded_languages()
+# ["elixir"]
+```
+
+Loading is global to the VM, so this is the same list in every process.
+
+  </TabItem>
+  <TabItem value="cli" label="CLI">
+
+```bash
+lumis parsers cache rust javascript
 ```
 
   </TabItem>

--- a/docs/content/usage/cli-behavior.mdx
+++ b/docs/content/usage/cli-behavior.mdx
@@ -91,18 +91,18 @@ package range, then loads the exact parser version and matching queries named
 there. Parser filenames contain the package version and SHA-256 digest.
 
 - first use of a language downloads its parser
-- `lumis parsers cache ...` persists selected parsers ahead of time, so no run
+- `lumis languages cache ...` persists selected parsers ahead of time, so no run
   pays for a download and the Wasmtime compile that follows it
-- `lumis parsers cache ... --force` resolves the package range again and
+- `lumis languages cache ... --force` resolves the package range again and
   replaces valid cached parsers
 
 ```bash
-lumis parsers cache rust javascript elixir
-lumis parsers cache rust --force
+lumis languages cache rust javascript elixir
+lumis languages cache rust --force
 ```
 
 Parsers you build or vendor yourself go in the same `parsers/` directory as
-downloaded ones; `lumis --data-dir <dir> parsers cache ...` writes that layout.
+downloaded ones; `lumis --data-dir <dir> languages cache ...` writes that layout.
 
 ## Data directory
 

--- a/docs/content/usage/cli-highlight.mdx
+++ b/docs/content/usage/cli-highlight.mdx
@@ -57,20 +57,20 @@ lumis highlight main.rs --formatter bbcode-scoped
 ## Parser availability
 
 Highlighting downloads a missing compatible language package and parser on
-demand. `lumis parsers cache` moves that download and compilation ahead of the
+demand. `lumis languages cache` moves that download and compilation ahead of the
 first highlight, storing exact-version parser WASM under content-addressed,
 integrity-checked names in the data directory.
 
 - a missing root language is downloaded or returns an error if it cannot be fetched
-- `lumis parsers cache ...` persists selected parsers, `--all` takes every one
-- `lumis parsers cache ... --force` resolves the compatible package range again
+- `lumis languages cache ...` persists selected parsers, `--all` takes every one
+- `lumis languages cache ... --force` resolves the compatible package range again
   and replaces valid cached parsers
 - a missing injected language is downloaded during the highlighting walk; if it
   cannot be fetched, only that block stays plain
 
 ```bash
-lumis parsers cache rust javascript elixir
-lumis parsers cache rust --force
+lumis languages cache rust javascript elixir
+lumis languages cache rust --force
 ```
 
 ## Related pages

--- a/docs/content/usage/elixir-integration.mdx
+++ b/docs/content/usage/elixir-integration.mdx
@@ -149,7 +149,7 @@ lives in the shared Rust store:
 | `config :lumis, :wasm_path` | one directory now: `config :lumis, data_dir:` |
 
 `mix lumis.languages.cache` takes language names, a `:bundle_*` name, or
-`--all` rather than reading configuration, matching `lumis parsers cache`.
+`--all` rather than reading configuration, matching `lumis languages cache`.
 
 ## Discover supported languages and themes
 

--- a/docs/content/usage/elixir-integration.mdx
+++ b/docs/content/usage/elixir-integration.mdx
@@ -156,10 +156,16 @@ lives in the shared Rust store:
 ```elixir
 Lumis.available_languages()
 Lumis.available_themes()
+Lumis.loaded_languages()
+
+Lumis.Languages.get("js")
 Lumis.Theme.get("github_light")
 ```
 
-See [`Lumis`](https://hexdocs.pm/lumis/Lumis.html) and [`Lumis.Theme`](https://hexdocs.pm/lumis/Lumis.Theme.html) on HexDocs.
+`Lumis.Languages.get/2` and `Lumis.Theme.get/2` look one up by name, returning
+`nil` (or a default you pass) when there is no such language or theme.
+
+See [`Lumis`](https://hexdocs.pm/lumis/Lumis.html), [`Lumis.Languages`](https://hexdocs.pm/lumis/Lumis.Languages.html) and [`Lumis.Theme`](https://hexdocs.pm/lumis/Lumis.Theme.html) on HexDocs.
 
 ## Phoenix and LiveView
 

--- a/docs/content/usage/javascript-runtime.mdx
+++ b/docs/content/usage/javascript-runtime.mdx
@@ -204,7 +204,7 @@ To keep the download and compile off a first request, populate a project or imag
 before the application starts:
 
 ```bash
-npx lumis-wasm-cache javascript html css --output ./wasm-cache
+npx lumis-languages-cache javascript html css --output ./wasm-cache
 LUMIS_DATA_DIR=./wasm-cache node app.mjs
 ```
 
@@ -222,7 +222,7 @@ Both accept `bundle-*` names as well, covering the same languages as the
 matching `@lumis-sh/wasm-bundle-*` package:
 
 ```bash
-npx lumis-wasm-cache bundle-web --output ./wasm-cache
+npx lumis-languages-cache bundle-web --output ./wasm-cache
 ```
 
 Both paths resolve the runtime's compatible package range, then cache the exact

--- a/docs/content/usage/javascript-runtime.mdx
+++ b/docs/content/usage/javascript-runtime.mdx
@@ -144,6 +144,8 @@ Useful when rendering user-provided content or pasted snippets.
 Useful for dropdowns, config validation, and docs tooling:
 
 - [`availableLanguages()`](https://github.com/leandrocp/lumis/blob/main/packages/javascript/lumis/src/index.ts)
+- [`getLanguage()`](https://github.com/leandrocp/lumis/blob/main/packages/javascript/lumis/src/index.ts) — one language by id or alias, or `undefined`
+- [`loadedLanguages()`](https://github.com/leandrocp/lumis/blob/main/packages/javascript/lumis/src/index.ts) — ids ready to highlight without a download
 - [`availableThemes()`](https://github.com/leandrocp/lumis/blob/main/packages/javascript/lumis/src/index.ts)
 - [`sanitizeThemeName()`](https://github.com/leandrocp/lumis/blob/main/packages/javascript/lumis/src/index.ts)
 

--- a/docs/content/usage/wasm-and-cdn.mdx
+++ b/docs/content/usage/wasm-and-cdn.mdx
@@ -78,7 +78,7 @@ and every process after it does not.
   <TabItem value="cli" label="CLI">
 
 ```bash
-lumis parsers cache rust javascript elixir
+lumis languages cache rust javascript elixir
 ```
 
   </TabItem>
@@ -90,7 +90,7 @@ lumis parsers cache rust javascript elixir
   <TabItem value="javascript" label="JavaScript">
 
 ```bash
-npx lumis-wasm-cache rust javascript elixir --output ./wasm-cache
+npx lumis-languages-cache rust javascript elixir --output ./wasm-cache
 LUMIS_DATA_DIR=./wasm-cache node app.mjs
 ```
 
@@ -105,7 +105,7 @@ mix lumis.languages.cache rust javascript elixir
   <TabItem value="cli" label="CLI">
 
 ```bash
-lumis parsers cache rust javascript elixir
+lumis languages cache rust javascript elixir
 ```
 
   </TabItem>
@@ -208,7 +208,7 @@ COPY --from=builder --chown=nobody:root /app/lumis /app/lumis
 ENV LUMIS_DATA_DIR=/app/lumis
 ```
 
-The CLI writes the same layout with `lumis --data-dir /app/lumis parsers cache`.
+The CLI writes the same layout with `lumis --data-dir /app/lumis languages cache`.
 There is one directory and one way to name it, so a directory written this way is
 self-sufficient: parser bytes plus the metadata naming them.
 
@@ -423,18 +423,18 @@ can read it, while the native walk cannot access JavaScript's blob registry.
   <TabItem value="cli" label="CLI">
 
 ```bash title="Cache parsers"
-lumis parsers cache rust javascript elixir
+lumis languages cache rust javascript elixir
 ```
 
 ```bash title="Cache all parsers"
-lumis parsers cache --all
+lumis languages cache --all
 ```
 
 ```bash title="Replace cached parsers"
-lumis parsers cache rust --force
+lumis languages cache rust --force
 ```
 
-The CLI does not expose a custom WASM resolver hook. Use `lumis parsers cache`
+The CLI does not expose a custom WASM resolver hook. Use `lumis languages cache`
 and `--data-dir` when you need local control over parser files.
 
   </TabItem>

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -753,8 +753,7 @@ defmodule Lumis do
   @doc """
   Returns every built-in theme's name and appearance, sorted by name.
 
-  Use `Lumis.Theme.get/1` to get the actual theme struct, or
-  `available_theme_names/0` for names alone.
+  Use `Lumis.Theme.get/2` to get the actual theme struct.
 
   ## Example
 
@@ -764,18 +763,6 @@ defmodule Lumis do
   """
   @spec available_themes() :: [theme_info()]
   def available_themes, do: Lumis.Native.available_themes()
-
-  @doc """
-  Returns the name of every built-in theme, sorted.
-
-  ## Example
-
-      iex> "dracula" in Lumis.available_theme_names()
-      true
-
-  """
-  @spec available_theme_names() :: [name :: String.t()]
-  def available_theme_names, do: Enum.sort(Lumis.Native.available_theme_names())
 
   @deprecated "Use highlight/2 instead"
   def highlight(language, source, options) do

--- a/packages/elixir/lumis/lib/lumis/languages.ex
+++ b/packages/elixir/lumis/lib/lumis/languages.ex
@@ -179,6 +179,33 @@ defmodule Lumis.Languages do
   end
 
   @doc """
+  Looks one language up by id or alias, or returns `default`.
+
+  The same record `Lumis.available_languages/0` returns one of, without scanning
+  the catalog, and resolving aliases the way highlighting does: `"js"` finds
+  JavaScript.
+
+      iex> Lumis.Languages.get("js").id
+      "javascript"
+
+      iex> Lumis.Languages.get("not-a-language")
+      nil
+
+  """
+  @spec get(String.t() | atom(), any()) :: Lumis.language_info() | any()
+  def get(name, default \\ nil)
+
+  def get(name, default) when is_atom(name) and not is_nil(name),
+    do: get(Atom.to_string(name), default)
+
+  def get(name, default) when is_binary(name) do
+    case Native.language_info(name) do
+      nil -> default
+      language -> language
+    end
+  end
+
+  @doc """
   The languages each `:bundle_*` name covers.
 
   These are the same sets the `@lumis-sh/wasm-bundle-*` packages ship, so naming

--- a/packages/elixir/lumis/lib/lumis/native.ex
+++ b/packages/elixir/lumis/lib/lumis/native.ex
@@ -59,8 +59,8 @@ defmodule Lumis.Native do
     force_build: System.get_env("LUMIS_BUILD") in ["1", "true"]
 
   def available_languages(), do: :erlang.nif_error(:nif_not_loaded)
+  def language_info(_name), do: :erlang.nif_error(:nif_not_loaded)
   def available_themes(), do: :erlang.nif_error(:nif_not_loaded)
-  def available_theme_names(), do: :erlang.nif_error(:nif_not_loaded)
   def get_theme(_name), do: :erlang.nif_error(:nif_not_loaded)
   def build_theme_from_file(_path), do: :erlang.nif_error(:nif_not_loaded)
   def build_theme_from_json_string(_json_string), do: :erlang.nif_error(:nif_not_loaded)

--- a/packages/elixir/lumis/native/lumis_nif/src/lib.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/lib.rs
@@ -17,14 +17,6 @@ use rustler::{Encoder, Env, Error, NifMap, NifResult, Term};
 static THEME_CACHE: Lazy<RwLock<HashMap<String, ExTheme>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
 
-/// Cached list of theme names to avoid repeated allocations.
-/// Built once on first call to available_themes().
-static THEME_NAMES: Lazy<Vec<String>> = Lazy::new(|| {
-    themes::available_themes()
-        .map(|theme| theme.name.to_owned())
-        .collect()
-});
-
 static EXECUTOR: Lazy<Result<WasmExecutor, String>> = Lazy::new(WasmExecutor::new);
 
 enum WasmJob {
@@ -426,6 +418,13 @@ fn available_languages() -> Vec<ExLanguageInfo<'static>> {
 }
 
 #[rustler::nif]
+fn language_info(name: &str) -> Option<ExLanguageInfo<'static>> {
+    name.parse::<languages::Language>()
+        .ok()
+        .map(|language| ExLanguageInfo::from(language.info()))
+}
+
+#[rustler::nif]
 fn available_themes() -> Vec<ExThemeInfo<'static>> {
     // Rust's `available_themes` yields whole themes, which carry more than the
     // wire needs; the summary is built here rather than shipping 246 of them.
@@ -433,13 +432,6 @@ fn available_themes() -> Vec<ExThemeInfo<'static>> {
         themes::available_themes().map(ExThemeInfo::from).collect();
     summaries.sort_unstable_by_key(|theme| theme.name);
     summaries
-}
-
-#[rustler::nif]
-fn available_theme_names() -> Vec<String> {
-    // Return a clone of the cached theme names list
-    // This is cheaper than rebuilding the list every time
-    THEME_NAMES.clone()
 }
 
 #[rustler::nif]

--- a/packages/elixir/lumis/test/lumis/languages_test.exs
+++ b/packages/elixir/lumis/test/lumis/languages_test.exs
@@ -53,6 +53,40 @@ defmodule Lumis.LanguagesTest do
     assert length(names) > 100
   end
 
+  describe "get/2" do
+    test "finds a language by id" do
+      assert %{id: "elixir", name: "Elixir"} = Lumis.Languages.get("elixir")
+    end
+
+    test "resolves aliases the way highlighting does" do
+      assert Lumis.Languages.get("js").id == "javascript"
+      assert Lumis.Languages.get(:js).id == "javascript"
+    end
+
+    test "returns the same record available_languages/0 yields" do
+      from_list = Enum.find(Lumis.available_languages(), &(&1.id == "rust"))
+      assert Lumis.Languages.get("rust") == from_list
+    end
+
+    test "returns every alias in the catalog" do
+      for language <- Lumis.available_languages(), alias_name <- language.aliases do
+        assert Lumis.Languages.get(alias_name).id == language.id,
+               "alias #{alias_name} did not resolve to #{language.id}"
+      end
+    end
+
+    test "returns nil or the given default for an unknown name" do
+      assert Lumis.Languages.get("not-a-language") == nil
+      assert Lumis.Languages.get("not-a-language", :missing) == :missing
+    end
+
+    test "does not grow the atom table on unknown names" do
+      before = :erlang.system_info(:atom_count)
+      for index <- 1..50, do: Lumis.Languages.get("unknown-language-#{index}")
+      assert :erlang.system_info(:atom_count) == before
+    end
+  end
+
   describe "guess/2" do
     test "matches the shared language detection cases" do
       cases =

--- a/packages/elixir/lumis/test/lumis_test.exs
+++ b/packages/elixir/lumis/test/lumis_test.exs
@@ -148,14 +148,6 @@ defmodule Lumis.LumisTest do
     assert %{name: "dracula", appearance: "dark"} in themes
   end
 
-  test "available_theme_names" do
-    names = Lumis.available_theme_names()
-
-    assert names == Enum.sort(names)
-    assert "dracula" in names
-    assert length(names) == length(Lumis.available_themes())
-  end
-
   describe "Theme.build_css" do
     test "builds default linked CSS from a theme name" do
       assert {:ok, css} = Lumis.Theme.build_css("github_light")

--- a/packages/elixir/lumis/usage-rules.md
+++ b/packages/elixir/lumis/usage-rules.md
@@ -85,6 +85,12 @@ languages = Lumis.available_languages()
 # Check if a language is supported
 Enum.any?(Lumis.available_languages(), &(&1.id == "elixir"))
 
+# Look one up by id or alias, without scanning the catalog
+Lumis.Languages.get("js")
+# Returns: %{id: "javascript", name: "JavaScript", ...}
+Lumis.Languages.get("not-a-language")
+# Returns: nil
+
 # Or resolve a name, path or source the way highlighting does
 "elixir" = Lumis.Languages.guess("lib/app.ex")
 ```
@@ -328,7 +334,7 @@ themes = Lumis.available_themes()
 # Returns: [%{name: "dracula", appearance: "dark"}, ...]
 
 # Or just the names
-names = Lumis.available_theme_names()
+names = Enum.map(Lumis.available_themes(), & &1.name)
 # Returns: ["adwaita_dark", "adwaita_light", ...]
 
 # Use a theme by name
@@ -694,6 +700,12 @@ html = Lumis.highlight!(source, opts)
 
 # Get all available languages
 [%{id: _} | _] = Lumis.available_languages()
+
+# Get one language by id or alias
+%{id: "javascript"} = Lumis.Languages.get("js")
+
+# Get the ids loaded into this VM
+[_ | _] = Lumis.loaded_languages()
 
 # Get all available themes
 [%{name: _, appearance: _} | _] = Lumis.available_themes()

--- a/packages/javascript/lumis/README.md
+++ b/packages/javascript/lumis/README.md
@@ -61,7 +61,7 @@ injected languages up front or use a bundle.
 For a host with no network access, prepare a cache before starting:
 
 ```sh
-npx lumis-wasm-cache javascript html css --output ./wasm-cache
+npx lumis-languages-cache javascript html css --output ./wasm-cache
 LUMIS_DATA_DIR=./wasm-cache node app.mjs
 ```
 

--- a/packages/javascript/lumis/package.json
+++ b/packages/javascript/lumis/package.json
@@ -81,7 +81,7 @@
     "CHANGELOG.md"
   ],
   "bin": {
-    "lumis-wasm-cache": "./dist/cache-cli.js"
+    "lumis-languages-cache": "./dist/cache-cli.js"
   },
   "packageManager": "pnpm@11.15.1",
   "scripts": {

--- a/packages/javascript/lumis/src/cache-cli.ts
+++ b/packages/javascript/lumis/src/cache-cli.ts
@@ -5,12 +5,12 @@ import { availableLanguages } from "./runtime/node.js";
 
 function usage(): never {
   console.error(
-    "Usage: lumis-wasm-cache <language|bundle-name...> [--output <directory>] [--force]\n" +
-      "       lumis-wasm-cache --all [--output <directory>] [--force]\n" +
+    "Usage: lumis-languages-cache <language|bundle-name...> [--output <directory>] [--force]\n" +
+      "       lumis-languages-cache --all [--output <directory>] [--force]\n" +
       "\n" +
       "Examples:\n" +
-      "  lumis-wasm-cache rust javascript\n" +
-      "  lumis-wasm-cache bundle-web",
+      "  lumis-languages-cache rust javascript\n" +
+      "  lumis-languages-cache bundle-web",
   );
   process.exit(2);
 }

--- a/packages/javascript/lumis/src/cache.ts
+++ b/packages/javascript/lumis/src/cache.ts
@@ -182,7 +182,7 @@ async function writeSharedLanguagePackage(
  * Resolve compatible packages and cache exact, integrity-pinned parser WASMs.
  *
  * Accepts language names and `bundle-<name>` tokens, the same set
- * `Lumis.Languages.cache/2` and `lumis parsers cache` accept.
+ * `Lumis.Languages.cache/2` and `lumis languages cache` accept.
  *
  * Point `LUMIS_DATA_DIR` at the same directory in the deployed process.
  */

--- a/packages/javascript/lumis/src/catalog-metadata.ts
+++ b/packages/javascript/lumis/src/catalog-metadata.ts
@@ -1,4 +1,28 @@
+import { LANGUAGES } from "./generated/languages-meta.js";
 import type { LanguageInfo, ThemeInfo } from "./types.js";
+
+export function normalizeLanguageName(value: string): string {
+  return value.replace(/[A-Z]/g, (character) => character.toLowerCase());
+}
+
+/**
+ * Look one language up by id or alias.
+ *
+ * ```ts
+ * import { getLanguage } from '@lumis-sh/lumis'
+ * getLanguage('js')    // { id: 'javascript', name: 'JavaScript', ... }
+ * getLanguage('nope')  // undefined
+ * ```
+ */
+export function getLanguage(nameOrAlias: string): LanguageInfo | undefined {
+  const normalized = normalizeLanguageName(nameOrAlias.trim());
+  const language = LANGUAGES.find(
+    ({ id, aliases }) =>
+      normalizeLanguageName(id) === normalized ||
+      aliases.some((alias) => normalizeLanguageName(alias) === normalized),
+  );
+  return language && cloneLanguageInfo(language);
+}
 
 export function cloneLanguageInfo(language: LanguageInfo): LanguageInfo {
   return {

--- a/packages/javascript/lumis/src/core/languages.ts
+++ b/packages/javascript/lumis/src/core/languages.ts
@@ -3,7 +3,7 @@ import satisfies from "semver/functions/satisfies.js";
 import minVersion from "semver/ranges/min-version.js";
 import { buildHighlightEvents } from "../events.js";
 import { LANGUAGES } from "../generated/languages-meta.js";
-import { cloneLanguageInfo } from "../catalog-metadata.js";
+import { cloneLanguageInfo, normalizeLanguageName } from "../catalog-metadata.js";
 import { LANGUAGE_PACKAGE_VERSION_RANGE } from "../generated/package-version-range.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { HIGHLIGHT_NAMES } from "../highlights.js";
@@ -458,9 +458,7 @@ function isValidPackageName(value: string): boolean {
   return segments.every((segment) => /^[a-z0-9][a-z0-9._-]*$/.test(segment));
 }
 
-export function normalizeLanguageName(value: string): string {
-  return value.replace(/[A-Z]/g, (character) => character.toLowerCase());
-}
+export { normalizeLanguageName };
 
 function isSafePackagePathSegment(value: string): boolean {
   const stem = value.split(".", 1)[0]!.replace(/[ .]+$/, "");

--- a/packages/javascript/lumis/src/index.browser.ts
+++ b/packages/javascript/lumis/src/index.browser.ts
@@ -8,6 +8,7 @@ import {
   configureWasmResolver,
   createRuntime,
   getDefaultRuntime,
+  loadedLanguages,
 } from "./runtime/browser.js";
 
 export { runtimeKind } from "./runtime/browser.js";
@@ -77,6 +78,12 @@ export type {
   LanguageInfo,
   ThemeInfo,
 } from "./types.js";
-export { availableLanguages, configureLanguagePackageResolver, configureWasmResolver };
+export {
+  availableLanguages,
+  configureLanguagePackageResolver,
+  configureWasmResolver,
+  loadedLanguages,
+};
+export { getLanguage } from "./catalog-metadata.js";
 export type { LanguagePackageResolver, WasmResolver } from "./core/languages.js";
 export { availableThemes, sanitizeThemeName } from "./themes.js";

--- a/packages/javascript/lumis/src/index.ts
+++ b/packages/javascript/lumis/src/index.ts
@@ -8,6 +8,7 @@ import {
   configureWasmResolver,
   createRuntime,
   getDefaultRuntime,
+  loadedLanguages,
 } from "./runtime/node.js";
 
 export { runtimeKind } from "./runtime/node.js";
@@ -137,6 +138,12 @@ export type {
   LanguageInfo,
   ThemeInfo,
 } from "./types.js";
-export { availableLanguages, configureLanguagePackageResolver, configureWasmResolver };
+export {
+  availableLanguages,
+  configureLanguagePackageResolver,
+  configureWasmResolver,
+  loadedLanguages,
+};
+export { getLanguage } from "./catalog-metadata.js";
 export type { LanguagePackageResolver, WasmResolver } from "./core/languages.js";
 export { availableThemes, sanitizeThemeName } from "./themes.js";

--- a/packages/javascript/lumis/src/runtime/browser.ts
+++ b/packages/javascript/lumis/src/runtime/browser.ts
@@ -218,6 +218,10 @@ export function getLoadedLanguage(...args: Parameters<typeof runtime.getLoadedLa
 export function getLoadedLanguageIds(...args: Parameters<typeof runtime.getLoadedLanguageIds>) {
   return runtime.getLoadedLanguageIds(...args);
 }
+/** {@inheritDoc node.loadedLanguages} */
+export function loadedLanguages(): string[] {
+  return runtime.getLoadedLanguageIds();
+}
 /** {@inheritDoc node.availableLanguages} */
 export function availableLanguages(...args: Parameters<typeof runtime.availableLanguages>) {
   return runtime.availableLanguages(...args);

--- a/packages/javascript/lumis/src/runtime/node.ts
+++ b/packages/javascript/lumis/src/runtime/node.ts
@@ -191,6 +191,19 @@ export function getLoadedLanguageIds(...args: Parameters<LanguagesModule["getLoa
   return runtime.getLoadedLanguageIds(...args);
 }
 /**
+ * Ids of the languages loaded into this process, ready to highlight without a download.
+ *
+ * The complement of {@link availableLanguages}. Elixir spells it `Lumis.loaded_languages/0`.
+ *
+ * ```ts
+ * import { loadedLanguages } from '@lumis-sh/lumis'
+ * loadedLanguages()  // ['json', 'rust']
+ * ```
+ */
+export function loadedLanguages(): string[] {
+  return runtime.getLoadedLanguageIds();
+}
+/**
  * List all supported languages with their ID, name, aliases, and file extensions.
  *
  * ```ts

--- a/packages/javascript/lumis/test/languages.test.ts
+++ b/packages/javascript/lumis/test/languages.test.ts
@@ -89,6 +89,15 @@ describe("getLoadedLanguageIds", () => {
 });
 
 describe("loadedLanguages", () => {
+  // Loaded here rather than inherited from an earlier test, so this block still
+  // passes when run on its own.
+  beforeAll(async () => {
+    await loadLanguage({
+      definition: { id: json.id, aliases: json.aliases },
+      packageName: json.packageName,
+    });
+  });
+
   it("is reachable from the package entry point", async () => {
     const { loadedLanguages } = await import("../src/index.js");
 

--- a/packages/javascript/lumis/test/languages.test.ts
+++ b/packages/javascript/lumis/test/languages.test.ts
@@ -88,6 +88,21 @@ describe("getLoadedLanguageIds", () => {
   });
 });
 
+describe("loadedLanguages", () => {
+  it("is reachable from the package entry point", async () => {
+    const { loadedLanguages } = await import("../src/index.js");
+
+    expect(loadedLanguages()).toEqual(getLoadedLanguageIds());
+    expect(loadedLanguages()).toContain("json");
+  });
+
+  it("lists what is loaded, not the whole catalog", async () => {
+    const { loadedLanguages, availableLanguages } = await import("../src/index.js");
+
+    expect(loadedLanguages().length).toBeLessThan(availableLanguages().length);
+  });
+});
+
 describe("loadPlaintext", () => {
   it("does not load a parser for plaintext", async () => {
     await loadPlaintext();

--- a/packages/javascript/lumis/test/metadata.test.ts
+++ b/packages/javascript/lumis/test/metadata.test.ts
@@ -1,7 +1,42 @@
 import { describe, it, expect } from "vitest";
 import { readdirSync } from "node:fs";
 import { resolve } from "node:path";
-import { availableLanguages, availableThemes } from "../src/index.js";
+import { availableLanguages, availableThemes, getLanguage } from "../src/index.js";
+
+describe("getLanguage", () => {
+  it("finds a language by id", () => {
+    expect(getLanguage("javascript")?.name).toBe("JavaScript");
+  });
+
+  it("finds a language by alias", () => {
+    expect(getLanguage("js")?.id).toBe("javascript");
+    expect(getLanguage("JS")?.id).toBe("javascript");
+    expect(getLanguage("  js  ")?.id).toBe("javascript");
+  });
+
+  it("returns undefined for an unknown name", () => {
+    expect(getLanguage("not-a-language")).toBeUndefined();
+  });
+
+  it("returns the same record availableLanguages yields", () => {
+    const fromList = availableLanguages().find((language) => language.id === "rust");
+    expect(getLanguage("rust")).toEqual(fromList);
+  });
+
+  it("returns a fresh record the caller can mutate", () => {
+    const first = getLanguage("rust")!;
+    first.aliases.push("mutated");
+    expect(getLanguage("rust")!.aliases).not.toContain("mutated");
+  });
+
+  it("resolves every alias in the catalog", () => {
+    for (const language of availableLanguages()) {
+      for (const alias of language.aliases) {
+        expect(getLanguage(alias)?.id, `alias ${alias}`).toBe(language.id);
+      }
+    }
+  });
+});
 
 describe("availableLanguages", () => {
   it("returns a non-empty array", () => {


### PR DESCRIPTION
Gives every runtime one vocabulary for the language and theme catalog: adds the
lookup only Rust had, closes a JavaScript function that was written, tested and
unreachable, fixes a theme-ordering bug in the reference implementation, and
renames the one CLI command that was named after the wrong noun.

**One breaking change**, the CLI rename below. Everything else touches surface
that has never been released, so nothing else needs a deprecation and none is
added.

## Breaking: `lumis parsers cache` is now `lumis languages cache`

One operation had three names, and `docs/content/installation.mdx` said all
three in a single sentence:

> `Lumis.Languages.load/1` and `mix lumis.languages.cache` in Elixir,
> `lumis parsers cache` for the CLI, and `npx lumis-wasm-cache` for Node

The CLI's was not merely different, it named the wrong noun. `lumis parsers
cache rust javascript` takes **language** names, resolves **language** aliases
through `resolve_language_id`, and accepts `bundle-web`, which is a language
set. It was addressed by the concept and named after one artifact inside it.
Under `languages` it also sits beside `languages list` and `languages show`,
where someone looking for it would start.

`lumis-wasm-cache` becomes `lumis-languages-cache` on the same reasoning,
taking noun-then-verb from `lumis languages cache` and `mix
lumis.languages.cache`. Neither keeps an alias, by decision.
`cacheLanguages()` and `Lumis.Languages.cache/2` were already right and are
untouched.

"Parser" stays where it names the artifact rather than the concept:
`--data-dir`'s help, the `parsers/` directory on disk, `compiled N parser(s)`,
and the recipe about what lands on disk.

This is the only published surface the PR breaks — `cargo-lumis-cli/v0.4.2` is
tagged. The CLI already has a `feat(cli)!` queued from #1267, so it rides the
same major.

## The bug

`themes::available_themes()` returned themes in **filesystem order**.
`crates/lumis-core/build.rs` collected names from `fs::read_dir` and never
sorted, so a build here produced:

```
vec![&MIDNIGHT, &MFD_LUMON, &KANAGAWA_PAPER_LIGHT, &OLDWORLD, ...]
```

Every other runtime sorted around it — the CLI in `list_themes`, the NIF in
`available_themes`, the JavaScript generator in `build-langs.ts` — and
`available_languages()` in the same crate sorts. The reference implementation
was the only unordered one, and the order varied per machine.

Same defect class as D2, which #1266 fixed in `html_multi_themes` CSS variable
order. Nothing pinned it: the existing test asserted membership only. The new
test asserts the whole 246-theme corpus is sorted, and was shown to fail
against a reversed list before being kept.

## What each runtime gained

**JavaScript** — `loadedLanguages()`, now reachable. `getLoadedLanguageIds()`
was exported from `src/runtime/node.ts` and `src/runtime/browser.ts`, and
`package.json` publishes no `./runtime/*` subpath, so no consumer could call
it; `test/languages.test.ts` imported it by relative path, which proved the
function works and nothing about whether it was callable. Elixir has had
`Lumis.loaded_languages/0` all along.

Also `getLanguage(id)` — the same record `availableLanguages()` yields one of,
resolving aliases so `js` finds JavaScript, which
`availableLanguages().find(l => l.id === id)` cannot do. Returns `undefined`
for an unknown name and a fresh record the caller may mutate.

**Elixir** — `Lumis.Languages.get/2`, over a new `language_info` NIF that calls
`Language::from_str`, so alias matching stays in Rust rather than becoming a
second copy in Elixir.

**CLI** — `lumis languages show <name>` and `lumis themes show <name>`,
following the `formatters show` that #1267 added. Non-zero exit on an unknown
name; `themes show` finds data-directory themes too.

**Rust** — nothing new. `themes::get` and `"js".parse::<Language>()` already
answer both questions.

## Why the names differ per runtime

The original plan was `fetch_language` / `fetch_theme` everywhere. That does
not survive contact with the host languages, and forcing it would make three of
four unidiomatic:

- **Elixir** ships `Map.get` *and* `Map.fetch`, so the split is real there. But
  `fetch` exists to tell *key absent* from *key holding `nil`*, and a
  `language_info()` is never `nil`. It also composes worse: `theme:` accepts
  `nil` as "no theme", so `Theme.get/2` already flows straight into a
  formatter, and a tuple would be unwrapped back to `nil` at the call site.
  `get` it is, and `Lumis.Theme.get/2` is untouched.
- **Rust** ships `HashMap::get` and no `try_get`. `fetch` there names the
  atomic read-modify-writes (`fetch_add`, `fetch_update`) and, outside std,
  I/O. `themes::get` reads a `LazyLock` static already in the binary.
- **JavaScript** ships `Map.get` and no Result type. `fetch` means HTTP.
- The Rust API Guidelines do not settle it — C-GETTER only covers `get_`
  prefixes on field accessors, and the naming page says nothing about `Option`
  versus `Result`. The convention is std's.

So the *concept* is shared and the spelling is per host, which is the rule
`API_DRIFT.md` already applies to `Language::guess` /
`Lumis.Languages.guess/2` / `guessLanguage()`.

## Removed rather than deprecated

`Lumis.available_theme_names/0`. It was added by #1266 as the migration path
off the old `available_themes/0` and **has not been released** — latest tags
are `cargo-lumis-core/v2.3.0` and `hex-lumis/v0.6.3`, both of which predate it.
Nothing can depend on it, so a deprecation cycle would carry a redundant name
forever for no one. `Lumis.available_themes() |> Enum.map(& &1.name)` replaces
it.

## Deliberately not done

Three things an earlier draft wanted, dropped once the release state was
checked: `themes::get` from `Result` to `Option` and `available_themes()`
returning a summary record are both **published in 2.3.0**, so they break real
callers to buy a verb and a shape. `languages::get` in Rust is
`"js".parse::<Language>().ok()` under another name.

Worth being explicit about the contrast with the CLI rename above, which breaks
published surface too: that one fixes a command addressed by one noun and named
after another, so the name was telling users something untrue. These three
would rename functions that already say what they do. Published-ness raises the
bar; it does not settle it.

Also skipped: renaming `hl.languages`, a name-driven theme lookup in
JavaScript (`import dracula from '@lumis-sh/themes/dracula'` already works
statically), and a shared catalog manifest — the surface it would protect
barely moves after the above.

Four differences are accepted rather than removed, and belong in `API_DRIFT.md`:
per-host lookup spelling, Rust's `available_themes()` returning whole themes
(D19, reaffirmed), no `loaded_themes` because themes are compiled in, and
JavaScript's theme lookup being async for packaging reasons rather than idiom.

## Tests

The two CLI list formats are **pinned first**. Their tests asserted only that
certain names appeared, so the layout and ordering could have changed unnoticed
— which is what made adding a sibling command risky rather than routine.

New: the theme sort guard (proven red against a reversed list), 6 `getLanguage`
cases including one that resolves *every* alias in the catalog, 2
`loadedLanguages` cases importing from the package entry rather than a relative
path, 6 Elixir `get/2` cases including an atom-table check, and 9 CLI cases
covering both `show` commands and both pinned list formats.

## Verification

- `mise run lint` — clean
- `mise run test` — Rust workspace 210 + others, JavaScript 607 on both
  runtimes, Elixir 158, plus cli/markdown-it/react/rehype
- `mise run test-conformance` — Rust 174, CLI 145, JS native 145, JS wasm 145,
  **browser 12 across Chromium/Firefox/WebKit**, Elixir 145

`languages_help_uses_cache_terminology` (was `parsers_help_...`) now clears
`LUMIS_DATA_DIR` and `LUMIS_CONFIG` first. clap prints each env-backed option's
current value, so the assertion that help contains no "fetch" was matching the
*path* rather than the wording — it failed on any checkout under a directory
named like this branch's worktree, and passed everywhere else for luck.

