### PR TITLE
perf(languages): prepare large parser bundles concurrently

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -272,11 +272,12 @@ runtime, so the two commands cannot disagree about what a prepared cache
 contains. Downloads run concurrently and return one ordered result per name.
 
 Both then validate each parser and its queries in a disposable Tree-sitter
-store. Validation writes Wasmtime's compiled module under `compiled/`, catches
-link and external scanner failures that raw compilation cannot, and drops the
-store before moving to the next parser. A full catalog therefore never accumulates in Tree-sitter's
-shared 128 MiB address space. Compilation concurrency is capped at four to bound
-peak memory on high-core builders.
+store. Validation writes Wasmtime's compiled module under `compiled/` and
+catches link and external scanner failures that raw compilation cannot. Each
+worker drops its store after validating one parser, and the compilation limit
+bounds simultaneous stores to four. A full catalog therefore never accumulates
+in Tree-sitter's shared 128 MiB address space, and peak memory stays bounded on
+high-core builders.
 
 **One prepared directory serves every runtime, including the compile.** Wasmtime
 keys its module cache on the compiler and its version, so a release build of the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -267,12 +267,16 @@ mix lumis.languages.cache rust javascript # Elixir
 
 Both write a self-sufficient directory — parser bytes plus the `lumis.json`
 that names them — so pointing `LUMIS_DATA_DIR` at it is all a deployment needs.
-Both go through `LanguageStore::cache_language`, which needs no Wasmtime
+Both go through `LanguageStore::cache_languages`, which needs no Wasmtime
 runtime, so the two commands cannot disagree about what a prepared cache
-contains.
+contains. Downloads run concurrently and return one ordered result per name.
 
