### PR TITLE
perf(website): warm parsers concurrently and serve their metadata locally

### DIFF
--- a/website/src/app.ts
+++ b/website/src/app.ts
@@ -12,8 +12,16 @@ import { renderRuntimes } from "./sections/runtimes";
 import { renderIntegrations } from "./sections/integrations";
 import { renderFooter } from "./sections/footer";
 import { setupTabs, setupCopyButtons, SECTION_DIVIDER } from "./lib/utils";
+import { FIRST_PAINT_LANGUAGES } from "./data/languages";
+import { loadLanguages } from "./lib/highlighter";
 
 export async function mountApp(root: HTMLDivElement) {
+  // Started before the markup exists, and deliberately not awaited: every
+  // section below still loads what it needs on demand, so this only decides
+  // whether those parsers are already in flight by the time they ask. Awaiting
+  // it would make the whole page wait for the slowest one.
+  void loadLanguages(FIRST_PAINT_LANGUAGES);
+
   root.innerHTML = [
     '<a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:bg-zinc-900 focus:px-4 focus:py-2 focus:font-mono focus:text-sm focus:text-white dark:focus:bg-white dark:focus:text-zinc-900">Skip to content</a>',
     renderNav(),
@@ -47,7 +55,10 @@ export async function mountApp(root: HTMLDivElement) {
   setupTabs(root, ".install-tab", "install", "[data-install-panel]", "installPanel");
   setupCopyButtons(root);
 
-  await setupPlayground(root);
+  // Playground first, so its parser and theme are the first things asked for,
+  // but not awaited: nothing below needs its result, and `main.ts` does not wait
+  // on `mountApp`, so awaiting only held the other four sections back.
+  void setupPlayground(root);
   void setupTokenInspector(root);
   void setupStreaming(root);
   void setupQuickstart(root);

--- a/website/src/data/languages.ts
+++ b/website/src/data/languages.ts
@@ -25,4 +25,38 @@ export const LANGUAGES: LanguageOption[] = Object.entries(bundledLanguages)
 
 export const LANGUAGES_BY_ID = new Map(LANGUAGES.map((language) => [language.id, language]));
 
+/**
+ * What the Playground shows before the visitor picks anything.
+ *
+ * Fixed rather than random so the first thing a visitor sees is the same every
+ * time, and so the parser behind it can be warmed while the page is still
+ * rendering. Rust is the reference runtime, leads the install tabs, and its
+ * sample carries doc comments with a fenced code block in them, so injections
+ * show up without anyone having to go looking for them.
+ */
+export const PLAYGROUND_DEFAULT_LANGUAGE = "rust";
+
+/**
+ * The languages this page highlights before any interaction: the Playground
+ * default, every Quickstart tab, and the injections demo.
+ *
+ * Warming these is not what makes them work — every section still loads what it
+ * needs on demand — it only starts the fetches together and early instead of
+ * one at a time as each section reaches them. An entry that drifts out of date
+ * costs that head start and nothing else.
+ *
+ * The streaming demo's `markdown` is deliberately absent: that section waits for
+ * the visitor to scroll to it, so warming it would download a parser for a
+ * section most visits never reach.
+ */
+export const FIRST_PAINT_LANGUAGES = [
+  PLAYGROUND_DEFAULT_LANGUAGE,
+  "bash",
+  "javascript",
+  "elixir",
+  "java",
+  "html",
+  "css",
+];
+
 export { getSample };

--- a/website/src/lib/highlight-worker.ts
+++ b/website/src/lib/highlight-worker.ts
@@ -1,4 +1,10 @@
-import { configureWasmResolver, createHighlighter } from "@lumis-sh/lumis";
+import {
+  configureLanguagePackageResolver,
+  configureWasmResolver,
+  highlight,
+  loadedLanguages,
+  loadLanguages,
+} from "@lumis-sh/lumis";
 import { bundledLanguages } from "@lumis-sh/lumis/bundles/full";
 import { htmlInline, htmlMultiThemes } from "@lumis-sh/lumis/formatters";
 import type { Language, Theme } from "@lumis-sh/lumis";
@@ -26,6 +32,16 @@ const wasmVersions = import.meta.glob<string>(
   { eager: true, import: "version" },
 );
 
+const languagePackages = import.meta.glob<string>(
+  [
+    "../../node_modules/@lumis-sh/wasm-*/lumis.json",
+    "../../node_modules/.pnpm/@lumis-sh+wasm-*/node_modules/@lumis-sh/wasm-*/lumis.json",
+    "!../../node_modules/@lumis-sh/wasm-bundle-*/lumis.json",
+    "!../../node_modules/.pnpm/@lumis-sh+wasm-bundle-*/node_modules/@lumis-sh/wasm-bundle-*/lumis.json",
+  ],
+  { eager: true, import: "default", query: "?url" },
+);
+
 const versionByDirectory = new Map(
   Object.entries(wasmVersions).map(([path, version]) => [directoryOf(path), version]),
 );
@@ -46,6 +62,17 @@ const wasmUrls = new Map(
   }),
 );
 
+const packageUrls = new Map(
+  Object.entries(languagePackages).map(([path, url]) => {
+    const match = path.match(/(@lumis-sh\/wasm-[^/]+)\/lumis\.json$/);
+    if (!match) {
+      throw new Error(`Could not derive the language package name from ${path}`);
+    }
+
+    return [match[1], url];
+  }),
+);
+
 function directoryOf(path: string) {
   return path.slice(0, path.lastIndexOf("/"));
 }
@@ -61,34 +88,24 @@ configureWasmResolver((_language, wasm) => {
   return wasmUrls.get(file) ?? `https://cdn.jsdelivr.net/npm/${file}`;
 });
 
-const languageCache = new Map<string, Promise<Language>>();
-const highlighterPromise = createHighlighter();
-let highlighterQueue = Promise.resolve();
-
-function withHighlighter<T>(fn: () => Promise<T> | T): Promise<T> {
-  const task = highlighterQueue.then(fn, fn);
-  highlighterQueue = task.then(
-    () => undefined,
-    () => undefined,
+// Serving the metadata locally is what keeps the parser local too. The manifest
+// names the exact version and digest the parser is then fetched by, so reading
+// it from the CDN can name a release newer than the one `pnpm` installed, and
+// the resolver above would miss and pull megabytes over the network for a file
+// already in the build. Both come from the same directory, or neither does.
+configureLanguagePackageResolver((packageName, versionRange) => {
+  return (
+    packageUrls.get(packageName) ??
+    `https://cdn.jsdelivr.net/npm/${packageName}@${versionRange}/lumis.json`
   );
-  return task;
-}
+});
 
 async function getLanguage(languageId: string): Promise<Language> {
-  const existing = languageCache.get(languageId);
-  if (existing) return existing;
-
   const handle = bundledLanguages[languageId];
   if (!handle) {
     throw new Error(`Unknown language: ${languageId}`);
   }
-
-  const promise = (async () => {
-    return await handle();
-  })();
-
-  languageCache.set(languageId, promise);
-  return promise;
+  return handle();
 }
 
 export type WorkerRequest =
@@ -113,55 +130,47 @@ export type WorkerRequest =
 
 export type WorkerResponse =
   | { id: number; type: "result"; html: string }
-  | { id: number; type: "done" }
+  | { id: number; type: "done"; loaded: string[] }
   | { id: number; type: "error"; message: string };
 
 async function handleMessage(req: WorkerRequest): Promise<WorkerResponse> {
-  const hl = await highlighterPromise;
-
   switch (req.type) {
     case "highlight": {
-      const html = await withHighlighter(async () => {
-        const lang = await getLanguage(req.languageId);
-        await hl.loadLanguage(lang);
-        return hl.highlight(
-          req.source,
-          htmlInline({
-            language: lang,
-            theme: req.theme,
-            preClass: req.preClass ?? DEFAULT_PRE_CLASS,
-            includeHighlights: true,
-            italic: false,
-          }),
-        );
-      });
+      const language = await getLanguage(req.languageId);
+      const html = await highlight(
+        req.source,
+        htmlInline({
+          language,
+          theme: req.theme,
+          preClass: req.preClass ?? DEFAULT_PRE_CLASS,
+          includeHighlights: true,
+          italic: false,
+        }),
+      );
       return { id: req.id, type: "result", html };
     }
     case "highlightMultiTheme": {
-      const html = await withHighlighter(async () => {
-        const lang = await getLanguage(req.languageId);
-        await hl.loadLanguage(lang);
-        return hl.highlight(
-          req.source,
-          htmlMultiThemes({
-            language: lang,
-            themes: { light: req.lightTheme, dark: req.darkTheme },
-            defaultTheme: "light-dark()",
-            preClass: req.preClass ?? DEFAULT_PRE_CLASS,
-            italic: false,
-          }),
-        );
-      });
+      const language = await getLanguage(req.languageId);
+      const html = await highlight(
+        req.source,
+        htmlMultiThemes({
+          language,
+          themes: { light: req.lightTheme, dark: req.darkTheme },
+          defaultTheme: "light-dark()",
+          preClass: req.preClass ?? DEFAULT_PRE_CLASS,
+          italic: false,
+        }),
+      );
       return { id: req.id, type: "result", html };
     }
     case "loadLanguages": {
-      for (const id of req.languageIds) {
-        await withHighlighter(async () => {
-          const language = await getLanguage(id);
-          await hl.loadLanguage(language);
-        }).catch(() => {});
-      }
-      return { id: req.id, type: "done" };
+      // Warm-up is an optimization, so one unavailable parser reports itself and
+      // leaves the rest loaded rather than failing the batch. `loadLanguages`
+      // attempts every name concurrently and rejects with an AggregateError.
+      await loadLanguages(req.languageIds).catch((error: unknown) => {
+        console.warn("Lumis warm-up did not finish; languages load on demand", error);
+      });
+      return { id: req.id, type: "done", loaded: loadedLanguages() };
     }
   }
 }

--- a/website/src/lib/highlighter.ts
+++ b/website/src/lib/highlighter.ts
@@ -23,9 +23,17 @@ function send(req: Omit<WorkerRequest, "id">): Promise<WorkerResponse> {
   });
 }
 
