### PR TITLE
fix(queries): remove the cmake predicate that highlights differently per runtime

### DIFF
--- a/crates/dev/src/main.rs
+++ b/crates/dev/src/main.rs
@@ -2189,6 +2189,18 @@ fn apply_text_replacements(content: &str, lang: &str) -> String {
             "\"nil\" @constant.builtin",
         );
     }
+    // Upstream pairs an optional capture with a predicate on it, and the two
+    // query engines disagree about a capture that matched nothing: the Rust
+    // binding treats it as vacuously true, web-tree-sitter as false, so
+    // `list(TRANSFORM x TOUPPER)` highlights differently in the browser. The
+    // pattern immediately above this one in the upstream file already covers
+    // the no-selector case, so requiring the selector here loses nothing.
+    if lang == "cmake" {
+        s = s.replace(
+            "(argument)? @_selector @constant",
+            "(argument) @_selector @constant",
+        );
+    }
     s
 }
 

--- a/crates/lumis/tests/query_predicates.rs
+++ b/crates/lumis/tests/query_predicates.rs
@@ -1,0 +1,147 @@
+//! Rust's half of the Tree-sitter predicate parity check.
+//!
+//! `fixtures/query-predicates.json` records, per case, the match count each
+//! engine produces. This asserts the `rust` column and re-derives the supported
+//! operator set from the data, so the checked-in list cannot drift from what the
+//! engines actually do. `packages/javascript/lumis/test/query-predicates.test.ts`
+//! does the same for `web-tree-sitter`.
+//!
+//! Gated on `lang-rust` because the corpus is Rust source. The predicate
+//! semantics under test do not vary per grammar, so one language is enough.
+#![cfg(feature = "lang-rust")]
+
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::PathBuf;
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Parser, Query, QueryCursor};
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    supported: Vec<String>,
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Case {
+    name: String,
+    operator: String,
+    source: String,
+    query: String,
+    rust: Outcome,
+    browser: Outcome,
+}
+
+/// A match count, or `"error"` when the engine rejects the query outright.
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+enum Outcome {
+    Matches(u32),
+    Error(String),
+}
+
+fn manifest() -> Manifest {
+    let path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/query-predicates.json");
+    serde_json::from_str(&fs::read_to_string(&path).expect("read query-predicates.json"))
+        .expect("parse query-predicates.json")
+}
+
+fn run(parser: &mut Parser, language: &tree_sitter::Language, case: &Case) -> Outcome {
+    let tree = parser.parse(&case.source, None).expect("source parses");
+    let Ok(query) = Query::new(language, &case.query) else {
+        return Outcome::Error("error".to_string());
+    };
+
+    let mut cursor = QueryCursor::new();
+    let mut matches = cursor.matches(&query, tree.root_node(), case.source.as_bytes());
+    let mut count = 0;
+    while matches.next().is_some() {
+        count += 1;
+    }
+    Outcome::Matches(count)
+}
+
+#[test]
+fn the_corpus_covers_every_text_predicate() {
+    let manifest = manifest();
+
+    // A discovery bug that found nothing would otherwise pass silently.
+    assert!(
+        manifest.cases.len() >= 70,
+        "corpus shrank to {} cases",
+        manifest.cases.len()
+    );
+
+    let covered: BTreeSet<&str> = manifest
+        .cases
+        .iter()
+        .map(|case| case.operator.as_str())
+        .collect();
+    let expected: BTreeSet<&str> = [
+        "eq?",
+        "not-eq?",
+        "any-eq?",
+        "any-not-eq?",
+        "any-of?",
+        "not-any-of?",
+        "match?",
+        "not-match?",
+        "any-match?",
+        "any-not-match?",
+    ]
+    .into();
+
+    assert_eq!(
+        covered, expected,
+        "every text predicate tree-sitter evaluates needs a verdict"
+    );
+}
+
+#[test]
+fn recorded_rust_results_still_hold() {
+    let manifest = manifest();
+    let language: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+    let mut parser = Parser::new();
+    parser.set_language(&language).expect("rust grammar loads");
+
+    for case in &manifest.cases {
+        let observed = run(&mut parser, &language, case);
+        assert_eq!(
+            observed, case.rust,
+            "{}: the Rust engine changed. Re-record the fixture.",
+            case.name
+        );
+    }
+}
+
+/// The supported list is a conclusion, not a decision: an operator is supported
+/// when no case makes the two engines disagree.
+#[test]
+fn supported_operators_match_the_measurements() {
+    let manifest = manifest();
+
+    let mut diverging: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for case in &manifest.cases {
+        if case.rust != case.browser {
+            diverging
+                .entry(case.operator.as_str())
+                .or_default()
+                .push(case.name.as_str());
+        }
+    }
+
+    let derived: BTreeSet<&str> = manifest
+        .cases
+        .iter()
+        .map(|case| case.operator.as_str())
+        .filter(|operator| !diverging.contains_key(operator))
+        .collect();
+    let declared: BTreeSet<&str> = manifest.supported.iter().map(String::as_str).collect();
+
+    assert_eq!(
+        derived, declared,
+        "`supported` disagrees with the recorded results; diverging cases: {diverging:?}"
+    );
+}

