### PR TITLE
feat(elixir): mirror precompiled NIFs to Cloudflare R2

### DIFF
--- a/.github/workflows/elixir-release.yml
+++ b/.github/workflows/elixir-release.yml
@@ -27,6 +27,12 @@ jobs:
       project-name: lumis_nif
       project-dir: packages/elixir/lumis/native/lumis_nif
       working-directory: packages/elixir/lumis
+      r2-path: releases/download/${{ inputs.tag || github.ref_name }}
+    secrets:
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
 
   hex-publish:
     name: Publish to Hex

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,8 @@ none of these. They exist to override that default from the outside.
 
 Most of them matter only while working on the repository. The exceptions are
 `LUMIS_DATA_DIR`, which every runtime reads, and the tool-specific settings a
-user can hit without cloning anything: `LUMIS_CONFIG` for the CLI, `LUMIS_BUILD`
-and `LUMIS_USE_LEGACY_ARTIFACTS` for the Hex package, and
+user can hit without cloning anything: `LUMIS_CONFIG` for the CLI, `LUMIS_BUILD`,
+`LUMIS_USE_LEGACY_ARTIFACTS` and `LUMIS_ARTIFACT_SOURCE` for the Hex package, and
 `LUMIS_CLI_SKIP_DOWNLOAD` for the npm CLI.
 
 `LUMIS_DATA_DIR` names the directory Lumis persists parsers, themes, and
@@ -154,6 +154,7 @@ drift.
 | `LUMIS_CONFIG` | CLI | Config file path, same as `--config` |
 | `LUMIS_BUILD` | Elixir | Build the NIF from source instead of downloading a precompiled one |
 | `LUMIS_USE_LEGACY_ARTIFACTS` | Elixir | Select the legacy-CPU NIF variant |
+| `LUMIS_ARTIFACT_SOURCE` | Elixir | `github` or `cloudflare`; where to download the precompiled NIF from |
 | `LUMIS_CLI_SKIP_DOWNLOAD` | `@lumis-sh/cli` install | Skip the postinstall binary download |
 | `LUMIS_TEST_RUNTIME` | JavaScript tests | `native` or `wasm`; fails loudly if the requested runtime is unavailable |
 | `LUMIS_QUERY_LANGUAGES` | `test:queries` | Comma-separated languages, so CI can shard parser builds |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -174,6 +174,16 @@ Publish `hex-lumis` after the required `cargo-lumis-wasm-runtime` release.
 Refresh and commit `packages/elixir/lumis/native/lumis_nif/Cargo.lock` against
 that published runtime before creating the Hex tag.
 
+`elixir-release.yml` uploads the precompiled NIFs to a GitHub Release and syncs
+the same files to Cloudflare R2 under `releases/download/<tag>`, served from
+`https://artifacts.lumis.sh`. The R2 step fails the release if any of
+`R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` or `R2_BUCKET` is
+missing, so the mirror cannot silently fall behind the GitHub Release.
+
+Checksums are generated from GitHub, which `Lumis.Native.ArtifactURL` defaults
+to. Changing that default would put checksum generation behind the R2 sync, so
+leave it alone unless the ordering in the workflow changes too.
+
 ## Failed releases
 
 If a release fails before any registry accepts the new version:

--- a/docs/content/usage/elixir-integration.mdx
+++ b/docs/content/usage/elixir-integration.mdx
@@ -151,6 +151,31 @@ lives in the shared Rust store:
 `mix lumis.languages.cache` takes language names, a `:bundle_*` name, or
 `--all` rather than reading configuration, matching `lumis languages cache`.
 