-Both then load each parser once, so Wasmtime writes `compiled/` beside them and
-an image ships the compile as well as the download.
+Both then validate each parser and its queries in a disposable Tree-sitter
+store. Validation writes Wasmtime's compiled module under `compiled/`, catches
+link and external scanner failures that raw compilation cannot, and drops the
+store before moving to the next parser. A full catalog therefore never accumulates in Tree-sitter's
+shared 128 MiB address space. Compilation concurrency is capped at four to bound
+peak memory on high-core builders.
 
 **One prepared directory serves every runtime, including the compile.** Wasmtime
 keys its module cache on the compiler and its version, so a release build of the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,6 +1597,7 @@ dependencies = [
 name = "lumis_nif"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "lumis-core",
  "lumis-wasm-runtime",
  "once_cell",

--- a/crates/lumis-cli/src/main.rs
+++ b/crates/lumis-cli/src/main.rs
@@ -664,27 +664,20 @@ fn cache_languages(
         .map(|name| resolve_language_id(name).to_string())
         .collect();
 
-    // Verifying a cached parser rehashes it, so only ask when the answer is
-    // going to be printed; the download itself checks anyway.
-    let already_cached: Vec<bool> = names
-        .iter()
-        .map(|name| verbose && !force && reg.is_cached(name))
-        .collect();
-
     let mut errors = Vec::new();
-    for ((name, cached), result) in names
-        .iter()
-        .zip(already_cached)
-        .zip(reg.cache_parsers(&names, force))
-    {
+    for (name, result) in names.iter().zip(reg.cache_parsers_detailed(&names, force)) {
         match result {
-            Ok(path) if verbose && cached => eprintln!("{}: {}", name, path.display()),
-            Ok(path) if verbose => eprintln!(
-                "{}: {} -> {}",
-                name,
-                reg.parser_download_url(name)?,
-                path.display()
-            ),
+            Ok(outcome) if verbose => {
+                eprintln!("--> {name}");
+                if let Some(url) = outcome.download_url {
+                    eprintln!("downloading from {url}");
+                }
+                eprintln!(
+                    "downloaded to {}",
+                    relative_to_current(&outcome.path).display()
+                );
+                eprintln!("cached in {:.3}s", outcome.elapsed.as_secs_f64());
+            }
             Ok(_) => {}
             Err(error) => {
                 eprintln!("{name}: failed");
@@ -703,19 +696,16 @@ fn cache_languages(
     // Downloading is the smaller half of a cold parser; the Wasmtime compile is
     // the larger. Compiling each one here writes it into `compiled/`, so a
     // prepared directory carries both. `mix lumis.languages.cache` does the same.
-    let mut compiled = 0;
     let mut compile_errors = Vec::new();
-    for (name, result) in names.iter().zip(reg.precompile_parsers(&names)) {
+    for (name, result) in names.iter().zip(reg.precompile_parsers_detailed(&names)) {
         match result {
-            Ok(()) => compiled += 1,
+            Ok(elapsed) if verbose => eprintln!("compiled in {:.3}s", elapsed.as_secs_f64()),
+            Ok(_) => {}
             Err(error) => {
                 eprintln!("{name}: failed to compile");
                 compile_errors.push((name, error));
             }
         }
-    }
-    if verbose {
-        eprintln!("compiled {compiled} parser(s)");
     }
     if !compile_errors.is_empty() {
         return Err(anyhow::anyhow!(

--- a/crates/lumis-cli/src/main.rs
+++ b/crates/lumis-cli/src/main.rs
@@ -655,35 +655,40 @@ fn cache_languages(
         lumis_wasm_runtime::catalog::expand_bundles(languages.iter().map(String::as_str))?
     };
     let mut seen = std::collections::HashSet::new();
-    let names: Vec<&str> = expanded
+    let names: Vec<String> = expanded
         .iter()
-        .map(String::as_str)
         .filter(|name| {
             let language_id = resolve_language_id(name);
             language_id != "plaintext" && seen.insert(language_id)
         })
+        .map(|name| resolve_language_id(name).to_string())
+        .collect();
+
+    // Verifying a cached parser rehashes it, so only ask when the answer is
+    // going to be printed; the download itself checks anyway.
+    let already_cached: Vec<bool> = names
+        .iter()
+        .map(|name| verbose && !force && reg.is_cached(name))
         .collect();
 
     let mut errors = Vec::new();
-    for name in &names {
-        let language_id = resolve_language_id(name);
-        let already_cached = !force && reg.is_cached(language_id);
-        match reg.cache_parser(language_id, force) {
-            Ok(path) => {
-                if verbose && already_cached {
-                    eprintln!("{}: {}", name, path.display());
-                } else if verbose {
-                    eprintln!(
-                        "{}: {} -> {}",
-                        name,
-                        reg.parser_download_url(language_id)?,
-                        path.display()
-                    );
-                }
-            }
-            Err(e) => {
-                eprintln!("{}: failed", name);
-                errors.push((*name, e));
+    for ((name, cached), result) in names
+        .iter()
+        .zip(already_cached)
+        .zip(reg.cache_parsers(&names, force))
+    {
+        match result {
+            Ok(path) if verbose && cached => eprintln!("{}: {}", name, path.display()),
+            Ok(path) if verbose => eprintln!(
+                "{}: {} -> {}",
+                name,
+                reg.parser_download_url(name)?,
+                path.display()
+            ),
+            Ok(_) => {}
+            Err(error) => {
+                eprintln!("{name}: failed");
+                errors.push((name, error));
             }
         }
     }
@@ -696,17 +701,27 @@ fn cache_languages(
     }
 
     // Downloading is the smaller half of a cold parser; the Wasmtime compile is
-    // the larger. Loading each one here writes it into `compiled/`, so a
+    // the larger. Compiling each one here writes it into `compiled/`, so a
     // prepared directory carries both. `mix lumis.languages.cache` does the same.
     let mut compiled = 0;
-    for name in &names {
-        match reg.load_language(resolve_language_id(name)) {
+    let mut compile_errors = Vec::new();
+    for (name, result) in names.iter().zip(reg.precompile_parsers(&names)) {
+        match result {
             Ok(()) => compiled += 1,
-            Err(error) => eprintln!("{name}: cached but not compiled ({error})"),
+            Err(error) => {
+                eprintln!("{name}: failed to compile");
+                compile_errors.push((name, error));
+            }
         }
     }
     if verbose {
         eprintln!("compiled {compiled} parser(s)");
+    }
+    if !compile_errors.is_empty() {
+        return Err(anyhow::anyhow!(
+            "failed to compile {} parser(s)",
+            compile_errors.len()
+        ));
     }
 
     Ok(())

--- a/crates/lumis-cli/src/registry.rs
+++ b/crates/lumis-cli/src/registry.rs
@@ -1,10 +1,14 @@
-use anyhow::{Context, Result};
+#[cfg(test)]
+use anyhow::Context;
+use anyhow::Result;
 use lumis_wasm_runtime::catalog;
+#[cfg(test)]
+use lumis_wasm_runtime::LanguagePackage;
 use lumis_wasm_runtime::{
-    HighlightOptions, HighlightOutput, HttpFetcher, LanguagePackage, LanguageStore, Runtime,
-    StoreConfig,
+    HighlightOptions, HighlightOutput, HttpFetcher, LanguageStore, Runtime, StoreConfig,
 };
 use std::path::{Path, PathBuf};
+#[cfg(test)]
 use std::sync::Arc;
 use tree_sitter::Tree;
 
@@ -55,9 +59,13 @@ impl Registry {
     ///
     /// Caching a bundle one language at a time is a hundred sequential round
     /// trips to the CDN, which is most of the wall clock.
-    pub fn cache_parsers(&self, languages: &[String], force: bool) -> Vec<Result<PathBuf>> {
+    pub fn cache_parsers_detailed(
+        &self,
+        languages: &[String],
+        force: bool,
+    ) -> Vec<Result<lumis_wasm_runtime::CacheLanguageOutcome>> {
         self.store()
-            .cache_languages(languages, force, lumis_wasm_runtime::DOWNLOAD_CONCURRENCY)
+            .cache_languages_detailed(languages, force, lumis_wasm_runtime::DOWNLOAD_CONCURRENCY)
             .into_iter()
             .map(|result| result.map_err(Into::into))
             .collect()
@@ -68,14 +76,18 @@ impl Registry {
     /// Each parser uses a disposable Tree-sitter store, so a whole catalog never
     /// shares one address space. The load validates the parser and writes its
     /// compiled form into the image; query configuration is validated too.
-    pub fn precompile_parsers(&self, languages: &[String]) -> Vec<Result<()>> {
+    pub fn precompile_parsers_detailed(
+        &self,
+        languages: &[String],
+    ) -> Vec<Result<std::time::Duration>> {
         self.runtime
-            .precompile_languages(languages, lumis_wasm_runtime::compile_concurrency())
+            .precompile_languages_detailed(languages, lumis_wasm_runtime::compile_concurrency())
             .into_iter()
             .map(|result| result.map_err(Into::into))
             .collect()
     }
 
+    #[cfg(test)]
     pub fn is_cached(&self, language: &str) -> bool {
         self.local_package(language)
             .is_some_and(|package| self.store().cached_parser(&package).is_some())
@@ -86,6 +98,7 @@ impl Registry {
         Ok(self.store().parser_path(self.package(language)?.as_ref())?)
     }
 
+    #[cfg(test)]
     pub fn parser_download_url(&self, language: &str) -> Result<String> {
         Ok(LanguageStore::parser_url(self.package(language)?.as_ref())?)
     }
@@ -94,12 +107,14 @@ impl Registry {
         self.runtime.store().expect("the CLI always has a store")
     }
 
+    #[cfg(test)]
     fn package(&self, language: &str) -> Result<Arc<LanguagePackage>> {
         let location =
             catalog::find(language).with_context(|| format!("unknown language '{language}'"))?;
         Ok(self.store().package(location.package_name)?)
     }
 
+    #[cfg(test)]
     fn local_package(&self, language: &str) -> Option<Arc<LanguagePackage>> {
         let location = catalog::find(language)?;
         self.store().local_package(location.package_name)

--- a/crates/lumis-cli/src/registry.rs
+++ b/crates/lumis-cli/src/registry.rs
@@ -51,14 +51,29 @@ impl Registry {
         Ok(self.runtime.highlight_with(source, language, options)?)
     }
 
-    /// Download and cache `language`, returning where its parser landed.
-    pub fn cache_parser(&self, language: &str, force: bool) -> Result<PathBuf> {
-        Ok(self.store().cache_language(language, force)?)
+    /// Download and cache `languages` concurrently, one result per name.
+    ///
+    /// Caching a bundle one language at a time is a hundred sequential round
+    /// trips to the CDN, which is most of the wall clock.
+    pub fn cache_parsers(&self, languages: &[String], force: bool) -> Vec<Result<PathBuf>> {
+        self.store()
+            .cache_languages(languages, force, lumis_wasm_runtime::DOWNLOAD_CONCURRENCY)
+            .into_iter()
+            .map(|result| result.map_err(Into::into))
+            .collect()
     }
 
-    /// Load `language`, so Wasmtime writes its compiled form beside the parser.
-    pub fn load_language(&self, language: &str) -> Result<()> {
-        Ok(self.runtime.load_named_language(language)?)
+    /// Compile and validate `languages` without retaining them.
+    ///
+    /// Each parser uses a disposable Tree-sitter store, so a whole catalog never
+    /// shares one address space. The load validates the parser and writes its
+    /// compiled form into the image; query configuration is validated too.
+    pub fn precompile_parsers(&self, languages: &[String]) -> Vec<Result<()>> {
+        self.runtime
+            .precompile_languages(languages, lumis_wasm_runtime::compile_concurrency())
+            .into_iter()
+            .map(|result| result.map_err(Into::into))
+            .collect()
     }
 
     pub fn is_cached(&self, language: &str) -> bool {

--- a/crates/lumis-cli/tests/cli.rs
+++ b/crates/lumis-cli/tests/cli.rs
@@ -1257,7 +1257,9 @@ fn cache_languages_already_cached() {
         .arg(fixtures_dir())
         .args(["languages", "cache", "diff"])
         .assert()
-        .success();
+        .success()
+        .stdout("")
+        .stderr("");
 }
 
 #[test]

--- a/crates/lumis-cli/tests/cli.rs
+++ b/crates/lumis-cli/tests/cli.rs
@@ -1264,7 +1264,6 @@ fn cache_languages_already_cached() {
 
 #[test]
 fn cache_languages_already_cached_verbose() {
-    // With -V it shows the cached path
     cmd()
         .arg("--data-dir")
         .arg(fixtures_dir())
@@ -1272,7 +1271,11 @@ fn cache_languages_already_cached_verbose() {
         .args(["languages", "cache", "diff"])
         .assert()
         .success()
-        .stderr(predicate::str::contains("tree-sitter-diff-"));
+        .stderr(predicate::str::contains("--> diff"))
+        .stderr(predicate::str::contains("downloaded to "))
+        .stderr(predicate::str::contains("tree-sitter-diff-"))
+        .stderr(predicate::str::is_match("cached in [0-9]+\\.[0-9]{3}s").unwrap())
+        .stderr(predicate::str::is_match("compiled in [0-9]+\\.[0-9]{3}s").unwrap());
 }
 
 #[test]
@@ -1286,7 +1289,8 @@ fn cache_languages_skips_plaintext_aliases() {
         .args(["languages", "cache", "plaintext", "text", "txt", "plain"])
         .assert()
         .success()
-        .stderr(predicate::str::contains("compiled 0 parser(s)"));
+        .stdout("")
+        .stderr("");
 
     assert!(fs::read_dir(tmp.path().join("parsers"))
         .unwrap()

--- a/crates/lumis-wasm-runtime/src/lib.rs
+++ b/crates/lumis-wasm-runtime/src/lib.rs
@@ -1,5 +1,7 @@
 //! Tree-sitter highlighting shared by Lumis runtimes.
 
+use std::sync::Mutex;
+
 macro_rules! define_catalog {
     (
         package_version_range: $package_version_range:literal,
@@ -135,6 +137,89 @@ impl std::fmt::Display for UnknownBundle {
 
 impl std::error::Error for UnknownBundle {}
 
+/// Run `work` over every item on up to `concurrency` threads, in input order.
+///
+/// Preparing a bundle is a hundred-odd independent downloads and compiles, and
+/// doing them one at a time is what makes `bundle-full` take minutes. Threads
+/// pull from a shared cursor rather than taking a fixed slice each, so one
+/// 22 MB parser cannot leave a worker holding the whole run.
+///
+/// Results come back positionally, so a caller can zip them against the names it
+/// passed without threading identity through the closure.
+pub(crate) fn parallel_map<Item, Output, Work>(
+    items: &[Item],
+    concurrency: usize,
+    work: Work,
+) -> Vec<Output>
+where
+    Item: Sync,
+    Output: Send,
+    Work: Fn(&Item) -> Output + Sync,
+{
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let threads = concurrency.clamp(1, items.len().max(1));
+    if threads == 1 {
+        return items.iter().map(work).collect();
+    }
+
+    // `Option` because a slot is filled exactly once, by whichever thread claims
+    // that index, and there is no meaningful value to seed it with. The lock is
+    // taken to store a finished result, never across `work`.
+    let results: Mutex<Vec<Option<Output>>> = Mutex::new((0..items.len()).map(|_| None).collect());
+    let cursor = AtomicUsize::new(0);
+
+    let drain = || loop {
+        let index = cursor.fetch_add(1, Ordering::Relaxed);
+        let Some(item) = items.get(index) else { return };
+        let output = work(item);
+        results.lock().expect("parallel_map lock poisoned")[index] = Some(output);
+    };
+
+    std::thread::scope(|scope| {
+        // Downloading resolves TLS, which wants far more stack than a BEAM dirty
+        // scheduler carries, and the NIF reaches this directly rather than
+        // through its own 8 MiB executor threads.
+        for index in 1..threads {
+            let _ = std::thread::Builder::new()
+                .name(format!("lumis-batch-{index}"))
+                .stack_size(8 * 1024 * 1024)
+                .spawn_scoped(scope, drain);
+        }
+        // The calling thread is a worker too, so a refused spawn costs
+        // parallelism rather than leaving an item unclaimed.
+        drain();
+    });
+
+    results
+        .into_inner()
+        .expect("parallel_map lock poisoned")
+        .into_iter()
+        .map(|slot| slot.expect("every index is claimed exactly once"))
+        .collect()
+}
+
+/// Threads to spread bundle downloads across.
+///
+/// Downloads are latency-bound rather than CPU-bound — a CI container with two
+/// cores still waits on the CDN — so this deliberately does not follow
+/// [`std::thread::available_parallelism`]. Held well under what a public CDN
+/// would consider abusive.
+pub const DOWNLOAD_CONCURRENCY: usize = 8;
+
+/// Threads to spread parser compilation across.
+///
+/// Cranelift saturates a core per module but also uses enough memory that a
+/// full catalog can exhaust a memory-constrained builder. Four keeps the work
+/// parallel without letting a high core count multiply peak memory unchecked.
+#[must_use]
+pub fn compile_concurrency() -> usize {
+    std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+        .min(4)
+}
+
 #[cfg(feature = "wasm")]
 pub mod brackets;
 pub mod catalog;
@@ -162,6 +247,49 @@ pub use runtime::{
 #[cfg(feature = "wasm")]
 pub use store::HttpFetcher;
 pub use store::{
-    lowest_compatible_package_version, package_suffix, parser_filename, write_atomic, Fetcher,
-    LanguageStore, NoNetwork, StoreConfig, StoreError,
+    lowest_compatible_package_version, package_suffix, parser_filename, write_atomic,
+    CacheLanguageOutcome, Fetcher, LanguageStore, NoNetwork, StoreConfig, StoreError,
 };
+
+#[cfg(test)]
+mod parallel_map_tests {
+    #[test]
+    fn returns_results_in_input_order() {
+        let items: Vec<usize> = (0..64).collect();
+        // Reverse the durations so completion order cannot match input order.
+        let squares = super::parallel_map(&items, 8, |item| {
+            std::thread::sleep(std::time::Duration::from_micros((64 - *item as u64) * 50));
+            item * item
+        });
+        assert_eq!(
+            squares,
+            items.iter().map(|item| item * item).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn runs_every_item_exactly_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let items: Vec<usize> = (0..100).collect();
+        let calls = AtomicUsize::new(0);
+        let seen = super::parallel_map(&items, 16, |item| {
+            calls.fetch_add(1, Ordering::Relaxed);
+            *item
+        });
+        assert_eq!(calls.into_inner(), 100);
+        assert_eq!(seen, items);
+    }
+
+    #[test]
+    fn handles_empty_input_and_excess_concurrency() {
+        let empty: Vec<usize> = Vec::new();
+        assert!(super::parallel_map(&empty, 8, |item| *item).is_empty());
+        assert_eq!(super::parallel_map(&[7usize], 64, |item| *item), vec![7]);
+    }
+
+    #[test]
+    fn bounds_compile_concurrency() {
+        assert!((1..=4).contains(&super::compile_concurrency()));
+    }
+}

--- a/crates/lumis-wasm-runtime/src/runtime.rs
+++ b/crates/lumis-wasm-runtime/src/runtime.rs
@@ -961,7 +961,7 @@ mod tests {
     ) -> crate::LanguagePackage {
         crate::LanguagePackage {
             package_name: package_name.into(),
-            version: "0.26.0".into(),
+            version: crate::lowest_compatible_package_version(),
             definition_hash: "test".into(),
             parser: crate::ParserMetadata {
                 name: format!("tree-sitter-{grammar_name}"),

--- a/crates/lumis-wasm-runtime/src/runtime.rs
+++ b/crates/lumis-wasm-runtime/src/runtime.rs
@@ -4,6 +4,7 @@ use lumis_core::events::HighlightEvent;
 use lumis_core::highlights::HIGHLIGHT_NAMES;
 use std::collections::HashMap;
 use std::sync::{Arc, Condvar, Mutex, OnceLock, RwLock};
+use std::time::{Duration, Instant};
 use thiserror::Error;
 use tree_sitter::{Language, Parser, Query, Tree, WasmStore};
 use wasmtime::{Cache, CacheConfig, Config, Engine};
@@ -83,6 +84,10 @@ impl WorkerPool {
             state: Mutex::new(WorkerPoolState::default()),
             available: Condvar::new(),
         }
+    }
+
+    fn engine(&self) -> &Engine {
+        &self.engine
     }
 
     fn lease(&self) -> Result<WorkerLease<'_>, RuntimeError> {
@@ -172,6 +177,12 @@ pub enum RuntimeError {
     Query { language: String, message: String },
     #[error("language '{0}' is not loaded")]
     LanguageNotLoaded(String),
+    #[error("unknown language '{0}'")]
+    UnknownLanguage(String),
+    #[error("language store is not configured")]
+    LanguageStoreUnavailable,
+    #[error("language '{0}' is not cached")]
+    LanguageNotCached(String),
     #[error("highlighting failed: {0}")]
     Highlight(String),
 }
@@ -232,6 +243,83 @@ impl Runtime {
     /// parser cannot be obtained or verified.
     pub fn load_named_language(&self, name: &str) -> Result<(), RuntimeError> {
         self.load_through_store(name).map(|_| ())
+    }
+
+    /// Compile and validate every cached parser and its queries in `names`, up
+    /// to `concurrency` at a time.
+    ///
+    /// Each parser gets a disposable Tree-sitter [`WasmStore`]. Loading through
+    /// that store performs the link and scanner validation that compiling a raw
+    /// Wasmtime module does not; building its highlight configuration validates
+    /// the queries. Dropping the store after one parser avoids the shared 128 MiB
+    /// address space filling across a full catalog. The load also writes the
+    /// compiled module to the engine's on-disk cache.
+    ///
+    /// Results come back in the order the names were given, one per name.
+    #[must_use]
+    pub fn precompile_languages(
+        &self,
+        names: &[String],
+        concurrency: usize,
+    ) -> Vec<Result<(), RuntimeError>> {
+        self.precompile_languages_detailed(names, concurrency)
+            .into_iter()
+            .map(|result| result.map(|_| ()))
+            .collect()
+    }
+
+    /// Compile and validate every cached parser and report per-language timing.
+    #[must_use]
+    pub fn precompile_languages_detailed(
+        &self,
+        names: &[String],
+        concurrency: usize,
+    ) -> Vec<Result<Duration, RuntimeError>> {
+        crate::parallel_map(names, concurrency, |name| {
+            let started = Instant::now();
+            self.precompile_language(name).map(|()| started.elapsed())
+        })
+    }
+
+    /// Compile and validate one cached parser and its queries without retaining it.
+    fn precompile_language(&self, name: &str) -> Result<(), RuntimeError> {
+        let store = self
+            .store
+            .as_ref()
+            .ok_or(RuntimeError::LanguageStoreUnavailable)?;
+        let location =
+            crate::catalog::find(name).ok_or_else(|| RuntimeError::UnknownLanguage(name.into()))?;
+        let package = store
+            .local_package(location.package_name)
+            .ok_or_else(|| RuntimeError::LanguageNotCached(name.into()))?;
+        let wasm = store
+            .local_parser(&package)
+            .ok_or_else(|| RuntimeError::LanguageNotCached(name.into()))?;
+
+        let mut wasm_store = WasmStore::new(self.workers.engine())
+            .map_err(|error| RuntimeError::TreeSitter(error.to_string()))?;
+        let language = wasm_store
+            .load_language(&package.parser.grammar_name, &wasm)
+            .map_err(|error| RuntimeError::Parser {
+                language: name.to_string(),
+                message: error.to_string(),
+            })?;
+        let (id, definition) = package
+            .language(name)
+            .ok_or_else(|| RuntimeError::UnknownLanguage(name.into()))?;
+        let mut highlight = HighlightConfiguration::new(
+            language,
+            id.to_string(),
+            &definition.highlights,
+            &definition.injections,
+            &definition.locals,
+        )
+        .map_err(|error| RuntimeError::Query {
+            language: id.to_string(),
+            message: error.to_string(),
+        })?;
+        highlight.configure(&HIGHLIGHT_NAMES);
+        Ok(())
     }
 
     /// Resolve, download and load `id` through the store, if one is attached.
@@ -858,28 +946,48 @@ mod tests {
 
     const JSON_WASM: &[u8] =
         include_bytes!("../../lumis-cli/tests/fixtures/parsers/tree-sitter-json.wasm");
+    const INVALID_TREE_SITTER_WASM: &[u8] = &[
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,
+        0x03, 0x02, 0x01, 0x00, 0x07, 0x16, 0x01, 0x12, 0x74, 0x72, 0x65, 0x65, 0x5f, 0x73, 0x69,
+        0x74, 0x74, 0x65, 0x72, 0x5f, 0x62, 0x72, 0x6f, 0x6b, 0x65, 0x6e, 0x00, 0x00, 0x0a, 0x06,
+        0x01, 0x04, 0x00, 0x41, 0x00, 0x0b,
+    ];
 
-    fn json_package(wasm: &[u8]) -> crate::LanguagePackage {
+    fn package(
+        package_name: &str,
+        language: &str,
+        grammar_name: &str,
+        wasm: &[u8],
+    ) -> crate::LanguagePackage {
         crate::LanguagePackage {
-            package_name: "@lumis-sh/wasm-json".into(),
+            package_name: package_name.into(),
             version: "0.26.0".into(),
             definition_hash: "test".into(),
             parser: crate::ParserMetadata {
-                name: "tree-sitter-json".into(),
-                grammar_name: "json".into(),
+                name: format!("tree-sitter-{grammar_name}"),
+                grammar_name: grammar_name.into(),
                 upstream_version: None,
                 revision: None,
                 sha256: crate::sha256_hex(wasm),
                 size: u64::try_from(wasm.len()).expect("parser size fits in u64"),
             },
             languages: std::collections::BTreeMap::from([(
-                "json".into(),
+                language.into(),
                 crate::PackagedLanguage {
                     highlights: "(string) @string".into(),
                     ..crate::PackagedLanguage::default()
                 },
             )]),
         }
+    }
+
+    fn json_package(wasm: &[u8]) -> crate::LanguagePackage {
+        package("@lumis-sh/wasm-json", "json", "json", wasm)
+    }
+
+    fn cache_package(store: &LanguageStore, package: &crate::LanguagePackage, wasm: &[u8]) {
+        store.cache_package(package).unwrap();
+        crate::write_atomic(&store.parser_path(package).unwrap(), wasm).unwrap();
     }
 
     fn install_json(runtime: &Runtime, injections: &str) {
@@ -967,12 +1075,6 @@ mod tests {
 
     #[test]
     fn a_failed_parser_module_load_is_cached_by_content() {
-        const INVALID_TREE_SITTER_WASM: &[u8] = &[
-            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60, 0x00, 0x01,
-            0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x16, 0x01, 0x12, 0x74, 0x72, 0x65, 0x65, 0x5f,
-            0x73, 0x69, 0x74, 0x74, 0x65, 0x72, 0x5f, 0x62, 0x72, 0x6f, 0x6b, 0x65, 0x6e, 0x00,
-            0x00, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x41, 0x00, 0x0b,
-        ];
         let runtime = Runtime::with_worker_limit(1).unwrap();
         let spec = LanguageSpec {
             id: "broken-first".into(),
@@ -1005,6 +1107,78 @@ mod tests {
                 && first_message == second_message
         ));
         assert_eq!(runtime.module_load_attempt_count(), 1);
+    }
+
+    #[test]
+    fn precompile_validates_loadability_and_continues_after_a_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanguageStore::new(
+            StoreConfig {
+                cache_dir: dir.path().to_path_buf(),
+            },
+            Box::new(crate::NoNetwork),
+        );
+        let invalid = package(
+            "@lumis-sh/wasm-json",
+            "json",
+            "broken",
+            INVALID_TREE_SITTER_WASM,
+        );
+        let valid = package("@lumis-sh/wasm-diff", "diff", "json", JSON_WASM);
+        cache_package(&store, &invalid, INVALID_TREE_SITTER_WASM);
+        cache_package(&store, &valid, JSON_WASM);
+
+        let runtime = Runtime::with_worker_limit(1).unwrap().with_store(store);
+        assert!(wasmtime::Module::new(runtime.workers.engine(), INVALID_TREE_SITTER_WASM).is_ok());
+
+        let names = vec!["json".to_string(), "diff".to_string()];
+        let results = runtime.precompile_languages(&names, 1);
+        assert!(matches!(
+            &results[0],
+            Err(RuntimeError::Parser { language, .. }) if language == "json"
+        ));
+        assert!(results[1].is_ok(), "later parsers must still be attempted");
+    }
+
+    #[test]
+    fn precompile_validates_queries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanguageStore::new(
+            StoreConfig {
+                cache_dir: dir.path().to_path_buf(),
+            },
+            Box::new(crate::NoNetwork),
+        );
+        let mut invalid = json_package(JSON_WASM);
+        invalid.languages.get_mut("json").unwrap().highlights =
+            "(definitely_not_a_json_node) @string".into();
+        cache_package(&store, &invalid, JSON_WASM);
+
+        let runtime = Runtime::with_worker_limit(1).unwrap().with_store(store);
+        let results = runtime.precompile_languages(&["json".to_string()], 1);
+        assert!(matches!(
+            &results[0],
+            Err(RuntimeError::Query { language, .. }) if language == "json"
+        ));
+    }
+
+    #[test]
+    fn precompile_requires_a_cached_parser_even_when_the_language_is_loaded() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LanguageStore::new(
+            StoreConfig {
+                cache_dir: dir.path().to_path_buf(),
+            },
+            Box::new(crate::NoNetwork),
+        );
+        let runtime = Runtime::with_worker_limit(1).unwrap().with_store(store);
+        install_json(&runtime, "");
+
+        let results = runtime.precompile_languages(&["json".to_string()], 1);
+        assert!(matches!(
+            &results[0],
+            Err(RuntimeError::LanguageNotCached(language)) if language == "json"
+        ));
     }
 
     #[test]

--- a/crates/lumis-wasm-runtime/src/store.rs
+++ b/crates/lumis-wasm-runtime/src/store.rs
@@ -68,7 +68,7 @@ pub enum StoreError {
 }
 
 /// Result of caching one language package.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CacheLanguageOutcome {
     pub path: PathBuf,
     pub download_url: Option<String>,
@@ -393,9 +393,48 @@ impl LanguageStore {
         force: bool,
         concurrency: usize,
     ) -> Vec<Result<CacheLanguageOutcome, StoreError>> {
-        crate::parallel_map(names, concurrency, |name| {
-            self.cache_language_detailed(name, force)
-        })
+        let mut groups: Vec<Vec<usize>> = Vec::new();
+        let mut packages: HashMap<&str, usize> = HashMap::new();
+
+        for (index, name) in names.iter().enumerate() {
+            let package_name = crate::catalog::find(name).map(|location| location.package_name);
+            if let Some(&group) = package_name.and_then(|name| packages.get(name)) {
+                groups[group].push(index);
+            } else {
+                if let Some(package_name) = package_name {
+                    packages.insert(package_name, groups.len());
+                }
+                groups.push(vec![index]);
+            }
+        }
+
+        let grouped = crate::parallel_map(&groups, concurrency, |indices| {
+            let first = indices[0];
+            self.cache_language_detailed(&names[first], force)
+        });
+        let mut results: Vec<Option<Result<CacheLanguageOutcome, StoreError>>> =
+            (0..names.len()).map(|_| None).collect();
+
+        for (indices, result) in groups.iter().zip(grouped) {
+            match result {
+                Ok(outcome) => {
+                    for &index in indices {
+                        results[index] = Some(Ok(outcome.clone()));
+                    }
+                }
+                Err(error) => {
+                    results[indices[0]] = Some(Err(error));
+                    for &index in &indices[1..] {
+                        results[index] = Some(self.cache_language_detailed(&names[index], force));
+                    }
+                }
+            }
+        }
+
+        results
+            .into_iter()
+            .map(|result| result.expect("every language belongs to one cache group"))
+            .collect()
     }
 
     /// Write `package` into the cache, so a later run needs neither a source
@@ -725,6 +764,23 @@ mod tests {
     impl Fetcher for Canned {
         fn get(&self, _url: &str) -> Result<Vec<u8>, String> {
             Ok(self.0.clone())
+        }
+    }
+
+    struct PackageFetcher {
+        package: Vec<u8>,
+        requests: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl Fetcher for PackageFetcher {
+        fn get(&self, url: &str) -> Result<Vec<u8>, String> {
+            self.requests
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if url.ends_with("/lumis.json") {
+                Ok(self.package.clone())
+            } else {
+                Ok(WASM.to_vec())
+            }
         }
     }
 
@@ -1293,6 +1349,35 @@ mod tests {
 
     /// A cache that holds a parser but not its metadata cannot be used offline,
     /// so `cache_language` writes both.
+    #[test]
+    fn a_batch_caches_a_shared_package_once() {
+        let dir = tempdir();
+        let mut shared = package();
+        shared.package_name = "@lumis-sh/wasm-markdown".into();
+        shared.languages = BTreeMap::from([
+            ("markdown".into(), PackagedLanguage::default()),
+            ("mdx".into(), PackagedLanguage::default()),
+        ]);
+        let requests = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let store = make(
+            dir.path(),
+            Box::new(PackageFetcher {
+                package: serde_json::to_vec(&shared).unwrap(),
+                requests: Arc::clone(&requests),
+            }),
+        );
+        let names = vec!["markdown".to_string(), "mdx".to_string()];
+
+        let results = store.cache_languages_detailed(&names, true, 8);
+
+        assert!(results.iter().all(Result::is_ok));
+        assert_eq!(
+            results[0].as_ref().unwrap().path,
+            results[1].as_ref().unwrap().path
+        );
+        assert_eq!(requests.load(std::sync::atomic::Ordering::Relaxed), 2);
+    }
+
     #[test]
     fn caching_a_language_leaves_the_cache_self_sufficient() {
         let dir = tempdir();

--- a/crates/lumis-wasm-runtime/src/store.rs
+++ b/crates/lumis-wasm-runtime/src/store.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use semver::{Version, VersionReq};
 use thiserror::Error;
@@ -65,6 +65,14 @@ pub enum StoreError {
     },
     #[error(transparent)]
     Package(#[from] LanguagePackageError),
+}
+
+/// Result of caching one language package.
+#[derive(Debug)]
+pub struct CacheLanguageOutcome {
+    pub path: PathBuf,
+    pub download_url: Option<String>,
+    pub elapsed: Duration,
 }
 
 impl StoreError {
@@ -311,28 +319,83 @@ impl LanguageStore {
     /// Fails when the name is unknown, or the package or parser cannot be
     /// obtained or verified.
     pub fn cache_language(&self, name: &str, force: bool) -> Result<PathBuf, StoreError> {
+        self.cache_language_detailed(name, force)
+            .map(|outcome| outcome.path)
+    }
+
+    fn cache_language_detailed(
+        &self,
+        name: &str,
+        force: bool,
+    ) -> Result<CacheLanguageOutcome, StoreError> {
+        let started = Instant::now();
         let location =
             crate::catalog::find(name).ok_or_else(|| StoreError::UnknownLanguage(name.into()))?;
 
-        if force {
+        let (path, download_url) = if force {
             let (package, bytes) = self
                 .resolve_package(location.package_name)
                 .map_err(|error| self.unavailable(location.package_name, error))?;
             let path = self.parser_path(&package)?;
+            let download_url = Self::parser_url(&package)?;
             self.refresh_parser(&package)?;
             write_atomic(&self.package_path(location.package_name)?, &bytes)?;
             self.remember(location.package_name, package);
-            return Ok(path);
-        }
+            (path, Some(download_url))
+        } else {
+            let package = self.package(location.package_name)?;
+            let path = self.parser_path(&package)?;
+            let download_url = if self.cached_parser(&package).is_none() {
+                let url = Self::parser_url(&package)?;
+                self.fetch_parser(&package, &path)?;
+                Some(url)
+            } else {
+                None
+            };
+            self.cache_package(&package)?;
+            (path, download_url)
+        };
 
-        let package = self.package(location.package_name)?;
-        let path = self.parser_path(&package)?;
-        if self.cached_parser(&package).is_none() {
-            self.fetch_parser(&package, &path)?;
-        }
+        Ok(CacheLanguageOutcome {
+            path,
+            download_url,
+            elapsed: started.elapsed(),
+        })
+    }
 
-        self.cache_package(&package)?;
-        Ok(path)
+    /// Cache every name in `names`, downloading up to `concurrency` at a time.
+    ///
+    /// Results come back in the order the names were given, one per name, so a
+    /// caller reports every language that could not be obtained rather than only
+    /// the first. Preparing a bundle is otherwise a hundred sequential round
+    /// trips to the CDN, which dominates the wall clock even on a fast link.
+    ///
+    /// Concurrent writers are already safe — see the module docs — so the
+    /// threads share one store and one connection pool.
+    #[must_use]
+    pub fn cache_languages(
+        &self,
+        names: &[String],
+        force: bool,
+        concurrency: usize,
+    ) -> Vec<Result<PathBuf, StoreError>> {
+        self.cache_languages_detailed(names, force, concurrency)
+            .into_iter()
+            .map(|result| result.map(|outcome| outcome.path))
+            .collect()
+    }
+
+    /// Cache every name and report its source, destination, and elapsed time.
+    #[must_use]
+    pub fn cache_languages_detailed(
+        &self,
+        names: &[String],
+        force: bool,
+        concurrency: usize,
+    ) -> Vec<Result<CacheLanguageOutcome, StoreError>> {
+        crate::parallel_map(names, concurrency, |name| {
+            self.cache_language_detailed(name, force)
+        })
     }
 
     /// Write `package` into the cache, so a later run needs neither a source

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -275,9 +275,10 @@ Download exact, integrity-checked parser WASM files ahead of time, and compile
 them. Highlighting does both anyway; this moves them off the first run.
 
 A cold parser costs a download and then a Wasmtime compile, and the compile is
-the larger half, so each parser is loaded once here and its compiled form is
-written beside it. `mix lumis.languages.cache` prepares the identical directory,
-and every runtime reads it: cache with the CLI, and Elixir or Node start warm.
+the larger half. Each parser and its queries are validated in a disposable
+Tree-sitter store, so its compiled form is written beside it without retaining
+the full catalog in memory. `mix lumis.languages.cache` prepares the identical directory, and every
+runtime reads it: cache with the CLI, and Elixir or Node start warm.
 
 ```bash title="Selected parsers"
 lumis languages cache rust javascript elixir

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -275,10 +275,8 @@ Download exact, integrity-checked parser WASM files ahead of time, and compile
 them. Highlighting does both anyway; this moves them off the first run.
 
 A cold parser costs a download and then a Wasmtime compile, and the compile is
-the larger half. Each parser and its queries are validated in a disposable
-Tree-sitter store, so its compiled form is written beside it without retaining
-the full catalog in memory. `mix lumis.languages.cache` prepares the identical directory, and every
-runtime reads it: cache with the CLI, and Elixir or Node start warm.
+the larger half. See [Filling the store at build time](/advanced/wasm-and-cdn#filling-the-store-at-build-time)
+for how the CLI and Elixir validate parsers and prepare the shared cache.
 
 ```bash title="Selected parsers"
 lumis languages cache rust javascript elixir

--- a/docs/content/usage/elixir-integration.mdx
+++ b/docs/content/usage/elixir-integration.mdx
@@ -100,10 +100,10 @@ mix lumis.languages.cache elixir html javascript css
 mix lumis.languages.cache --all
 ```
 
-Each parser and its queries are validated in a disposable Tree-sitter store, so
-Wasmtime writes its compiled form beside it without retaining the full catalog.
-An image built this way starts serving without paying either cost, and a restart
-or a new pod does not pay it again.
+The task prepares the same shared parser and compile cache as the CLI. See
+[Filling the store at build time](/advanced/wasm-and-cdn#filling-the-store-at-build-time)
+for the cross-runtime workflow. An image built this way starts serving without
+paying either cost, and a restart or a new pod does not pay it again.
 
 Parsers land under `LUMIS_DATA_DIR`, which defaults to the user data directory.
 The result is self-sufficient — parser bytes, their metadata, and the compiled

--- a/docs/content/usage/elixir-integration.mdx
+++ b/docs/content/usage/elixir-integration.mdx
@@ -100,9 +100,10 @@ mix lumis.languages.cache elixir html javascript css
 mix lumis.languages.cache --all
 ```
 
-Each parser is downloaded *and* loaded once, so Wasmtime writes its compiled
-form beside it. An image built this way starts serving without paying either
-cost, and a restart or a new pod does not pay it again.
+Each parser and its queries are validated in a disposable Tree-sitter store, so
+Wasmtime writes its compiled form beside it without retaining the full catalog.
+An image built this way starts serving without paying either cost, and a restart
+or a new pod does not pay it again.
 
 Parsers land under `LUMIS_DATA_DIR`, which defaults to the user data directory.
 The result is self-sufficient — parser bytes, their metadata, and the compiled

--- a/docs/content/usage/wasm-and-cdn.mdx
+++ b/docs/content/usage/wasm-and-cdn.mdx
@@ -113,8 +113,10 @@ lumis languages cache rust javascript elixir
 
 Each writes a self-sufficient directory — parser bytes plus the metadata naming
 them — so pointing `LUMIS_DATA_DIR` at it is all the deployment needs. Pass
-`--all` to take the whole catalog. The Elixir task also loads each parser, so
-the compiled forms travel with it and the first request pays neither cost.
+`--all` to take the whole catalog. The native CLI and Elixir task validate each
+parser and its queries in a disposable Tree-sitter store, so Wasmtime's compiled
+forms travel with the cache without retaining the full catalog in memory. The
+first request therefore pays neither the download nor the compile.
 
 ## What ships where
 

--- a/packages/elixir/lumis/guides/deployment.md
+++ b/packages/elixir/lumis/guides/deployment.md
@@ -15,7 +15,13 @@ RUN mix release
 Include the root languages and any injected languages, such as the languages in
 Markdown code fences. The task accepts language names, bundles such as
 `bundle_web` and `bundle_system`, or `--all`. Use `--force` to refresh compatible
-versions already in the cache.
+versions already in the cache. `--verbose` prints one section per language with
+the download URL when fetched, destination path, cache time, and compile time.
+
+Downloads and parser validation both run concurrently, so a large bundle is
+worth naming directly rather than splitting across layers. The task prints a
+two-line summary unless asked for more, and reports every failure in a phase
+instead of stopping at the first.
 
 By default, the task writes parser metadata, verified WASM, and compiled modules
 to Lumis's `priv/lumis` directory. `mix release` includes that directory

--- a/packages/elixir/lumis/lib/lumis/languages.ex
+++ b/packages/elixir/lumis/lib/lumis/languages.ex
@@ -225,32 +225,113 @@ defmodule Lumis.Languages do
   written. `mix lumis.languages.cache` is the entry point; this is the API
   behind it.
 
+  Names are downloaded concurrently, and every one is attempted: a bundle
+  reports each language it could not obtain rather than stopping at the first,
+  the same way `load/1` does.
+
+      {:ok, paths} = Lumis.Languages.cache(["elixir", "html"])
+      {:error, %{"css" => reason}} = Lumis.Languages.cache(["elixir", "css"])
+
   ## Options
 
     * `:force` — resolve the compatible package range again and replace a
       verified parser
   """
-  @spec cache([String.t() | atom()], keyword()) :: {:ok, [String.t()]} | {:error, term()}
+  @spec cache([String.t() | atom()], keyword()) ::
+          {:ok, [String.t()]}
+          | {:error, String.t() | {:unknown_bundle, String.t()} | %{String.t() => String.t()}}
   def cache(names, options \\ []) when is_list(names) and is_list(options) do
     force? = Keyword.get(options, :force, false)
 
     with {:ok, expanded} <- expand_bundles(names) do
-      do_cache(expanded, force?)
+      expanded
+      |> Enum.reject(&(&1 in @plaintext_names))
+      |> do_cache(force?)
     end
   end
 
+  defp do_cache([], _force?), do: {:ok, []}
+
   defp do_cache(names, force?) do
     names
-    |> Enum.reject(&(&1 in @plaintext_names))
-    |> Enum.reduce_while({:ok, []}, fn name, {:ok, paths} ->
-      case Native.cache_language_by_name(name, force?) do
-        {:ok, path} -> {:cont, {:ok, [path | paths]}}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
+    |> Native.cache_languages(force?)
+    |> collect(names, fn {:ok, {_download_url, path, _elapsed}}, _name -> path end)
     |> case do
-      {:ok, paths} -> {:ok, paths |> Enum.reverse() |> Enum.uniq()}
-      {:error, reason} -> {:error, reason}
+      # A few languages share one grammar, so this is shorter than `names`.
+      {:ok, paths} ->
+        {:ok, Enum.uniq(paths)}
+
+      {:error, failures} when length(names) == 1 ->
+        {:error, Map.fetch!(failures, hd(names))}
+
+      error ->
+        error
     end
+  end
+
+  @doc false
+  def __cache_details__(names, options \\ []) do
+    force? = Keyword.get(options, :force, false)
+
+    with {:ok, expanded} <- expand_bundles(names) do
+      names = Enum.reject(expanded, &(&1 in @plaintext_names))
+
+      names
+      |> Native.cache_languages(force?)
+      |> collect(names, fn {:ok, details}, name -> {name, details} end)
+    end
+  end
+
+  @doc false
+  @spec __precompile__([String.t() | atom()]) ::
+          {:ok, [String.t()]}
+          | {:error, {:unknown_bundle, String.t()} | %{String.t() => String.t()}}
+  def __precompile__(names) when is_list(names) do
+    with {:ok, expanded} <- expand_bundles(names) do
+      expanded
+      |> Enum.reject(&(&1 in @plaintext_names))
+      |> do_precompile()
+    end
+  end
+
+  defp do_precompile([]), do: {:ok, []}
+
+  defp do_precompile(names) do
+    names
+    |> Native.precompile_languages()
+    |> collect(names, fn {:ok, _elapsed}, name -> name end)
+  end
+
+  @doc false
+  def __precompile_details__(names) when is_list(names) do
+    with {:ok, expanded} <- expand_bundles(names) do
+      names = Enum.reject(expanded, &(&1 in @plaintext_names))
+
+      names
+      |> Native.precompile_languages()
+      |> collect(names, fn {:ok, elapsed}, name -> {name, elapsed} end)
+    end
+  end
+
+  # The batch NIFs answer positionally, one result per name, so a failure is
+  # named by zipping rather than by threading the name through the batch.
+  # `Enum.zip/1` would quietly drop the tail if the two ever disagreed, and a
+  # language silently missing from a prepared image is the bug that costs most.
+  defp collect(results, names, success) do
+    if length(results) != length(names) do
+      raise "expected one result per language, got #{length(results)} for #{length(names)}"
+    end
+
+    {values, failures} =
+      [names, results]
+      |> Enum.zip()
+      |> Enum.reduce({[], %{}}, fn {name, result}, {values, failures} ->
+        case result do
+          {:error, reason} -> {values, Map.put(failures, name, reason)}
+          result -> {[success.(result, name) | values], failures}
+        end
+      end)
+
+    if failures == %{}, do: {:ok, Enum.reverse(values)}, else: {:error, failures}
   end
 end

--- a/packages/elixir/lumis/lib/lumis/native.ex
+++ b/packages/elixir/lumis/lib/lumis/native.ex
@@ -71,7 +71,8 @@ defmodule Lumis.Native do
   def language_bundles(), do: :erlang.nif_error(:nif_not_loaded)
   def load_language_by_name(_name), do: :erlang.nif_error(:nif_not_loaded)
 
-  def cache_language_by_name(_name, _force), do: :erlang.nif_error(:nif_not_loaded)
+  def cache_languages(_names, _force), do: :erlang.nif_error(:nif_not_loaded)
+  def precompile_languages(_names), do: :erlang.nif_error(:nif_not_loaded)
 
   def guess_language(_name, _source), do: :erlang.nif_error(:nif_not_loaded)
   def has_language(_name), do: :erlang.nif_error(:nif_not_loaded)

--- a/packages/elixir/lumis/lib/mix/tasks/lumis.languages.cache.ex
+++ b/packages/elixir/lumis/lib/mix/tasks/lumis.languages.cache.ex
@@ -63,6 +63,8 @@ defmodule Mix.Tasks.Lumis.Languages.Cache do
   end
 
   defp verbose(names, options) do
+    names = Enum.reject(names, &(&1 in ~w(plaintext text txt plain)))
+
     cached =
       case Lumis.Languages.__cache_details__(names, force: options[:force] || false) do
         {:ok, details} -> Map.new(details)

--- a/packages/elixir/lumis/lib/mix/tasks/lumis.languages.cache.ex
+++ b/packages/elixir/lumis/lib/mix/tasks/lumis.languages.cache.ex
@@ -11,6 +11,7 @@ defmodule Mix.Tasks.Lumis.Languages.Cache do
       mix lumis.languages.cache bundle_web
       mix lumis.languages.cache --all
       mix lumis.languages.cache --force elixir
+      mix lumis.languages.cache --verbose bundle_web
 
   Parsers land under `$LUMIS_DATA_DIR`, or wherever `config :lumis, data_dir:`
   points, and are verified against the size and SHA-256 in their language
@@ -21,31 +22,115 @@ defmodule Mix.Tasks.Lumis.Languages.Cache do
   `config :lumis, data_dir:`, and nothing needs the network. It expects the
   directory holding `parsers/`, not `parsers/` itself.
 
-  Each parser is also loaded once, so Wasmtime writes its compiled form beside
+  Each parser is also compiled once, so Wasmtime writes its compiled form beside
   it and the first request pays neither the download nor the compile.
+
+  Downloads and compiles both run concurrently, which is what makes a large
+  bundle finish in a reasonable time. Every language is attempted, so one
+  unpublished parser is reported alongside the rest rather than ending the run.
+
+  ## Options
+
+    * `--all` — every language in the catalog
+    * `--force` — resolve the compatible package range again and replace
+      parsers already cached
+    * `--verbose` — show each language's source, destination, and timings;
+      otherwise only a summary is printed
   """
 
   use Mix.Task
 
   @shortdoc "Downloads Lumis parser WASMs ahead of time"
 
-  @switches [all: :boolean, force: :boolean]
+  @switches [all: :boolean, force: :boolean, verbose: :boolean]
 
   @impl Mix.Task
   def run(arguments) do
     Mix.Task.run("app.start")
     {options, languages} = parse_arguments(arguments)
 
-    # Expanded here rather than left to `cache/2` so a bundle reports how many
-    # parsers it actually covers, and an unknown one fails before downloading.
+    # Expanded once here rather than separately inside each step, so downloading
+    # and compiling cover exactly the same set, and an unknown bundle fails
+    # before anything is fetched.
     names = options |> languages(languages) |> expand!()
 
-    case Lumis.Languages.cache(names, cache_options(options)) do
-      {:ok, paths} -> Enum.each(paths, fn path -> Mix.shell().info(path) end)
-      {:error, reason} -> Mix.raise(format_reason(reason))
+    if options[:verbose] do
+      verbose(names, options)
+    else
+      download(names, options)
+      compile(names)
     end
+  end
 
-    compile(names)
+  defp verbose(names, options) do
+    cached =
+      case Lumis.Languages.__cache_details__(names, force: options[:force] || false) do
+        {:ok, details} -> Map.new(details)
+        {:error, reason} -> Mix.raise("could not cache: " <> format_reason(reason))
+      end
+
+    compiled =
+      case Lumis.Languages.__precompile_details__(names) do
+        {:ok, details} -> Map.new(details)
+        {:error, reason} -> Mix.raise("could not compile: " <> format_reason(reason))
+      end
+
+    Enum.each(names, fn name ->
+      {download_url, path, cache_elapsed} = Map.fetch!(cached, name)
+      Mix.shell().info("--> #{name}")
+      if download_url, do: Mix.shell().info("downloading from #{download_url}")
+      Mix.shell().info("downloaded to #{display_path(path)}")
+      Mix.shell().info("cached in #{seconds(cache_elapsed)}s")
+      Mix.shell().info("compiled in #{seconds(Map.fetch!(compiled, name))}s")
+    end)
+  end
+
+  # Counted in parsers rather than languages because a handful of languages share
+  # one grammar, so the two numbers differ and the file count is what landed on
+  # disk. `compile/1` reports languages, which is what the caller named.
+  defp download(names, options) do
+    case timed(fn -> Lumis.Languages.cache(names, force: options[:force] || false) end) do
+      {{:ok, paths}, elapsed} ->
+        Mix.shell().info("cached #{length(paths)} parser(s) in #{elapsed}s")
+
+      {{:error, reason}, _elapsed} ->
+        Mix.raise("could not cache: " <> format_reason(reason))
+    end
+  end
+
+  # Downloading is only half the first-request cost: Wasmtime still compiles each
+  # parser to native code, which is the larger half. Validating each one through
+  # a disposable Tree-sitter store also catches failures that compilation alone
+  # cannot, without retaining a full catalog in one store.
+  defp compile(names) do
+    case timed(fn -> Lumis.Languages.__precompile__(names) end) do
+      {{:ok, compiled}, elapsed} ->
+        Mix.shell().info("compiled #{length(compiled)} language(s) in #{elapsed}s")
+
+      {{:error, failures}, _elapsed} when is_map(failures) ->
+        Mix.raise("could not compile: " <> format_reason(failures))
+
+      {{:error, reason}, _elapsed} ->
+        Mix.raise("could not compile: " <> format_reason(reason))
+    end
+  end
+
+  defp timed(fun) do
+    {microseconds, result} = :timer.tc(fun)
+    {result, seconds(microseconds / 1_000_000)}
+  end
+
+  defp seconds(value), do: :erlang.float_to_binary(value, decimals: 3)
+
+  defp display_path(path) do
+    expanded = Path.expand(path)
+    relative = Path.relative_to(expanded, File.cwd!())
+
+    if relative == expanded or relative == ".." or String.starts_with?(relative, "../") do
+      path
+    else
+      relative
+    end
   end
 
   defp expand!(names) do
@@ -57,28 +142,14 @@ defmodule Mix.Tasks.Lumis.Languages.Cache do
 
   defp format_reason({:unknown_bundle, name}), do: "unknown bundle #{inspect(name)}"
   defp format_reason(reason) when is_binary(reason), do: reason
-  defp format_reason(reason), do: inspect(reason)
 
-  # Downloading is only half the first-request cost: Wasmtime still compiles each
-  # parser to native code, which is the larger half. Loading them here writes
-  # that into `compiled/` beside the parsers, so an image ships both.
-  defp compile(names) do
-    case Lumis.Languages.load(names) do
-      :ok ->
-        Mix.shell().info("compiled #{length(names)} parser(s)")
-
-      {:error, failures} ->
-        Mix.raise("could not load: " <> format_failures(failures))
-    end
-  end
-
-  defp format_failures(failures) when is_map(failures) do
+  defp format_reason(failures) when is_map(failures) do
     failures
     |> Enum.sort()
     |> Enum.map_join(", ", fn {name, reason} -> "#{name} (#{reason})" end)
   end
 
-  defp format_failures(reason), do: to_string(reason)
+  defp format_reason(reason), do: inspect(reason)
 
   defp parse_arguments(arguments) do
     case OptionParser.parse(arguments, strict: @switches) do
@@ -101,9 +172,5 @@ defmodule Mix.Tasks.Lumis.Languages.Cache do
     else
       languages
     end
-  end
-
-  defp cache_options(options) do
-    [force: options[:force] || false]
   end
 end

--- a/packages/elixir/lumis/native/lumis_nif/Cargo.lock
+++ b/packages/elixir/lumis/native/lumis_nif/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
 name = "lumis_nif"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "lumis-core",
  "lumis-wasm-runtime",
  "once_cell",

--- a/packages/elixir/lumis/native/lumis_nif/Cargo.toml
+++ b/packages/elixir/lumis/native/lumis_nif/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+anyhow = "1"
 once_cell = "1.21"
 parking_lot = "0.12"
 rustler = "0.38"

--- a/packages/elixir/lumis/native/lumis_nif/src/lib.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/lib.rs
@@ -4,6 +4,7 @@ use std::thread;
 
 mod elixir;
 
+use anyhow::{anyhow, Context, Result};
 use elixir::{ExCssOptions, ExFormatterOption, ExTheme};
 use lumis_core::events::HighlightEvent;
 use lumis_core::{languages, themes};
@@ -17,17 +18,14 @@ use rustler::{Encoder, Env, Error, NifMap, NifResult, Term};
 static THEME_CACHE: Lazy<RwLock<HashMap<String, ExTheme>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
 
-static EXECUTOR: Lazy<Result<WasmExecutor, String>> = Lazy::new(WasmExecutor::new);
+static EXECUTOR: Lazy<Result<WasmExecutor>> = Lazy::new(WasmExecutor::new);
+static CACHE_BATCH: Lazy<parking_lot::Mutex<()>> = Lazy::new(|| parking_lot::Mutex::new(()));
+static PRECOMPILE_BATCH: Lazy<parking_lot::Mutex<()>> = Lazy::new(|| parking_lot::Mutex::new(()));
 
 enum WasmJob {
     LoadNamed {
         name: String,
         reply: mpsc::SyncSender<Result<(), RuntimeError>>,
-    },
-    CacheNamed {
-        name: String,
-        force: bool,
-        reply: mpsc::SyncSender<Result<String, String>>,
     },
     Highlight {
         source: String,
@@ -82,7 +80,7 @@ struct WasmExecutor {
 }
 
 impl WasmExecutor {
-    fn new() -> Result<Self, String> {
+    fn new() -> Result<Self> {
         // Sized to the machine, not capped. These threads exist for their 8 MiB
         // stacks: nested injections recurse per layer and overflow the BEAM
         // dirty-scheduler default, which crashes the VM rather than erroring.
@@ -99,10 +97,9 @@ impl WasmExecutor {
                 }
                 Ok(runtime)
             })
-            .map_err(|error| error.to_string())?
+            .context("could not spawn the Lumis WASM runtime initializer")?
             .join()
-            .map_err(|_| "Lumis WASM runtime initialization panicked".to_string())?
-            .map_err(|error| error.to_string())?;
+            .map_err(|_| anyhow!("Lumis WASM runtime initialization panicked"))??;
         let runtime = Arc::new(runtime);
         let (sender, receiver) = mpsc::sync_channel::<WasmJob>(workers * 2);
         let receiver = Arc::new(Mutex::new(receiver));
@@ -122,10 +119,6 @@ impl WasmExecutor {
                         WasmJob::LoadNamed { name, reply } => {
                             let _ = reply.send(runtime.load_named_language(&name));
                         }
-                        WasmJob::CacheNamed { name, force, reply } => {
-                            let _ =
-                                reply.send(cache_named_language(runtime.as_ref(), &name, force));
-                        }
                         WasmJob::Highlight {
                             source,
                             language,
@@ -137,7 +130,7 @@ impl WasmExecutor {
                         }
                     }
                 })
-                .map_err(|error| error.to_string())?;
+                .with_context(|| format!("could not spawn Lumis WASM worker {index}"))?;
         }
 
         Ok(Self { runtime, sender })
@@ -158,20 +151,6 @@ impl WasmExecutor {
             Err(RuntimeError::LanguageNotLoaded(_)) => Err(LoadFailure::UnknownLanguage),
             Err(_) => Err(LoadFailure::Parser),
         }
-    }
-
-    fn cache_named_language(&self, name: &str, force: bool) -> Result<String, String> {
-        let (reply, result) = mpsc::sync_channel(1);
-        self.sender
-            .send(WasmJob::CacheNamed {
-                name: name.to_string(),
-                force,
-                reply,
-            })
-            .map_err(|_| "WASM executor is unavailable".to_string())?;
-        result
-            .recv()
-            .map_err(|_| "WASM executor stopped while caching the language".to_string())?
     }
 
     fn highlight(
@@ -287,7 +266,7 @@ pub fn highlight<'a>(env: Env<'a>, source: &'a str, options: ExOptions) -> NifRe
     } else {
         let executor = match executor() {
             Ok(executor) => executor,
-            Err(message) => return Ok((error(), message).encode(env)),
+            Err(reason) => return Ok((error(), format!("{reason:#}")).encode(env)),
         };
         match executor.highlight(source, language.id_name(), rainbow_brackets) {
             Ok(events) => events,
@@ -309,8 +288,8 @@ pub fn highlight<'a>(env: Env<'a>, source: &'a str, options: ExOptions) -> NifRe
     Ok((ok(), output).encode(env))
 }
 
-fn executor() -> Result<&'static WasmExecutor, String> {
-    EXECUTOR.as_ref().map_err(Clone::clone)
+fn executor() -> Result<&'static WasmExecutor> {
+    EXECUTOR.as_ref().map_err(|error| anyhow!("{error:#}"))
 }
 
 /// Point the store at `data_dir`, overriding `LUMIS_DATA_DIR`.
@@ -345,30 +324,114 @@ fn load_language_by_name<'a>(env: Env<'a>, name: &str) -> Term<'a> {
     }
 }
 
-/// Download and cache without loading, for `mix lumis.languages.cache`.
+/// Stack for a thread that resolves TLS or runs Cranelift.
 ///
-/// Returns the path the parser was written to.
+/// Both want far more than a BEAM dirty scheduler carries, and overrunning one
+/// takes the whole emulator down rather than raising. The executor's workers are
+/// sized the same way, for the same reason.
+const DEEP_STACK: usize = 8 * 1024 * 1024;
+
+/// Run `work` on a thread with a stack the emulator's own do not have.
+///
+/// The batch entry points below do their work on the calling thread when there
+/// is only one item, and `parallel_map` drains from the caller too, so a dirty
+/// scheduler must not be the thread that ends up running either.
+fn on_deep_stack<Output: Send>(work: impl FnOnce() -> Output + Send) -> Result<Output> {
+    std::thread::scope(|scope| {
+        thread::Builder::new()
+            .name("lumis-batch".into())
+            .stack_size(DEEP_STACK)
+            .spawn_scoped(scope, work)
+            .context("could not spawn the Lumis batch thread")?
+            .join()
+            .map_err(|_| anyhow!("the Lumis batch thread panicked"))
+    })
+}
+
+/// Download and cache `names` concurrently, for `mix lumis.languages.cache`.
+///
+/// One result per name, in order, so the caller reports every language that
+/// could not be obtained instead of stopping at the first. Caching a bundle one
+/// language at a time is a hundred sequential round trips to the CDN.
+///
+/// Downloading needs no Wasmtime runtime, so this goes straight to a store
+/// rather than waking the executor.
 #[rustler::nif(schedule = "DirtyIo")]
-fn cache_language_by_name<'a>(env: Env<'a>, name: &str, force: bool) -> Term<'a> {
-    let executor = match executor() {
-        Ok(executor) => executor,
-        Err(message) => return (error(), message).encode(env),
-    };
-    match executor.cache_named_language(name, force) {
-        Ok(path) => (ok(), path).encode(env),
-        Err(message) => (error(), message).encode(env),
+fn cache_languages<'a>(env: Env<'a>, names: Vec<String>, force: bool) -> Term<'a> {
+    let results = on_deep_stack(|| {
+        let _batch = CACHE_BATCH.lock();
+        language_store(None)
+            .cache_languages_detailed(&names, force, lumis_wasm_runtime::DOWNLOAD_CONCURRENCY)
+            .into_iter()
+            .map(|result| result.map_err(|failure| failure.to_string()))
+            .collect::<Vec<_>>()
+    });
+
+    match results {
+        Ok(results) => results
+            .into_iter()
+            .map(|result| match result {
+                Ok(outcome) => {
+                    let details = (
+                        outcome.download_url,
+                        outcome.path.display().to_string(),
+                        duration_seconds(outcome.elapsed),
+                    );
+                    (ok(), details).encode(env)
+                }
+                Err(message) => (error(), message).encode(env),
+            })
+            .collect::<Vec<_>>()
+            .encode(env),
+        Err(error) => repeated_failure(env, &format!("{error:#}"), names.len()),
     }
 }
 
-/// Caching needs no Wasmtime runtime, but it does do a TLS handshake, so it
-/// still runs on an executor thread rather than a dirty scheduler.
-fn cache_named_language(runtime: &Runtime, name: &str, force: bool) -> Result<String, String> {
-    runtime
-        .store()
-        .ok_or_else(|| "this runtime has no language store".to_string())?
-        .cache_language(name, force)
-        .map(|path| path.display().to_string())
-        .map_err(|error| error.to_string())
+/// Compile `names` into the on-disk Wasmtime cache without loading them.
+///
+/// Downloading is the smaller half of a cold parser; the Cranelift compile is
+/// the larger, and this is what puts it in the image. One result per name, in
+/// order.
+#[rustler::nif(schedule = "DirtyCpu")]
+fn precompile_languages<'a>(env: Env<'a>, names: Vec<String>) -> Term<'a> {
+    let executor = match executor() {
+        Ok(executor) => executor,
+        Err(error) => return repeated_failure(env, &format!("{error:#}"), names.len()),
+    };
+
+    let results = on_deep_stack(|| {
+        let _batch = PRECOMPILE_BATCH.lock();
+        executor
+            .runtime
+            .precompile_languages_detailed(&names, lumis_wasm_runtime::compile_concurrency())
+            .into_iter()
+            .map(|result| result.map(duration_seconds))
+            .map(|result| result.map_err(|failure| failure.to_string()))
+            .collect::<Vec<_>>()
+    });
+
+    match results {
+        Ok(results) => results
+            .into_iter()
+            .map(|result| match result {
+                Ok(seconds) => (ok(), seconds).encode(env),
+                Err(message) => (error(), message).encode(env),
+            })
+            .collect::<Vec<_>>()
+            .encode(env),
+        Err(error) => repeated_failure(env, &format!("{error:#}"), names.len()),
+    }
+}
+
+fn duration_seconds(duration: std::time::Duration) -> f64 {
+    duration.as_secs_f64()
+}
+
+/// One failure per name, for the cases that fail before any name is attempted.
+/// The batch NIFs answer positionally, so the list still has to line up.
+fn repeated_failure<'a>(env: Env<'a>, message: &str, count: usize) -> Term<'a> {
+    let failure = (error(), message).encode(env);
+    vec![failure; count].encode(env)
 }
 
 /// Dirty because the source is caller-supplied and unbounded: detection runs

--- a/packages/elixir/lumis/test/lumis/languages_test.exs
+++ b/packages/elixir/lumis/test/lumis/languages_test.exs
@@ -311,6 +311,16 @@ defmodule Lumis.LanguagesTest do
       refute output =~ "tree-sitter-comment-"
     end
 
+    test "skips parserless languages with --verbose" do
+      output =
+        capture_io(fn ->
+          Mix.Task.reenable("lumis.languages.cache")
+          Mix.Task.run("lumis.languages.cache", ["--verbose", "plaintext"])
+        end)
+
+      assert output == ""
+    end
+
     test "reports per-language details without totals with --verbose" do
       output =
         capture_io(fn ->

--- a/packages/elixir/lumis/test/lumis/languages_test.exs
+++ b/packages/elixir/lumis/test/lumis/languages_test.exs
@@ -266,21 +266,66 @@ defmodule Lumis.LanguagesTest do
       assert File.exists?(Path.join([@store, "parsers", "python.lumis.json"]))
     end
 
-    test "reports an unknown language" do
+    test "preserves the single-language error shape" do
       assert {:error, reason} = Lumis.Languages.cache(["not-a-language"])
       assert reason =~ "not-a-language"
+    end
+
+    test "reports every failure rather than stopping at the first" do
+      assert {:error, failures} = Lumis.Languages.cache(["not-a-language", "also-not", "comment"])
+      assert Map.keys(failures) |> Enum.sort() == ["also-not", "not-a-language"]
+    end
+  end
+
+  describe "build-time parser validation" do
+    test "returns the languages it compiled" do
+      assert {:ok, _} = Lumis.Languages.cache(["comment"])
+      assert {:ok, ["comment"]} = Lumis.Languages.__precompile__(["comment"])
+    end
+
+    test "skips names that have no parser to compile" do
+      assert {:ok, []} = Lumis.Languages.__precompile__(["plaintext"])
+    end
+
+    test "reports failures by name rather than stopping at the first" do
+      assert {:error, %{"not-a-language" => _}} =
+               Lumis.Languages.__precompile__(["not-a-language"])
+    end
+
+    test "rejects an unknown bundle" do
+      assert {:error, {:unknown_bundle, "bundle_nope"}} =
+               Lumis.Languages.__precompile__([:bundle_nope])
     end
   end
 
   describe "mix lumis.languages.cache" do
-    test "writes the named parsers and prints their paths" do
+    test "summarizes instead of listing every parser" do
       output =
         capture_io(fn ->
           Mix.Task.reenable("lumis.languages.cache")
           Mix.Task.run("lumis.languages.cache", ["comment"])
         end)
 
+      assert output =~ ~r/cached 1 parser\(s\) in \d+\.\d{3}s/
+      assert output =~ ~r/compiled 1 language\(s\) in \d+\.\d{3}s/
+      refute output =~ "tree-sitter-comment-"
+    end
+
+    test "reports per-language details without totals with --verbose" do
+      output =
+        capture_io(fn ->
+          Mix.Task.reenable("lumis.languages.cache")
+          Mix.Task.run("lumis.languages.cache", ["--verbose", "comment"])
+        end)
+
+      assert output =~ "--> comment"
+      assert output =~ "downloaded to "
       assert output =~ "tree-sitter-comment-"
+      refute output =~ "downloaded to #{File.cwd!()}"
+      assert output =~ ~r/cached in \d+\.\d{3}s/
+      assert output =~ ~r/compiled in \d+\.\d{3}s/
+      refute output =~ ~r/cached \d+ parser/
+      refute output =~ ~r/compiled \d+ language/
     end
 
     test "refuses to guess when given neither names nor --all" do


### PR DESCRIPTION
## Summary

- cache parser bundles concurrently instead of making one CDN round trip at a time
- validate parsers and queries in disposable Tree-sitter stores so `bundle_full` does not exhaust one shared store
- bound download, compile, and NIF batch concurrency to control memory and CDN usage
- keep normal cache output concise and add per-language source, destination, cache time, and compile time under `--verbose`
- align the CLI and Elixir build-time cache paths and document the preparation model

## Motivation

`mix lumis.languages.cache bundle_full` took about 239 seconds and then failed while loading `systemverilog`. It also printed every parser path by default, making Docker build output noisy.

The cache command now performs downloads concurrently, validates each parser and its queries without retaining the full catalog, and reports only two summary lines unless verbose output is requested.

A local cold full-bundle validation completed successfully with 113 parser packages and 115 language definitions:

```text
cached 113 parser(s) in 0.421s
compiled 115 language(s) in 37.630s
```

## Validation

- `cargo test -p lumis-wasm-runtime --all-features`
- `cargo test -p lumis-cli`
- `cargo test --manifest-path packages/elixir/lumis/native/lumis_nif/Cargo.toml`
- `cargo clippy -p lumis-wasm-runtime -p lumis-cli --all-targets --all-features -- -D warnings`
- `cargo clippy --manifest-path packages/elixir/lumis/native/lumis_nif/Cargo.toml --all-targets -- -D warnings`
- `mise run test-elixir`
- `mise run elixir-nif-lock-check`
- Rust and Elixir format checks
- local `mix lumis.languages.cache bundle_full` and `--verbose --force` runs