--- a/fixtures/query-predicates.json
+++ b/fixtures/query-predicates.json
@@ -1,0 +1,618 @@
+{
+  "$comment": [
+    "Where Lumis's two query engines disagree about text predicates.",
+    "",
+    "Text predicates are not implemented in the Tree-sitter C library; each binding",
+    "evaluates them itself. Lumis runs two: the `tree-sitter` crate in Rust, the CLI,",
+    "Elixir and Node, and `web-tree-sitter` in the browser. They disagree on 24 of",
+    "these 72 cases, so the same query can highlight differently per runtime.",
+    "",
+    "This is a parity guard, not a study. Perfect agreement is not reachable while",
+    "the bindings differ, so `supported` records what is portable *today* and the",
+    "tests fail the moment either engine moves.",
+    "",
+    "Three shapes account for every divergence:",
+    "  - Zero-node captures, from `?` or `*` on a capture. Rust treats them as",
+    "    vacuously true; the browser returns false via an explicit",
+    "    `if (nodes.length === 0)` that its own `#eq?` path lacks. Reachable from",
+    "    shipped queries: cmake/highlights.scm pairs `(argument)? @_selector` with",
+    "    `#any-of? @_selector`, so `list(TRANSFORM x TOUPPER)` highlights",
+    "    differently in the browser. Open upstream as tree-sitter#2375.",
+    "  - `any-*` on a non-empty capture that nothing satisfies. Rust falls through",
+    "    to true, the browser returns false. tree-sitter#2514, which introduced the",
+    "    `any-` prefix, defines it as `at least one node`.",
+    "  - Regex dialect, `regex` crate vs JavaScript `RegExp`: inline `(?i)`, POSIX",
+    "    classes, Unicode-width `\\d`. Pattern portability across those two is",
+    "    already pinned over the whole shipped corpus by",
+    "    crates/lumis-build/tests/processed_queries.rs and",
+    "    packages/javascript/lumis/test/query-patterns.test.ts; this file covers the",
+    "    operator semantics those two do not.",
+    "",
+    "Two tests read this file: crates/lumis/tests/query_predicates.rs and",
+    "packages/javascript/lumis/test/query-predicates.test.ts. Each asserts its own",
+    "column, and both re-derive `supported` from the data and compare it against the",
+    "list here, so the list cannot drift from the measurements."
+  ],
+  "supported": [
+    "eq?",
+    "not-eq?"
+  ],
+  "cases": [
+    {
+      "name": "eq/zero-nodes",
+      "operator": "eq?",
+      "source": "fn beta() {}",
+      "query": "((function_item (visibility_modifier)? @vis) (#eq? @vis \"pub\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "eq/one-node/hit",
+      "operator": "eq?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#eq? @vis \"pub\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "eq/one-node/miss",
+      "operator": "eq?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#eq? @vis \"nope\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "eq/multi/all-satisfy",
+      "operator": "eq?",
+      "source": "fn f() { x; x; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#eq? @i \"x\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "eq/multi/some-satisfy",
+      "operator": "eq?",
+      "source": "fn f() { x; y; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#eq? @i \"x\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "eq/multi/none-satisfy",
+      "operator": "eq?",
+      "source": "fn f() { y; z; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#eq? @i \"x\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_eq/zero-nodes",
+      "operator": "not-eq?",
+      "source": "fn beta() {}",
+      "query": "((function_item (visibility_modifier)? @vis) (#not-eq? @vis \"pub\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "not_eq/one-node/hit",
+      "operator": "not-eq?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#not-eq? @vis \"pub\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_eq/one-node/miss",
+      "operator": "not-eq?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#not-eq? @vis \"nope\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "not_eq/multi/all-satisfy",
+      "operator": "not-eq?",
+      "source": "fn f() { x; x; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#not-eq? @i \"x\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_eq/multi/some-satisfy",
+      "operator": "not-eq?",
+      "source": "fn f() { x; y; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#not-eq? @i \"x\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_eq/multi/none-satisfy",
+      "operator": "not-eq?",
+      "source": "fn f() { y; z; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#not-eq? @i \"x\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_eq/zero-nodes",
+      "operator": "any-eq?",
+      "source": "fn beta() {}",
+      "query": "((function_item (visibility_modifier)? @vis) (#any-eq? @vis \"pub\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_eq/one-node/hit",
+      "operator": "any-eq?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#any-eq? @vis \"pub\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_eq/one-node/miss",
+      "operator": "any-eq?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#any-eq? @vis \"nope\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_eq/multi/all-satisfy",
+      "operator": "any-eq?",
+      "source": "fn f() { x; x; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-eq? @i \"x\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_eq/multi/some-satisfy",
+      "operator": "any-eq?",
+      "source": "fn f() { x; y; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-eq? @i \"x\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_eq/multi/none-satisfy",
+      "operator": "any-eq?",
+      "source": "fn f() { y; z; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-eq? @i \"x\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_not_eq/zero-nodes",
+      "operator": "any-not-eq?",
+      "source": "fn beta() {}",
+      "query": "((function_item (visibility_modifier)? @vis) (#any-not-eq? @vis \"pub\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_not_eq/one-node/hit",
+      "operator": "any-not-eq?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#any-not-eq? @vis \"pub\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_not_eq/one-node/miss",
+      "operator": "any-not-eq?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#any-not-eq? @vis \"nope\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_not_eq/multi/all-satisfy",
+      "operator": "any-not-eq?",
+      "source": "fn f() { x; x; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-not-eq? @i \"x\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_not_eq/multi/some-satisfy",
+      "operator": "any-not-eq?",
+      "source": "fn f() { x; y; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-not-eq? @i \"x\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_not_eq/multi/none-satisfy",
+      "operator": "any-not-eq?",
+      "source": "fn f() { y; z; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-not-eq? @i \"x\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_of/zero-nodes",
+      "operator": "any-of?",
+      "source": "fn beta() {}",
+      "query": "((function_item (visibility_modifier)? @vis) (#any-of? @vis \"pub\" \"crate\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_of/one-node/hit",
+      "operator": "any-of?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#any-of? @vis \"pub\" \"crate\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_of/one-node/miss",
+      "operator": "any-of?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#any-of? @vis \"nope\" \"nada\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "any_of/multi/all-satisfy",
+      "operator": "any-of?",
+      "source": "fn f() { x; x; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-of? @i \"x\" \"unused\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_of/multi/some-satisfy",
+      "operator": "any-of?",
+      "source": "fn f() { x; y; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-of? @i \"x\" \"unused\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "any_of/multi/none-satisfy",
+      "operator": "any-of?",
+      "source": "fn f() { y; z; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-of? @i \"x\" \"unused\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_any_of/zero-nodes",
+      "operator": "not-any-of?",
+      "source": "fn beta() {}",
+      "query": "((function_item (visibility_modifier)? @vis) (#not-any-of? @vis \"pub\" \"crate\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "not_any_of/one-node/hit",
+      "operator": "not-any-of?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#not-any-of? @vis \"pub\" \"crate\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_any_of/one-node/miss",
+      "operator": "not-any-of?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#not-any-of? @vis \"nope\" \"nada\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "not_any_of/multi/all-satisfy",
+      "operator": "not-any-of?",
+      "source": "fn f() { x; x; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#not-any-of? @i \"x\" \"unused\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_any_of/multi/some-satisfy",
+      "operator": "not-any-of?",
+      "source": "fn f() { x; y; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#not-any-of? @i \"x\" \"unused\"))",
+      "rust": 0,
+      "browser": 1
+    },
+    {
+      "name": "not_any_of/multi/none-satisfy",
+      "operator": "not-any-of?",
+      "source": "fn f() { y; z; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#not-any-of? @i \"x\" \"unused\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "match/zero-nodes",
+      "operator": "match?",
+      "source": "fn beta() {}",
+      "query": "((function_item (visibility_modifier)? @vis) (#match? @vis \"^pub$\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "match/one-node/hit",
+      "operator": "match?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#match? @vis \"^pub$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "match/one-node/miss",
+      "operator": "match?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#match? @vis \"^nope$\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "match/multi/all-satisfy",
+      "operator": "match?",
+      "source": "fn f() { x; x; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#match? @i \"^x$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "match/multi/some-satisfy",
+      "operator": "match?",
+      "source": "fn f() { x; y; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#match? @i \"^x$\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "match/multi/none-satisfy",
+      "operator": "match?",
+      "source": "fn f() { y; z; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#match? @i \"^x$\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_match/zero-nodes",
+      "operator": "not-match?",
+      "source": "fn beta() {}",
+      "query": "((function_item (visibility_modifier)? @vis) (#not-match? @vis \"^pub$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "not_match/one-node/hit",
+      "operator": "not-match?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#not-match? @vis \"^pub$\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_match/one-node/miss",
+      "operator": "not-match?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#not-match? @vis \"^nope$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "not_match/multi/all-satisfy",
+      "operator": "not-match?",
+      "source": "fn f() { x; x; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#not-match? @i \"^x$\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_match/multi/some-satisfy",
+      "operator": "not-match?",
+      "source": "fn f() { x; y; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#not-match? @i \"^x$\"))",
+      "rust": 0,
+      "browser": 0
+    },
+    {
+      "name": "not_match/multi/none-satisfy",
+      "operator": "not-match?",
+      "source": "fn f() { y; z; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#not-match? @i \"^x$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_match/zero-nodes",
+      "operator": "any-match?",
+      "source": "fn beta() {}",
+      "query": "((function_item (visibility_modifier)? @vis) (#any-match? @vis \"^pub$\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_match/one-node/hit",
+      "operator": "any-match?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#any-match? @vis \"^pub$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_match/one-node/miss",
+      "operator": "any-match?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#any-match? @vis \"^nope$\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_match/multi/all-satisfy",
+      "operator": "any-match?",
+      "source": "fn f() { x; x; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-match? @i \"^x$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_match/multi/some-satisfy",
+      "operator": "any-match?",
+      "source": "fn f() { x; y; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-match? @i \"^x$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_match/multi/none-satisfy",
+      "operator": "any-match?",
+      "source": "fn f() { y; z; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-match? @i \"^x$\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_not_match/zero-nodes",
+      "operator": "any-not-match?",
+      "source": "fn beta() {}",
+      "query": "((function_item (visibility_modifier)? @vis) (#any-not-match? @vis \"^pub$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_not_match/one-node/hit",
+      "operator": "any-not-match?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#any-not-match? @vis \"^pub$\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_not_match/one-node/miss",
+      "operator": "any-not-match?",
+      "source": "pub fn alpha() {}",
+      "query": "((function_item (visibility_modifier) @vis) (#any-not-match? @vis \"^nope$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_not_match/multi/all-satisfy",
+      "operator": "any-not-match?",
+      "source": "fn f() { x; x; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-not-match? @i \"^x$\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_not_match/multi/some-satisfy",
+      "operator": "any-not-match?",
+      "source": "fn f() { x; y; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-not-match? @i \"^x$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_not_match/multi/none-satisfy",
+      "operator": "any-not-match?",
+      "source": "fn f() { y; z; }",
+      "query": "((block (expression_statement (identifier) @i) (expression_statement (identifier) @i)) (#any-not-match? @i \"^x$\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "match/regex-inline-case-insensitive",
+      "operator": "match?",
+      "source": "fn alpha() {}",
+      "query": "((function_item name: (identifier) @n) (#match? @n \"(?i)ALPHA\"))",
+      "rust": 1,
+      "browser": "error"
+    },
+    {
+      "name": "match/regex-posix-class",
+      "operator": "match?",
+      "source": "fn alpha() {}",
+      "query": "((function_item name: (identifier) @n) (#match? @n \"[[:alpha:]]\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "match/regex-unicode-digit-width",
+      "operator": "match?",
+      "source": "fn f() { \"٣\"; }",
+      "query": "((string_literal) @s (#match? @s \"\\\\d\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "not_match/regex-inline-case-insensitive",
+      "operator": "not-match?",
+      "source": "fn alpha() {}",
+      "query": "((function_item name: (identifier) @n) (#not-match? @n \"(?i)ALPHA\"))",
+      "rust": 0,
+      "browser": "error"
+    },
+    {
+      "name": "not_match/regex-posix-class",
+      "operator": "not-match?",
+      "source": "fn alpha() {}",
+      "query": "((function_item name: (identifier) @n) (#not-match? @n \"[[:alpha:]]\"))",
+      "rust": 0,
+      "browser": 1
+    },
+    {
+      "name": "not_match/regex-unicode-digit-width",
+      "operator": "not-match?",
+      "source": "fn f() { \"٣\"; }",
+      "query": "((string_literal) @s (#not-match? @s \"\\\\d\"))",
+      "rust": 0,
+      "browser": 1
+    },
+    {
+      "name": "any_match/regex-inline-case-insensitive",
+      "operator": "any-match?",
+      "source": "fn alpha() {}",
+      "query": "((function_item name: (identifier) @n) (#any-match? @n \"(?i)ALPHA\"))",
+      "rust": 1,
+      "browser": "error"
+    },
+    {
+      "name": "any_match/regex-posix-class",
+      "operator": "any-match?",
+      "source": "fn alpha() {}",
+      "query": "((function_item name: (identifier) @n) (#any-match? @n \"[[:alpha:]]\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_match/regex-unicode-digit-width",
+      "operator": "any-match?",
+      "source": "fn f() { \"٣\"; }",
+      "query": "((string_literal) @s (#any-match? @s \"\\\\d\"))",
+      "rust": 1,
+      "browser": 0
+    },
+    {
+      "name": "any_not_match/regex-inline-case-insensitive",
+      "operator": "any-not-match?",
+      "source": "fn alpha() {}",
+      "query": "((function_item name: (identifier) @n) (#any-not-match? @n \"(?i)ALPHA\"))",
+      "rust": 1,
+      "browser": "error"
+    },
+    {
+      "name": "any_not_match/regex-posix-class",
+      "operator": "any-not-match?",
+      "source": "fn alpha() {}",
+      "query": "((function_item name: (identifier) @n) (#any-not-match? @n \"[[:alpha:]]\"))",
+      "rust": 1,
+      "browser": 1
+    },
+    {
+      "name": "any_not_match/regex-unicode-digit-width",
+      "operator": "any-not-match?",
+      "source": "fn f() { \"٣\"; }",
+      "query": "((string_literal) @s (#any-not-match? @s \"\\\\d\"))",
+      "rust": 1,
+      "browser": 1
+    }
+  ]
+}