+## Where the precompiled NIF comes from
+
+The NIF ships precompiled, and it is downloaded once while the `lumis` dependency
+compiles. GitHub Releases serves it by default. The same artifacts are mirrored
+to Cloudflare R2, which you can opt into when GitHub is unreachable:
+
+```elixir title="config/config.exs"
+config :lumis, artifact_source: :cloudflare
+```
+
+`LUMIS_ARTIFACT_SOURCE=cloudflare` does the same thing, and is easier to reach
+inside a Dockerfile or a CI job than a config file that has already been baked
+into an image. Configuration wins when both are set. Valid values are `:github`
+and `:cloudflare`.
+
+This is a switch, not a fallback. The source you choose is the only one tried, so
+a failed download does not reach for the other one. Both serve byte-identical
+files, and either way the download is checked against the SHA-256 in
+`checksum-Elixir.Lumis.Native.exs` from the Hex package before it is used, so the
+mirror cannot hand you a different NIF.
+
+Two other escape hatches sit alongside it: `LUMIS_BUILD=1` builds the NIF from
+source instead of downloading anything, and `LUMIS_USE_LEGACY_ARTIFACTS=1` takes
+the legacy-CPU variant on a machine without the newer instruction sets.
+
 ## Discover supported languages and themes
 
 ```elixir

--- a/packages/elixir/lumis/README.md
+++ b/packages/elixir/lumis/README.md
@@ -88,7 +88,7 @@ without the newer instruction sets.
 
 It downloads from GitHub Releases, mirrored to Cloudflare R2. Set
 `config :lumis, artifact_source: :cloudflare` or `LUMIS_ARTIFACT_SOURCE=cloudflare`
-to use the mirror when GitHub is unreachable — see
+to use the mirror when GitHub is down, see
 [where the precompiled NIF comes from](https://lumis.sh/docs/usage/elixir-integration#where-the-precompiled-nif-comes-from).
 
 ## Documentation

--- a/packages/elixir/lumis/README.md
+++ b/packages/elixir/lumis/README.md
@@ -86,6 +86,11 @@ The NIF is precompiled. Set `LUMIS_BUILD=1` to build it from source instead, or
 `LUMIS_USE_LEGACY_ARTIFACTS=1` to take the legacy-CPU variant on a machine
 without the newer instruction sets.
 
+It downloads from GitHub Releases, mirrored to Cloudflare R2. Set
+`config :lumis, artifact_source: :cloudflare` or `LUMIS_ARTIFACT_SOURCE=cloudflare`
+to use the mirror when GitHub is unreachable — see
+[where the precompiled NIF comes from](https://lumis.sh/docs/usage/elixir-integration#where-the-precompiled-nif-comes-from).
+
 ## Documentation
 
 - [Elixir integration](https://lumis.sh/docs/usage/elixir-integration) — configuration, releases, Phoenix

--- a/packages/elixir/lumis/lib/lumis/native.ex
+++ b/packages/elixir/lumis/lib/lumis/native.ex
@@ -5,7 +5,6 @@ defmodule Lumis.Native do
 
   mix_config = Mix.Project.config()
   version = mix_config[:version]
-  github_url = mix_config[:package][:links][:GitHub]
   mode = if Mix.env() in [:dev, :test], do: :debug, else: :release
 
   use_legacy =
@@ -33,7 +32,7 @@ defmodule Lumis.Native do
     otp_app: :lumis,
     crate: "lumis_nif",
     version: version,
-    base_url: "#{github_url}/releases/download/hex-lumis/v#{version}",
+    base_url: {Lumis.Native.ArtifactURL, :url},
     targets: ~w(
       aarch64-apple-darwin
       aarch64-unknown-linux-gnu

--- a/packages/elixir/lumis/lib/lumis/native/artifact_url.ex
+++ b/packages/elixir/lumis/lib/lumis/native/artifact_url.ex
@@ -1,0 +1,33 @@
+defmodule Lumis.Native.ArtifactURL do
+  @moduledoc false
+
+  mix_config = Mix.Project.config()
+  version = mix_config[:version]
+  github_url = mix_config[:package][:links][:GitHub]
+
+  @base_urls %{
+    github: "#{github_url}/releases/download/hex-lumis/v#{version}",
+    cloudflare: "https://artifacts.lumis.sh/releases/download/hex-lumis/v#{version}"
+  }
+
+  @sources Map.keys(@base_urls)
+
+  env_source =
+    case System.get_env("LUMIS_ARTIFACT_SOURCE") do
+      empty when empty in [nil, ""] -> :github
+      name -> Enum.find(@sources, name, &(Atom.to_string(&1) == name))
+    end
+
+  @source Application.compile_env(:lumis, :artifact_source, env_source)
+
+  if @source not in @sources do
+    raise ArgumentError,
+          "invalid Lumis artifact source: #{inspect(@source)}. Expected one of #{inspect(@sources)}"
+  end
+
+  def url(file_name), do: url(file_name, @source)
+
+  def url(file_name, source) when source in @sources do
+    "#{Map.fetch!(@base_urls, source)}/#{file_name}"
+  end
+end

--- a/packages/elixir/lumis/mix.exs
+++ b/packages/elixir/lumis/mix.exs
@@ -91,7 +91,7 @@ defmodule Lumis.MixProject do
   defp deps do
     [
       {:rustler, "~> 0.29", optional: true},
-      {:rustler_precompiled, "~> 0.6"},
+      {:rustler_precompiled, "~> 0.8"},
       {:nimble_options, "~> 1.0"},
       {:ex_doc, ">= 0.0.0", only: :docs},
       {:makeup_elixir, ">= 0.0.0", only: :docs},

--- a/packages/elixir/lumis/test/lumis/native/artifact_url_test.exs
+++ b/packages/elixir/lumis/test/lumis/native/artifact_url_test.exs
@@ -1,0 +1,36 @@
+defmodule Lumis.Native.ArtifactURLTest do
+  use ExUnit.Case, async: true
+
+  alias Lumis.Native.ArtifactURL
+
+  @version Mix.Project.config()[:version]
+  @file_name "liblumis_nif-v#{@version}-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz"
+
+  test "defaults to GitHub releases" do
+    assert ArtifactURL.url(@file_name) ==
+             "https://github.com/leandrocp/lumis/releases/download/hex-lumis/v#{@version}/#{@file_name}"
+  end
+
+  test "serves the same file name from the Cloudflare mirror" do
+    assert ArtifactURL.url(@file_name, :cloudflare) ==
+             "https://artifacts.lumis.sh/releases/download/hex-lumis/v#{@version}/#{@file_name}"
+  end
+
+  test "both sources agree on everything after the base URL" do
+    "https://github.com/leandrocp/lumis/releases/download/" <> github =
+      ArtifactURL.url(@file_name, :github)
+
+    "https://artifacts.lumis.sh/releases/download/" <> cloudflare =
+      ArtifactURL.url(@file_name, :cloudflare)
+
+    assert github == cloudflare
+  end
+
+  test "rejects a source that is not one of the two" do
+    # Built at runtime so the type checker cannot rule it out the way it does a
+    # literal, which is also how a source reaches us from config or the environment.
+    source = String.to_atom("s3")
+
+    assert_raise FunctionClauseError, fn -> ArtifactURL.url(@file_name, source) end
+  end
+end


### PR DESCRIPTION
## Why

GitHub's release-asset CDN intermittently resets connections mid-transfer. `:httpc` reports it as `{:error, :socket_closed_remotely}` and the `lumis` dependency fails to compile:

```
== Compilation error in file lib/lumis/native.ex ==
** (RuntimeError) Error while downloading precompiled NIF: couldn't fetch NIF from
https://github.com/leandrocp/lumis/releases/download/hex-lumis/v0.6.3/liblumis_nif-v0.6.3-nif-2.15-x86_64-unknown-linux-gnu.so.tar.gz:
{:error, :socket_closed_remotely}.
```

The artifact is fine — it downloads and its SHA-256 matches the checksum file; 20/20 `curl` retries succeeded while the same URL was failing elsewhere. It is a transient CDN reset, and `curl: (56)` reproduces it independently.

Two things make it bite harder than a coin flip should. rustler_precompiled resolves the URL once and retries that one URL, so all four attempts can burn in ~7s — in that run the `Lint` job recovered on attempt 2 while `Export schema & dump` lost four in a row. And a 13.6 MB artifact leaves a wide window for a mid-transfer reset.

## What

Release artifacts now sync to Cloudflare R2 alongside the GitHub Release, served from `artifacts.lumis.sh`. `:base_url` resolves through `Lumis.Native.ArtifactURL`, so consumers can choose:

```elixir
config :lumis, artifact_source: :cloudflare
```

```sh
LUMIS_ARTIFACT_SOURCE=cloudflare
```

Config wins when both are set. The env var exists because a Dockerfile or CI job is easier to reach than a config file already baked into an image — which is exactly the situation this is meant to rescue.

**Defaults to `:github`**, so nothing changes for anyone who does not opt in, and checksum generation at release time keeps reading from GitHub instead of waiting on the R2 sync.

## What this is not

A switch, not a fallback. rustler_precompiled resolves the URL once, so a failed download does not reach for the other source. This gives a one-line escape hatch when GitHub is down; it does not make the download self-healing. The real fix for that is upstream support for an ordered list of base URLs, which is worth a separate issue against `philss/rustler_precompiled`.

## Notes

- Both sources are byte-identical after the base URL, which is what keeps the single `checksum-Elixir.Lumis.Native.exs` valid for either. A test pins that, so a future path change breaks the test rather than the mirror. Downloads are checksum-verified regardless of source, so the mirror cannot serve a different NIF.
- Includes a separate fix: `rustler_precompiled` was required as `~> 0.6`, but the `{module, function}` form of `:base_url` only exists from **0.8.0**. Under `~> 0.6` a consumer resolving 0.7.x would get the tuple treated as a string. `mix.lock` already pinned 0.8.4, so nothing resolves differently.
- The R2 step fails the release if any of the four secrets is missing, rather than silently skipping, so the mirror cannot fall behind the GitHub Release. All four are set on this repo.
- 0.6.3's artifacts are not on R2 — the mirror covers releases cut after this lands.

## Verification

`actionlint` clean · `mix format --check-formatted` clean · no compile warnings · credo 0 issues · Elixir suite 162 passed, 0 failed · 4 new tests.

Local builds use `LUMIS_BUILD=1` (the checksum file is generated at release, not tracked), so `:base_url` is not exercised end-to-end here. The unit tests pin the URLs and the MFA clause was confirmed against rustler_precompiled's `tar_gz_file_url/2`; the first real download through `ArtifactURL` happens on the next release.