-export async function loadLanguages(languageIds: string[]): Promise<void> {
+/**
+ * Load languages into the runtime the worker highlights with, concurrently.
+ *
+ * Returns every language the runtime now holds, so a caller can tell a warm
+ * language from one that still has to be fetched. Highlighting loads on demand
+ * regardless, so a caller that does not need the answer should not await this.
+ */
+export async function loadLanguages(languageIds: string[]): Promise<string[]> {
   const res = await send({ type: "loadLanguages", languageIds });
   if (res.type === "error") throw new Error(res.message);
+  return (res as Extract<WorkerResponse, { type: "done" }>).loaded;
 }
 
 export async function renderHighlight(

--- a/website/src/sections/playground.ts
+++ b/website/src/sections/playground.ts
@@ -1,4 +1,9 @@
-import { LANGUAGES, LANGUAGES_BY_ID, getSample } from "../data/languages";
+import {
+  LANGUAGES,
+  LANGUAGES_BY_ID,
+  PLAYGROUND_DEFAULT_LANGUAGE,
+  getSample,
+} from "../data/languages";
 import { loadTheme, THEMES, THEMES_BY_ID } from "../data/themes";
 import { renderHighlight } from "../lib/highlighter";
 
@@ -50,7 +55,10 @@ export async function setupPlayground(root: HTMLElement) {
   const preview = root.querySelector<HTMLDivElement>(".preview-content")!;
   const randomizeButton = root.querySelector<HTMLButtonElement>(".randomize")!;
 
-  languageSelect.value = pickRandom(LANGUAGES).id;
+  // The first render is the one the warm-up in `mountApp` has been fetching, so
+  // it has to name the same language every time. Randomizing is what the button
+  // is for.
+  languageSelect.value = PLAYGROUND_DEFAULT_LANGUAGE;
   themeSelect.value = pickRandom(THEMES).id;
 
   let renderToken = 0;

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -4,6 +4,12 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineConfig({
   plugins: [tailwindcss()],
   build: {
+    // Every parser's `lumis.json` is reachable from the worker, but a visit
+    // needs the handful of languages it actually highlights. Most are under the
+    // 4 kB default, so inlining put 46 of them in the worker chunk as base64 and
+    // grew it by 171 kB that every visitor downloads to use a few. Emitted as
+    // files, they are fetched only by the language that names one.
+    assetsInlineLimit: (filePath: string) => (filePath.endsWith("lumis.json") ? false : undefined),
     rollupOptions: {
       input: {
         main: fileURLToPath(new URL("index.html", import.meta.url)),


### PR DESCRIPTION
## Why

The Playground offers all 116 catalog languages. Every one was loaded one at a time through a serial queue in the highlight worker, and each load first made a jsDelivr round-trip for its `lumis.json`. On a first visit the eight parsers the page needs took **3.5–5.5 s** to arrive.

## What changed

**Warm-up uses `loadLanguages()`** (added in 0.7.0, #1273). It attempts every name concurrently and loads into the runtime `highlight()` already uses, so the worker drops its own `createHighlighter()` instance and the `withHighlighter` queue that serialized every load behind every render. That queue was not protecting anything: `highlight` is synchronous, and `loadLanguage` already dedupes both loaded and in-flight languages per runtime, so it only cost overlap.

**`configureLanguagePackageResolver` serves each `lumis.json` from the build**, the way the parser wasm already was. This is not just one saved round-trip per language — the manifest names the exact version and digest the parser is then fetched by, so reading it from the CDN could name a release newer than the one `pnpm` installed, and the wasm resolver would miss and pull megabytes from jsDelivr for a file already in the build. Verified: all 115 non-plaintext languages now resolve to a local manifest, zero CDN fallbacks.

**Vite no longer inlines those manifests.** Most are under the 4 kB default, so inlining put 46 of them in the worker chunk as base64 and grew it by 171 kB that every visitor downloads to use a handful. Emitted as files, the worker chunk costs +3.7 kB gzipped and a visit fetches only the languages it highlights.

**The Playground opens on Rust** instead of a random pick, so the parser behind the first render is one the warm-up has already been fetching, and the first thing a visitor sees is a language chosen to show the highlighter off — the baseline runs below opened on `http` and `perl`. Rust is the reference runtime, leads the install tabs, and its sample has a fenced code block inside a doc comment, so injections show up without going looking. The randomize button is still random.

## Measurements

Production build, cold cache, fresh origin, time until every first-paint parser is delivered:

| | baseline | this branch |
|---|---|---|
| run 1 | 3565 ms | **178 ms** |
| run 2 | 5503 ms | **219 ms** |
| parsers | 8 | 7 |
| `lumis.json` served locally | 0 of 8 | 7 of 7 |
| language on load | `http`, `perl` (random) | `rust` |

Isolating the two effects in Node against the browser entry, 12 languages:

| | time |
|---|---|
| sequential + CDN metadata (before) | 2826 ms |
| concurrent `loadLanguages()` | 661 ms |
| + local metadata | 589 ms |

## What this does not fix

**Switching to a single cold language is roughly unchanged.** It is dominated by the wasm download and the Tree-sitter compile, which this does not touch; only the metadata round-trip goes away. Fresh-origin samples were noisy and went both ways (haskell 2129→1634 ms, kotlin 1036→480 ms, but ruby 626→683 ms and zig 494→537 ms). The win here is first paint and any path that loads more than one language, not an individual switch.

**Warming all 116 is not viable** and this does not attempt it: the full set is 148.7 MB of parser wasm, with `systemverilog` alone at 21.8 MB against a 0.17 MB median. The warm set is the 7 languages the page paints before any interaction. `markdown` is deliberately excluded — the streaming demo waits for the visitor to scroll to it, so warming it would download a parser most visits never use. Everything else still loads on demand.

## Notes

- `tsc --noEmit` reports 4 pre-existing errors in `website/src`, unchanged by this PR (3 are `Omit<WorkerRequest, "id">` collapsing the union to its common keys in `send()`, so worker payloads are not actually typechecked; 1 is a null check in `streaming.ts`). Left alone as out of scope, but the `send()` one is worth a follow-up since it means the worker protocol is unvalidated.
- `pnpm lint` and `pnpm fmt` are clean.