### PR TITLE
docs: add next release migration steps

### DIFF
--- a/crates/lumis-cli/CHANGELOG.md
+++ b/crates/lumis-cli/CHANGELOG.md
@@ -1,3 +1,21 @@
+## Next release migration
+
+Why: commands now use one vocabulary.
+
+1. Replace `lumis parsers fetch <names>` with `lumis languages cache <names>`.
+2. Replace `lumis parsers update <names>` with `lumis languages cache --force <names>`.
+3. Use `-H` for highlighted lines and `-h` for help.
+4. Use `-V` for version and `-v` for verbose output.
+5. Remove flags rejected by `lumis formatters show <name>`.
+
+Why: `--all` now means every language.
+
+1. Name languages explicitly to refresh only selected cache entries.
+
+Why: HTML output now matches.
+
+1. Regenerate exact HTML snapshots.
+
 ## [0.4.2](https://github.com/leandrocp/lumis/compare/cargo-lumis-cli/v0.4.1...cargo-lumis-cli/v0.4.2) (2026-07-23)
 
 

--- a/crates/lumis/CHANGELOG.md
+++ b/crates/lumis/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Next release migration
+
+Why: catalog shapes now match.
+
+1. Treat `available_languages()` as a sorted `Vec<LanguageInfo>`, not a `HashMap`.
+2. Use `Language::Rust.info()` for known languages; search the vector for dynamic ids.
+
+Why: HTML output now matches.
+
+1. Regenerate exact HTML snapshots.
+2. Expect attribute-less tokens as `<span>...</span>`.
+3. Expect compact, sorted multi-theme CSS and `light-dark()` highlighted-line backgrounds.
+
 ## [0.12.1](https://github.com/leandrocp/lumis/compare/cargo-lumis/v0.12.0...cargo-lumis/v0.12.1) (2026-07-23)
 
 

--- a/packages/elixir/lumis/CHANGELOG.md
+++ b/packages/elixir/lumis/CHANGELOG.md
@@ -1,3 +1,28 @@
+## Next release migration
+
+Why: parsers now use shared packages.
+
+1. Online deployments need no change.
+2. During the build, cache every root and injected language with `mix lumis.languages.cache <names>`.
+
+Why: defaults now match.
+
+1. Add `theme: "onedark"` to `:html_inline` and `:terminal` to keep old colors.
+
+Why: catalogs now share one shape.
+
+1. Replace `Lumis.available_languages()["elixir"]` with `Lumis.Languages.get("elixir")`.
+2. Get theme names with `Enum.map(Lumis.available_themes(), & &1.name)`.
+
+Why: errors are now explicit.
+
+1. Use `Lumis.highlight!/2` to keep raising.
+2. Otherwise handle `{:ok, output}` and `{:error, reason}`.
+
+Why: HTML output now matches.
+
+1. Regenerate exact HTML snapshots.
+
 ## [0.6.3](https://github.com/leandrocp/lumis/compare/hex-lumis/v0.6.2...hex-lumis/v0.6.3) (2026-07-23)
 
 

--- a/packages/javascript/cli/CHANGELOG.md
+++ b/packages/javascript/cli/CHANGELOG.md
@@ -1,3 +1,21 @@
+## Next release migration
+
+Why: commands now use one vocabulary.
+
+1. Replace `lumis parsers fetch <names>` with `lumis languages cache <names>`.
+2. Replace `lumis parsers update <names>` with `lumis languages cache --force <names>`.
+3. Use `-H` for highlighted lines and `-h` for help.
+4. Use `-V` for version and `-v` for verbose output.
+5. Remove flags rejected by `lumis formatters show <name>`.
+
+Why: `--all` now means every language.
+
+1. Name languages explicitly to refresh only selected cache entries.
+
+Why: HTML output now matches.
+
+1. Regenerate exact HTML snapshots.
+
 ## [0.5.0](https://github.com/leandrocp/lumis/compare/npm-cli/v0.4.1...npm-cli/v0.5.0) (2026-07-23)
 
 

--- a/packages/javascript/lumis/CHANGELOG.md
+++ b/packages/javascript/lumis/CHANGELOG.md
@@ -1,3 +1,29 @@
+## Next release migration
+
+Why: parsers and queries are now atomic.
+
+1. Built-in `@lumis-sh/lumis/langs/*` imports need no change.
+2. Replace custom objects carrying query fields with `{id, aliases, packageName}` package handles.
+3. Resolve package `lumis.json` files with `languagePackageResolver`.
+4. Use `wasmResolver` or `withWasm()` only to override verified parser bytes.
+5. Add exact `sha256` and `size` values to manually created `WasmRef` objects.
+
+Why: invalid formatter options now fail.
+
+1. Give `htmlMultiThemes()` at least one theme.
+2. Make `defaultTheme` name one of them; `light-dark()` requires `light` and `dark`.
+
+Why: Node runtimes now share one cache.
+
+1. Expect one parser download into the shared macOS or Windows directory.
+2. Set `LUMIS_DATA_DIR` to keep a fixed location.
+
+Why: HTML output now matches.
+
+1. Regenerate exact HTML snapshots.
+2. Expect attribute-less tokens as `<span>...</span>`.
+3. Expect compact, sorted multi-theme CSS and `light-dark()` highlighted-line backgrounds.
+
 ## [0.6.1](https://github.com/leandrocp/lumis/compare/npm-lumis/v0.6.0...npm-lumis/v0.6.1) (2026-07-23)
 
 


### PR DESCRIPTION
## Summary

- add concise migration steps to the five affected public package changelogs
- cover Rust, CLI, Elixir, JavaScript, and rendered HTML breaking changes
- leave internal packages and packages requiring no migration unchanged

## Why

The next minor release wave contains breaking changes across packages. Keeping each migration beside its package release notes makes the required action immediately visible.

The audit starts at each package's latest release: `lumis` 0.12.1, `lumis-cli` 0.4.2, `@lumis-sh/lumis` 0.6.1, `@lumis-sh/cli` 0.5.0, and Hex `lumis` 0.6.3.

## User impact

Users get short replacement steps for changed catalog shapes, CLI commands and flags, Elixir behavior, JavaScript language packages, cache locations, formatter validation, and exact HTML output.

## Validation

- audited intervening changes and PRs from each package release tag
- rebased onto current `main`
- `git diff --check`