--- a/packages/javascript/lumis/test/query-predicates.test.ts
+++ b/packages/javascript/lumis/test/query-predicates.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The browser's half of the Tree-sitter predicate parity check.
+ *
+ * `fixtures/query-predicates.json` records, per case, the match count each
+ * engine produces. This asserts the `browser` column and re-derives the
+ * supported operator set from the data, so the checked-in list cannot drift
+ * from what the engines actually do. `crates/lumis/tests/query_predicates.rs`
+ * does the same for the `tree-sitter` crate.
+ */
+import { readFileSync } from "node:fs";
+import { beforeAll, describe, expect, it } from "vitest";
+import { Language, Parser, Query } from "web-tree-sitter";
+
+import { ensureLocalWasm } from "./wasm.js";
+
+type Outcome = number | "error";
+
+interface Case {
+  name: string;
+  operator: string;
+  source: string;
+  query: string;
+  rust: Outcome;
+  browser: Outcome;
+}
+
+interface Manifest {
+  supported: string[];
+  cases: Case[];
+}
+
+const manifest: Manifest = JSON.parse(
+  readFileSync(new URL("../../../../fixtures/query-predicates.json", import.meta.url), "utf8"),
+);
+
+let language: Language;
+let parser: Parser;
+
+beforeAll(async () => {
+  await Parser.init();
+  language = await Language.load(readFileSync(ensureLocalWasm("rust")));
+  parser = new Parser();
+  parser.setLanguage(language);
+}, 120_000);
+
+function run(testCase: Case): Outcome {
+  const tree = parser.parse(testCase.source);
+  if (!tree) throw new Error(`source did not parse: ${testCase.name}`);
+  try {
+    return new Query(language, testCase.query).matches(tree.rootNode).length;
+  } catch {
+    return "error";
+  } finally {
+    tree.delete();
+  }
+}
+
+describe("tree-sitter predicate parity", () => {
+  it("covers every text predicate", () => {
+    // A discovery bug that found nothing would otherwise pass silently.
+    expect(manifest.cases.length).toBeGreaterThanOrEqual(70);
+
+    const covered = [...new Set(manifest.cases.map((c) => c.operator))].sort();
+    expect(covered).toEqual(
+      [
+        "any-eq?",
+        "any-match?",
+        "any-not-eq?",
+        "any-not-match?",
+        "any-of?",
+        "eq?",
+        "match?",
+        "not-any-of?",
+        "not-eq?",
+        "not-match?",
+      ].sort(),
+    );
+  });
+
+  it("recorded browser results still hold", () => {
+    for (const testCase of manifest.cases) {
+      expect(
+        run(testCase),
+        `${testCase.name}: web-tree-sitter changed. Re-record the fixture.`,
+      ).toBe(testCase.browser);
+    }
+  });
+
+  // The supported list is a conclusion, not a decision: an operator is
+  // supported when no case makes the two engines disagree.
+  it("supported operators match the measurements", () => {
+    const diverging = new Set(
+      manifest.cases.filter((c) => c.rust !== c.browser).map((c) => c.operator),
+    );
+    const derived = [...new Set(manifest.cases.map((c) => c.operator))]
+      .filter((operator) => !diverging.has(operator))
+      .sort();
+
+    expect(derived).toEqual([...manifest.supported].sort());
+  });
+});

--- a/queries/processed/cmake/highlights.scm
+++ b/queries/processed/cmake/highlights.scm
@@ -197,7 +197,7 @@
     .
     (argument) @_action @constant
     .
-    (argument)? @_selector @constant
+    (argument) @_selector @constant
     (#eq? @_transform "TRANSFORM")
     (#any-of? @_action "APPEND" "PREPEND" "TOUPPER" "TOLOWER" "STRIP" "GENEX_STRIP" "REPLACE")
     (#any-of? @_selector "AT" "FOR" "REGEX")))


### PR DESCRIPTION
Lumis evaluates queries with two engines: the `tree-sitter` crate in Rust, the CLI, Elixir and Node, and `web-tree-sitter` in the browser. Text predicates are not implemented in the Tree-sitter C library — each binding evaluates them itself — and nothing checked that ours agree. They do not.

### The live bug

`queries/processed/cmake/highlights.scm` pairs an optional capture with a predicate on it:

```scheme
(argument)? @_selector @constant
(#any-of? @_selector "AT" "FOR" "REGEX")
```

When the optional argument is absent, `@_selector` holds zero nodes, and that is exactly where the two engines part company. Measured on `list(TRANSFORM mylist TOUPPER)`:

| engine | upstream | with this fix |
| --- | --- | --- |
| `tree-sitter` crate | 1 match | 0 |
| `web-tree-sitter` | 0 matches | 0 |

So the same CMake source highlighted differently in the browser than in every other runtime.

Requiring the selector loses nothing. The pattern immediately above it upstream already covers the no-selector case, and supplies exactly the captures the optional pattern did when the selector was absent — `@_transform`, `@constant`, `@variable`, `@_action`. Rust was matching both patterns and producing the same output twice.

It is applied as a language-scoped text replacement in `apply_text_replacements` rather than a `queries/override/` entry, so the other 220 lines of the file keep tracking upstream.

### The guard

`fixtures/query-predicates.json` records what each engine returns for 72 cases across all ten text predicates — zero-node, one-node and genuine multi-node captures, plus regex-dialect patterns. **They disagree on 24 of them. Only `#eq?` and `#not-eq?` are portable.**

Three shapes account for every divergence:

- **Zero-node captures**, from `?` or `*`. Rust treats them as vacuously true; the browser returns false via an explicit `if (nodes.length === 0)` that its own `#eq?` path lacks. Open upstream as [tree-sitter#2375](https://github.com/tree-sitter/tree-sitter/issues/2375). This is the one cmake hits.
- **`any-*` on a non-empty capture that nothing satisfies.** Rust falls through to `true`, the browser returns `false`. [tree-sitter#2514](https://github.com/tree-sitter/tree-sitter/issues/2514), which introduced the `any-` prefix, defines it as "at least one node".
- **Regex dialect**, `regex` crate vs `RegExp`. Already pinned over the whole corpus by `processed_queries.rs` and `query-patterns.test.ts`; this covers the operator semantics those two do not.

Two tests read the fixture — `crates/lumis/tests/query_predicates.rs` and `packages/javascript/lumis/test/query-predicates.test.ts`. Each asserts its own column, and both re-derive the supported set from the recorded results and compare it against the checked-in list, so the list cannot be asserted into existence. Perfect agreement is not reachable while the bindings differ, so this records what is portable today and fails the moment either engine moves.

All three guards were proven to fail on the defect they catch: a wrong recorded result, a `supported` entry the data contradicts, and a silently shrinking corpus.

### Scope

I scanned all 67 quantified captures in the shipped corpus. cmake is the only live occurrence — clojure's is commented out and ruby's quantifier and predicate sit in different patterns.

`mise run lint`, `mise run test` and `mise run test-conformance` all pass; conformance output is unchanged, which is the fix being output-neutral.
