### PR TITLE
docs: use Catppuccin Latte and Frappé

### DIFF
--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -45,12 +45,12 @@ These flags work with any subcommand:
 ## `lumis highlight`
 
 ```bash title="Terminal output (default formatter)"
-lumis highlight main.rs --theme dracula
+lumis highlight main.rs --theme catppuccin_frappe
 ```
 
 ```bash title="Pipe from stdin"
 cat main.rs | lumis highlight -l rust
-echo 'const x = 1' | lumis highlight -l javascript --formatter html-inline --theme dracula
+echo 'const x = 1' | lumis highlight -l javascript --formatter html-inline --theme catppuccin_frappe
 ```
 
 ### Options
@@ -81,7 +81,7 @@ Accepted by `html-inline` and `terminal`:
 
 | Flag | Short | Description |
 | --- | --- | --- |
-| `--theme <name>` | `-t` | Theme name (e.g., `dracula`, `github_dark`) or `auto` |
+| `--theme <name>` | `-t` | Theme name (e.g., `catppuccin_latte`, `catppuccin_frappe`) or `auto` |
 
 Accepted by `terminal`:
 
@@ -112,14 +112,14 @@ Accepted by `html-multi-themes`:
 
 | Flag | Short | Description |
 | --- | --- | --- |
-| `--themes <key:theme>` | | Theme pair (repeatable, e.g., `--themes light:github_light --themes dark:github_dark`) |
+| `--themes <key:theme>` | | Theme pair (repeatable, e.g., `--themes light:catppuccin_latte --themes dark:catppuccin_frappe`) |
 | `--default-theme <id>` | | Which `--themes` entry gets inline styles |
 | `--css-variable-prefix <prefix>` | | Prefix for CSS custom properties (default: `--lumis`). A value starting with `-` needs the `=` form: `--css-variable-prefix=--shiki` |
 
 ### Examples
 
 ```bash title="HTML inline"
-lumis highlight main.rs -f html-inline -t github_dark
+lumis highlight main.rs -f html-inline -t catppuccin_frappe
 ```
 
 ```bash title="HTML linked"
@@ -129,8 +129,8 @@ lumis highlight main.rs -f html-linked
 ```bash title="HTML multi-themes"
 lumis highlight main.rs \
   -f html-multi-themes \
-  --themes light:github_light \
-  --themes dark:github_dark \
+  --themes light:catppuccin_latte \
+  --themes dark:catppuccin_frappe \
   --default-theme light
 ```
 
@@ -310,7 +310,7 @@ Lists built-in themes and any custom themes found in the data directory.
 ## `lumis themes show`
 
 ```bash
-lumis themes show dracula
+lumis themes show catppuccin_frappe
 ```
 
 Prints a theme's appearance, foreground, background and how many highlight
@@ -339,7 +339,7 @@ lumis themes generate \
 ```bash title="Light theme"
 lumis themes generate \
   -u https://github.com/projekt0n/github-nvim-theme \
-  -c github_light \
+  -c catppuccin_latte \
   -a light \
   -o github-light.json
 ```

--- a/docs/content/cli/commands.mdx
+++ b/docs/content/cli/commands.mdx
@@ -339,7 +339,7 @@ lumis themes generate \
 ```bash title="Light theme"
 lumis themes generate \
   -u https://github.com/projekt0n/github-nvim-theme \
-  -c catppuccin_latte \
+  -c github_light \
   -a light \
   -o github-light.json
 ```

--- a/docs/content/installation.mdx
+++ b/docs/content/installation.mdx
@@ -81,11 +81,11 @@ The installed binary is `lumis`. npm resolves it from a platform package, so the
   import {highlight} from 'https://esm.sh/@lumis-sh/lumis';
   import {htmlInline} from 'https://esm.sh/@lumis-sh/lumis/formatters';
   import javascript from 'https://esm.sh/@lumis-sh/lumis/langs/javascript';
-  import dracula from 'https://esm.sh/@lumis-sh/themes/dracula';
+  import frappe from 'https://esm.sh/@lumis-sh/themes/catppuccin_frappe';
 
   const html = await highlight(
     'const x = 1',
-    htmlInline({language: javascript, theme: dracula})
+    htmlInline({language: javascript, theme: frappe})
   );
 
   document.getElementById('output').innerHTML = html;

--- a/docs/content/integrations/astro.mdx
+++ b/docs/content/integrations/astro.mdx
@@ -37,13 +37,13 @@ import {defineConfig} from 'astro/config'
 import rehypeLumis from '@lumis-sh/rehype-lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 export default defineConfig({
   markdown: {
     rehypePlugins: [
       [rehypeLumis, {
-        formatter: (language) => htmlInline({language, theme: githubLight}),
+        formatter: (language) => htmlInline({language, theme: latte}),
         languages: [bundledLanguages],
       }],
     ],
@@ -59,14 +59,14 @@ import mdx from '@astrojs/mdx'
 import rehypeLumis from '@lumis-sh/rehype-lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 export default defineConfig({
   integrations: [
     mdx({
       rehypePlugins: [
         [rehypeLumis, {
-          formatter: (language) => htmlInline({language, theme: githubLight}),
+          formatter: (language) => htmlInline({language, theme: latte}),
           languages: [bundledLanguages],
         }],
       ],

--- a/docs/content/integrations/docusaurus.mdx
+++ b/docs/content/integrations/docusaurus.mdx
@@ -28,7 +28,7 @@ npm install @lumis-sh/rehype-lumis @lumis-sh/lumis @lumis-sh/themes
 import rehypeLumis from '@lumis-sh/rehype-lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 export default {
   presets: [
@@ -38,7 +38,7 @@ export default {
         docs: {
           rehypePlugins: [
             [rehypeLumis, {
-              formatter: (language) => htmlInline({language, theme: githubLight}),
+              formatter: (language) => htmlInline({language, theme: latte}),
               languages: [bundledLanguages],
             }],
           ],

--- a/docs/content/integrations/markdown-it.mdx
+++ b/docs/content/integrations/markdown-it.mdx
@@ -30,11 +30,11 @@ import {htmlInline} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
 import rust from '@lumis-sh/lumis/langs/rust'
 import plaintext from '@lumis-sh/lumis/langs/plaintext'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const md = new MarkdownIt()
 const lumis = await markdownItLumis({
-  formatter: (language) => htmlInline({language, theme: githubLight}),
+  formatter: (language) => htmlInline({language, theme: latte}),
   languages: [javascript, rust, plaintext],
 })
 
@@ -63,7 +63,7 @@ import {createHighlighter} from '@lumis-sh/lumis'
 import {fromHighlighter} from '@lumis-sh/markdown-it-lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const highlighter = await createHighlighter({languages: [bundledLanguages]})
 await highlighter.loadLanguage(bundledLanguages.javascript)

--- a/docs/content/integrations/markdown-it.mdx
+++ b/docs/content/integrations/markdown-it.mdx
@@ -63,8 +63,6 @@ import {createHighlighter} from '@lumis-sh/lumis'
 import {fromHighlighter} from '@lumis-sh/markdown-it-lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import latte from '@lumis-sh/themes/catppuccin_latte'
-
 const highlighter = await createHighlighter({languages: [bundledLanguages]})
 await highlighter.loadLanguage(bundledLanguages.javascript)
 

--- a/docs/content/integrations/mdx.mdx
+++ b/docs/content/integrations/mdx.mdx
@@ -31,12 +31,12 @@ import {compile} from '@mdx-js/mdx'
 import rehypeLumis from '@lumis-sh/rehype-lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const file = await compile(source, {
   rehypePlugins: [
     [rehypeLumis, {
-      formatter: (language) => htmlInline({language, theme: githubLight}),
+      formatter: (language) => htmlInline({language, theme: latte}),
       languages: [bundledLanguages],
     }],
   ],

--- a/docs/content/integrations/nextjs.mdx
+++ b/docs/content/integrations/nextjs.mdx
@@ -48,11 +48,11 @@ export default withMDX({
 import rehypeLumis from '@lumis-sh/rehype-lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 export default function configuredRehypeLumis() {
   return rehypeLumis.call(this, {
-    formatter: (language) => htmlInline({language, theme: githubLight}),
+    formatter: (language) => htmlInline({language, theme: latte}),
     languages: [bundledLanguages],
   })
 }

--- a/docs/content/integrations/nimble-publisher.mdx
+++ b/docs/content/integrations/nimble-publisher.mdx
@@ -49,7 +49,7 @@ defmodule MyApp.Blog.Markdown do
   def convert(_path, body, _attrs, _opts) do
     MDEx.to_html!(body,
       syntax_highlight: [
-        formatter: {:html_inline, theme: "github_light"}
+        formatter: {:html_inline, theme: "catppuccin_latte"}
       ]
     )
   end
@@ -62,7 +62,7 @@ end
 MDEx.to_html!(body,
   syntax_highlight: [
     formatter: {:html_multi_themes,
-      themes: [light: "github_light", dark: "github_dark"],
+      themes: [light: "catppuccin_latte", dark: "catppuccin_frappe"],
       default_theme: "light-dark()"}
   ]
 )

--- a/docs/content/integrations/nuxt.mdx
+++ b/docs/content/integrations/nuxt.mdx
@@ -27,7 +27,7 @@ npm install @nuxt/content @lumis-sh/rehype-lumis @lumis-sh/lumis @lumis-sh/theme
 ```ts
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 export default defineNuxtConfig({
   modules: ['@nuxt/content'],
@@ -38,7 +38,7 @@ export default defineNuxtConfig({
         rehypePlugins: {
           '@lumis-sh/rehype-lumis': {
             options: {
-              formatter: (language) => htmlInline({language, theme: githubLight}),
+              formatter: (language) => htmlInline({language, theme: latte}),
               languages: [bundledLanguages],
             },
           },

--- a/docs/content/integrations/ratatui.mdx
+++ b/docs/content/integrations/ratatui.mdx
@@ -39,7 +39,7 @@ use lumis::{formatters::Formatter, languages::Language, themes, TerminalBuilder}
 use ratatui::widgets::{Block, Paragraph};
 
 fn code_paragraph(source: &str, language: Language) -> Paragraph<'static> {
-    let theme = themes::get("dracula").unwrap();
+    let theme = themes::get("catppuccin_frappe").unwrap();
     let formatter = TerminalBuilder::new()
         .language(language)
         .theme(Some(theme))
@@ -55,4 +55,4 @@ fn code_paragraph(source: &str, language: Language) -> Paragraph<'static> {
 }
 ```
 
-Use a dark theme (like `dracula`) for terminal UIs since they render on a dark background.
+Use a dark theme (like `catppuccin_frappe`) for terminal UIs since they render on a dark background.

--- a/docs/content/integrations/react-markdown.mdx
+++ b/docs/content/integrations/react-markdown.mdx
@@ -32,13 +32,13 @@ import {MarkdownAsync} from 'react-markdown'
 import rehypeLumis from '@lumis-sh/rehype-lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 export async function Article({source}: {source: string}) {
   return (
     <MarkdownAsync
       rehypePlugins={[[rehypeLumis, {
-        formatter: (language) => htmlInline({language, theme: githubLight}),
+        formatter: (language) => htmlInline({language, theme: latte}),
         languages: [bundledLanguages],
       }]]}
     >
@@ -57,13 +57,13 @@ import {MarkdownHooks} from 'react-markdown'
 import rehypeLumis from '@lumis-sh/rehype-lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 function Article({source}: {source: string}) {
   return (
     <MarkdownHooks
       rehypePlugins={[[rehypeLumis, {
-        formatter: (language) => htmlInline({language, theme: githubLight}),
+        formatter: (language) => htmlInline({language, theme: latte}),
         languages: [bundledLanguages],
       }]]}
     >

--- a/docs/content/integrations/react.mdx
+++ b/docs/content/integrations/react.mdx
@@ -34,7 +34,7 @@ Use `CodeBlock` when you want a drop-in React component.
 ```tsx
 import {CodeBlock} from '@lumis-sh/react'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const codeString = `export function Hello() {
   return <h1>Hello</h1>
@@ -42,7 +42,7 @@ const codeString = `export function Hello() {
 
 export function Example() {
   return (
-    <CodeBlock formatter={htmlInline({language: 'tsx', theme: githubLight})}>
+    <CodeBlock formatter={htmlInline({language: 'tsx', theme: latte})}>
       {codeString}
     </CodeBlock>
   )
@@ -56,7 +56,7 @@ import {CodeBlock} from '@lumis-sh/react'
 import {createHighlighter} from '@lumis-sh/lumis'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const highlighter = createHighlighter({languages: [bundledLanguages]})
 
@@ -68,7 +68,7 @@ export function Example() {
   return (
     <CodeBlock
       highlighter={highlighter}
-      formatter={htmlInline({language: bundledLanguages.tsx, theme: githubLight})}
+      formatter={htmlInline({language: bundledLanguages.tsx, theme: latte})}
     >
       {codeString}
     </CodeBlock>
@@ -87,14 +87,14 @@ import {useLumis} from '@lumis-sh/react'
 import {createHighlighter} from '@lumis-sh/lumis'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const highlighter = createHighlighter({languages: [bundledLanguages]})
 
 export function Example() {
   const {content, error, isLoading} = useLumis({
     children: 'export const answer = 42',
-    formatter: htmlInline({language: 'typescript', theme: githubLight}),
+    formatter: htmlInline({language: 'typescript', theme: latte}),
     highlighter,
   })
 
@@ -116,7 +116,7 @@ This is a good fit for React Server Components and Next.js App Router pages.
 import {renderCodeBlock} from '@lumis-sh/react/server'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const codeString = `export function Hello() {
   return <h1>Hello</h1>
@@ -125,7 +125,7 @@ const codeString = `export function Hello() {
 export async function Article() {
   const block = await renderCodeBlock({
     children: codeString,
-    formatter: htmlInline({language: bundledLanguages.tsx, theme: githubLight}),
+    formatter: htmlInline({language: bundledLanguages.tsx, theme: latte}),
   })
 
   return <article>{block}</article>
@@ -141,7 +141,7 @@ import {createHighlighter} from '@lumis-sh/lumis'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
 import {CodeBlock} from '@lumis-sh/react'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const codeString = `export const answer = 42`
 
@@ -151,7 +151,7 @@ export function Example() {
   return (
     <CodeBlock
       highlighter={highlighter}
-      formatter={htmlInline({language: 'tsx', theme: githubLight})}
+      formatter={htmlInline({language: 'tsx', theme: latte})}
     >
       {codeString}
     </CodeBlock>

--- a/docs/content/integrations/rehype-lumis.mdx
+++ b/docs/content/integrations/rehype-lumis.mdx
@@ -28,10 +28,10 @@ import rehypeLumis from '@lumis-sh/rehype-lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
 import plaintext from '@lumis-sh/lumis/langs/plaintext'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 processor.use(rehypeLumis, {
-  formatter: (language) => htmlInline({language, theme: githubLight}),
+  formatter: (language) => htmlInline({language, theme: latte}),
   languages: [javascript, plaintext],
 })
 ```
@@ -50,13 +50,13 @@ import {htmlInline} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
 import rust from '@lumis-sh/lumis/langs/rust'
 import plaintext from '@lumis-sh/lumis/langs/plaintext'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const file = await unified()
   .use(remarkParse)
   .use(remarkRehype)
   .use(rehypeLumis, {
-    formatter: (language) => htmlInline({language, theme: githubLight}),
+    formatter: (language) => htmlInline({language, theme: latte}),
     languages: [javascript, rust, plaintext],
   })
   .use(rehypeStringify)

--- a/docs/content/integrations/tableau.mdx
+++ b/docs/content/integrations/tableau.mdx
@@ -48,7 +48,7 @@ config :tableau, :config,
       ],
       render: [unsafe: true],
       syntax_highlight: [
-        formatter: {:html_inline, theme: "github_light"}
+        formatter: {:html_inline, theme: "catppuccin_latte"}
       ]
     ]
   ]
@@ -65,7 +65,7 @@ config :tableau, :config,
     mdex: [
       syntax_highlight: [
         formatter: {:html_multi_themes,
-          themes: [light: "github_light", dark: "github_dark"],
+          themes: [light: "catppuccin_latte", dark: "catppuccin_frappe"],
           default_theme: "light-dark()"}
       ]
     ]

--- a/docs/content/integrations/unified-rehype.mdx
+++ b/docs/content/integrations/unified-rehype.mdx
@@ -37,13 +37,13 @@ import {htmlInline} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
 import rust from '@lumis-sh/lumis/langs/rust'
 import plaintext from '@lumis-sh/lumis/langs/plaintext'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const file = await unified()
   .use(remarkParse)
   .use(remarkRehype)
   .use(rehypeLumis, {
-    formatter: (language) => htmlInline({language, theme: githubLight}),
+    formatter: (language) => htmlInline({language, theme: latte}),
     languages: [javascript, rust, plaintext],
   })
   .use(rehypeStringify)

--- a/docs/content/integrations/vitepress.mdx
+++ b/docs/content/integrations/vitepress.mdx
@@ -31,10 +31,10 @@ import {htmlInline} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
 import rust from '@lumis-sh/lumis/langs/rust'
 import plaintext from '@lumis-sh/lumis/langs/plaintext'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const lumis = await markdownItLumis({
-  formatter: (language) => htmlInline({language, theme: githubLight}),
+  formatter: (language) => htmlInline({language, theme: latte}),
   languages: [javascript, rust, plaintext],
 })
 

--- a/docs/content/intro.md
+++ b/docs/content/intro.md
@@ -42,4 +42,4 @@ It keeps the same core workflow across runtimes:
 
 ---
 
-Every code block on this site is highlighted by Lumis itself, using the [multi-themes formatter](/formatters/html-multi-themes) with `github_light` and `github_dark` themes for automatic light/dark mode switching.
+Every code block on this site is highlighted by Lumis itself, using the [multi-themes formatter](/formatters/html-multi-themes) with `catppuccin_latte` and `catppuccin_frappe` themes for automatic light/dark mode switching.

--- a/docs/content/recipes/auto-detect-language.mdx
+++ b/docs/content/recipes/auto-detect-language.mdx
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="javascript" label="JavaScript">
 
 ```js
-const html = await highlight('#!/usr/bin/env bash\necho "hello"', htmlInline({theme: dracula}))
+const html = await highlight('#!/usr/bin/env bash\necho "hello"', htmlInline({theme: frappe}))
 ```
 
   </TabItem>

--- a/docs/content/recipes/browser-cdn.mdx
+++ b/docs/content/recipes/browser-cdn.mdx
@@ -12,11 +12,11 @@ description: Highlight code directly in Browsers with ESM CDN imports.
   import {highlight} from 'https://esm.sh/@lumis-sh/lumis'
   import {htmlInline} from 'https://esm.sh/@lumis-sh/lumis/formatters'
   import javascript from 'https://esm.sh/@lumis-sh/lumis/langs/javascript'
-  import dracula from 'https://esm.sh/@lumis-sh/themes/dracula'
+  import frappe from 'https://esm.sh/@lumis-sh/themes/catppuccin_frappe'
 
   document.getElementById('output').innerHTML = await highlight(
     'const x = 1',
-    htmlInline({language: javascript, theme: dracula})
+    htmlInline({language: javascript, theme: frappe})
   )
 </script>
 <div id="output"></div>

--- a/docs/content/recipes/file-title-copy.mdx
+++ b/docs/content/recipes/file-title-copy.mdx
@@ -48,7 +48,7 @@ Resulting shape for runtimes that support custom header wrappers:
 import {highlight} from '@lumis-sh/lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
 const source = 'console.log("hello")'
 const filename = 'app.js'
@@ -57,7 +57,7 @@ const html = await highlight(
   source,
   htmlInline({
     language: javascript,
-    theme: dracula,
+    theme: frappe,
     header: {
       openTag: `<div class="snippet-frame">
   <div class="snippet-bar">
@@ -83,7 +83,7 @@ let filename = "app.js";
 
 let formatter = HtmlInlineBuilder::new()
     .language(Language::Javascript)
-    .theme(Some(themes::get("dracula").unwrap()))
+    .theme(Some(themes::get("catppuccin_frappe").unwrap()))
     .header(Some(HtmlElement {
         open_tag: format!(
             r#"<div class="snippet-frame">
@@ -114,7 +114,7 @@ html = Lumis.highlight!(
   source,
   formatter: {:html_inline,
     language: "javascript",
-    theme: "dracula",
+    theme: "catppuccin_frappe",
     header: %{
       open_tag: """
       <div class="snippet-frame">

--- a/docs/content/recipes/generate-css-from-a-theme-rust.mdx
+++ b/docs/content/recipes/generate-css-from-a-theme-rust.mdx
@@ -10,5 +10,5 @@ description: Generate linked CSS from a built-in Lumis theme in Rust.
 ```rust
 use lumis::themes;
 
-let css = themes::get("github_light").unwrap().css(true);
+let css = themes::get("catppuccin_latte").unwrap().css(true);
 ```

--- a/docs/content/recipes/highlight-diffs.mdx
+++ b/docs/content/recipes/highlight-diffs.mdx
@@ -23,7 +23,7 @@ import diff from '@lumis-sh/lumis/langs/diff'
 import elixir from '@lumis-sh/lumis/langs/elixir'
 
 const hl = await createHighlighter({languages: [diff, elixir]})
-const output = hl.highlight(source, htmlInline({language: diff, theme: dracula}))
+const output = hl.highlight(source, htmlInline({language: diff, theme: frappe}))
 ```
 
   </TabItem>
@@ -32,7 +32,7 @@ const output = hl.highlight(source, htmlInline({language: diff, theme: dracula})
 ```rust
 let html = highlight(source, HtmlInlineBuilder::new()
     .language(Language::Diff)
-    .theme(Some(themes::get("dracula").unwrap()))
+    .theme(Some(themes::get("catppuccin_frappe").unwrap()))
     .build()
     .unwrap());
 ```
@@ -41,7 +41,7 @@ let html = highlight(source, HtmlInlineBuilder::new()
   <TabItem value="elixir" label="Elixir">
 
 ```elixir
-Lumis.highlight!(source, formatter: {:html_inline, language: "diff", theme: "dracula"})
+Lumis.highlight!(source, formatter: {:html_inline, language: "diff", theme: "catppuccin_frappe"})
 ```
 
   </TabItem>
@@ -73,7 +73,7 @@ diff --git a/lib/varsel.ex b/lib/varsel.ex
 and the changed lines keep their `diff.plus` and `diff.minus` colours around
 that.
 
-![A git diff of an Elixir file, rendered with github_dark: the unchanged lines
+![A git diff of an Elixir file, rendered with catppuccin_frappe: the unchanged lines
 carry Elixir keyword, module and atom colours, and the removed and added lines
 keep their red and green backgrounds underneath them.](/img/diff-hunk-injection.png)
 

--- a/docs/content/recipes/injected-languages-html-css-js.mdx
+++ b/docs/content/recipes/injected-languages-html-css-js.mdx
@@ -19,7 +19,7 @@ import css from '@lumis-sh/lumis/langs/css'
 import javascript from '@lumis-sh/lumis/langs/javascript'
 
 const hl = await createHighlighter({languages: [html, css, javascript]})
-const output = hl.highlight(source, htmlInline({language: html, theme: dracula}))
+const output = hl.highlight(source, htmlInline({language: html, theme: frappe}))
 ```
 
   </TabItem>
@@ -28,7 +28,7 @@ const output = hl.highlight(source, htmlInline({language: html, theme: dracula})
 ```rust
 let html = highlight(source, HtmlInlineBuilder::new()
     .language(Language::Html)
-    .theme(Some(themes::get("dracula").unwrap()))
+    .theme(Some(themes::get("catppuccin_frappe").unwrap()))
     .build()
     .unwrap());
 ```
@@ -37,7 +37,7 @@ let html = highlight(source, HtmlInlineBuilder::new()
   <TabItem value="elixir" label="Elixir">
 
 ```elixir
-Lumis.highlight!(source, formatter: {:html_inline, language: "html", theme: "dracula"})
+Lumis.highlight!(source, formatter: {:html_inline, language: "html", theme: "catppuccin_frappe"})
 ```
 
   </TabItem>

--- a/docs/content/recipes/light-dark.mdx
+++ b/docs/content/recipes/light-dark.mdx
@@ -39,14 +39,14 @@ That's it for runtimes that support HTML Multi-Themes output. No JavaScript or m
 import {highlight} from '@lumis-sh/lumis'
 import {htmlMultiThemes} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
-import githubLight from '@lumis-sh/themes/github_light'
-import githubDark from '@lumis-sh/themes/github_dark'
+import latte from '@lumis-sh/themes/catppuccin_latte'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
 const html = await highlight(
   'const x = 1',
   htmlMultiThemes({
     language: javascript,
-    themes: {light: githubLight, dark: githubDark},
+    themes: {light: latte, dark: frappe},
     defaultTheme: 'light-dark()',
   })
 )
@@ -60,8 +60,8 @@ use lumis::{highlight, HtmlMultiThemesBuilder, languages::Language, themes};
 use std::collections::HashMap;
 
 let mut theme_map = HashMap::new();
-theme_map.insert("light".to_string(), themes::get("github_light").unwrap());
-theme_map.insert("dark".to_string(), themes::get("github_dark").unwrap());
+theme_map.insert("light".to_string(), themes::get("catppuccin_latte").unwrap());
+theme_map.insert("dark".to_string(), themes::get("catppuccin_frappe").unwrap());
 
 let html = highlight(
     "const x = 1",
@@ -82,7 +82,7 @@ Lumis.highlight!(
   "const x = 1",
   formatter: {:html_multi_themes,
     language: "javascript",
-    themes: [light: "github_light", dark: "github_dark"],
+    themes: [light: "catppuccin_latte", dark: "catppuccin_frappe"],
     default_theme: "light-dark()"
   }
 )
@@ -99,8 +99,8 @@ HTML Multi-Themes is not currently supported in `lumis4j`.
 ```bash
 lumis highlight index.js \
   --formatter html-multi-themes \
-  --themes light:github_light \
-  --themes dark:github_dark \
+  --themes light:catppuccin_latte \
+  --themes dark:catppuccin_frappe \
   --default-theme "light-dark()"
 ```
 
@@ -135,14 +135,14 @@ For runtimes that support HTML Multi-Themes, `default_theme: "light"` makes the 
 import {highlight} from '@lumis-sh/lumis'
 import {htmlMultiThemes} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
-import githubLight from '@lumis-sh/themes/github_light'
-import githubDark from '@lumis-sh/themes/github_dark'
+import latte from '@lumis-sh/themes/catppuccin_latte'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
 const html = await highlight(
   code,
   htmlMultiThemes({
     language: javascript,
-    themes: {light: githubLight, dark: githubDark},
+    themes: {light: latte, dark: frappe},
     defaultTheme: 'light',
   })
 )
@@ -156,8 +156,8 @@ use lumis::{highlight, HtmlMultiThemesBuilder, languages::Language, themes};
 use std::collections::HashMap;
 
 let mut theme_map = HashMap::new();
-theme_map.insert("light".to_string(), themes::get("github_light").unwrap());
-theme_map.insert("dark".to_string(), themes::get("github_dark").unwrap());
+theme_map.insert("light".to_string(), themes::get("catppuccin_latte").unwrap());
+theme_map.insert("dark".to_string(), themes::get("catppuccin_frappe").unwrap());
 
 let html = highlight(
     code,
@@ -178,7 +178,7 @@ Lumis.highlight!(
   code,
   formatter: {:html_multi_themes,
     language: "elixir",
-    themes: [light: "github_light", dark: "github_dark"],
+    themes: [light: "catppuccin_latte", dark: "catppuccin_frappe"],
     default_theme: "light"
   }
 )
@@ -195,8 +195,8 @@ HTML Multi-Themes is not currently supported in `lumis4j`.
 ```bash
 lumis highlight index.js \
   --formatter html-multi-themes \
-  --themes light:github_light \
-  --themes dark:github_dark \
+  --themes light:catppuccin_latte \
+  --themes dark:catppuccin_frappe \
   --default-theme light
 ```
 
@@ -241,14 +241,14 @@ This pattern works anywhere you render the generated HTML. In Phoenix LiveView, 
 import {highlight} from '@lumis-sh/lumis'
 import {htmlMultiThemes} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
-import githubLight from '@lumis-sh/themes/github_light'
-import githubDark from '@lumis-sh/themes/github_dark'
+import latte from '@lumis-sh/themes/catppuccin_latte'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
 const html = await highlight(
   code,
   htmlMultiThemes({
     language: javascript,
-    themes: {light: githubLight, dark: githubDark},
+    themes: {light: latte, dark: frappe},
     defaultTheme: 'light',
   })
 )
@@ -262,8 +262,8 @@ use lumis::{highlight, HtmlMultiThemesBuilder, languages::Language, themes};
 use std::collections::HashMap;
 
 let mut theme_map = HashMap::new();
-theme_map.insert("light".to_string(), themes::get("github_light").unwrap());
-theme_map.insert("dark".to_string(), themes::get("github_dark").unwrap());
+theme_map.insert("light".to_string(), themes::get("catppuccin_latte").unwrap());
+theme_map.insert("dark".to_string(), themes::get("catppuccin_frappe").unwrap());
 
 let html = highlight(
     code,
@@ -284,7 +284,7 @@ Lumis.highlight!(
   code,
   formatter: {:html_multi_themes,
     language: "elixir",
-    themes: [light: "github_light", dark: "github_dark"],
+    themes: [light: "catppuccin_latte", dark: "catppuccin_frappe"],
     default_theme: "light"
   }
 )
@@ -301,8 +301,8 @@ HTML Multi-Themes is not currently supported in `lumis4j`.
 ```bash
 lumis highlight index.js \
   --formatter html-multi-themes \
-  --themes light:github_light \
-  --themes dark:github_dark \
+  --themes light:catppuccin_latte \
+  --themes dark:catppuccin_frappe \
   --default-theme light
 ```
 

--- a/docs/content/recipes/linked-html-css-theme-file.mdx
+++ b/docs/content/recipes/linked-html-css-theme-file.mdx
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="javascript" label="JavaScript">
 
 ```js
-import '@lumis-sh/themes/css/dracula.css'
+import '@lumis-sh/themes/css/catppuccin_frappe.css'
 import {highlight} from '@lumis-sh/lumis'
 import {htmlLinked} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'

--- a/docs/content/recipes/list-languages-and-themes.mdx
+++ b/docs/content/recipes/list-languages-and-themes.mdx
@@ -94,7 +94,7 @@ getLanguage('nope')  // undefined
 Themes are separate modules, so import the one you want:
 
 ```js
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 ```
 
   </TabItem>
@@ -106,7 +106,7 @@ use lumis::{languages::Language, themes};
 let language: Language = "js".parse()?;
 println!("{:?}", language.info().extensions);
 
-let theme = themes::get("dracula")?;
+let theme = themes::get("catppuccin_frappe")?;
 println!("{} {}", theme.name, theme.appearance);
 ```
 
@@ -120,8 +120,8 @@ Lumis.Languages.get("js")
 Lumis.Languages.get("nope")
 # nil
 
-Lumis.Theme.get("dracula")
-# %Lumis.Theme{name: "dracula", appearance: "dark", ...}
+Lumis.Theme.get("catppuccin_frappe")
+# %Lumis.Theme{name: "catppuccin_frappe", appearance: "dark", ...}
 ```
 
   </TabItem>
@@ -129,7 +129,7 @@ Lumis.Theme.get("dracula")
 
 ```bash
 lumis languages show js
-lumis themes show dracula
+lumis themes show catppuccin_frappe
 ```
 
   </TabItem>

--- a/docs/content/recipes/local-wasm-bundle.mdx
+++ b/docs/content/recipes/local-wasm-bundle.mdx
@@ -12,7 +12,7 @@ import {createHighlighter, withWasmBundle} from '@lumis-sh/lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
 import {bundledWasms} from '@lumis-sh/wasm-bundle-web'
-import githubLight from '@lumis-sh/themes/github_light'
+import latte from '@lumis-sh/themes/catppuccin_latte'
 
 const languages = withWasmBundle(bundledLanguages, bundledWasms)
 const hl = await createHighlighter({languages: [languages]})
@@ -20,8 +20,8 @@ const hl = await createHighlighter({languages: [languages]})
 await hl.loadLanguage(languages.javascript)
 
 const html = hl.highlight(
-  'const theme = "github-light"',
-  htmlInline({language: languages.javascript, theme: githubLight})
+  'const theme = "catppuccin-latte"',
+  htmlInline({language: languages.javascript, theme: latte})
 )
 ```
 

--- a/docs/content/recipes/minimal-html.mdx
+++ b/docs/content/recipes/minimal-html.mdx
@@ -17,9 +17,9 @@ import TabItem from '@theme/TabItem';
 import {highlight} from '@lumis-sh/lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
-const html = await highlight('const x = 1', htmlInline({language: javascript, theme: dracula}))
+const html = await highlight('const x = 1', htmlInline({language: javascript, theme: frappe}))
 ```
 
   </TabItem>
@@ -32,7 +32,7 @@ let html = highlight(
     "const x = 1",
     HtmlInlineBuilder::new()
         .language(Language::Javascript)
-        .theme(Some(themes::get("dracula").unwrap()))
+        .theme(Some(themes::get("catppuccin_frappe").unwrap()))
         .build()
         .unwrap(),
 );
@@ -42,7 +42,7 @@ let html = highlight(
   <TabItem value="elixir" label="Elixir">
 
 ```elixir
-html = Lumis.highlight!("const x = 1", formatter: {:html_inline, language: "javascript", theme: "dracula"})
+html = Lumis.highlight!("const x = 1", formatter: {:html_inline, language: "javascript", theme: "catppuccin_frappe"})
 ```
 
   </TabItem>
@@ -57,7 +57,7 @@ var lumis = Lumis.builder().build();
 
 var highlighter = lumis.highlighter()
     .withLang(Lang.JAVASCRIPT)
-    .withTheme(Theme.DRACULA)
+    .withTheme(Theme.CATPPUCCIN_FRAPPE)
     .build();
 
 var html = highlighter.highlight("const x = 1").string();
@@ -67,7 +67,7 @@ var html = highlighter.highlight("const x = 1").string();
   <TabItem value="cli" label="CLI">
 
 ```bash
-lumis highlight index.js --formatter html-inline --theme dracula
+lumis highlight index.js --formatter html-inline --theme catppuccin_frappe
 ```
 
   </TabItem>

--- a/docs/content/recipes/multi-theme-html.mdx
+++ b/docs/content/recipes/multi-theme-html.mdx
@@ -17,14 +17,14 @@ import TabItem from '@theme/TabItem';
 import {highlight} from '@lumis-sh/lumis'
 import {htmlMultiThemes} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
-import githubLight from '@lumis-sh/themes/github_light'
-import githubDark from '@lumis-sh/themes/github_dark'
+import latte from '@lumis-sh/themes/catppuccin_latte'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
 const html = await highlight(
   'const x = 1',
   htmlMultiThemes({
     language: javascript,
-    themes: {light: githubLight, dark: githubDark},
+    themes: {light: latte, dark: frappe},
     defaultTheme: 'light-dark()',
   })
 )
@@ -36,8 +36,8 @@ const html = await highlight(
 ```bash
 lumis highlight index.js \
   --formatter html-multi-themes \
-  --themes light:github_light \
-  --themes dark:github_dark \
+  --themes light:catppuccin_latte \
+  --themes dark:catppuccin_frappe \
   --default-theme "light-dark()"
 ```
 

--- a/docs/content/recipes/phoenix-liveview-rendering.mdx
+++ b/docs/content/recipes/phoenix-liveview-rendering.mdx
@@ -9,7 +9,7 @@ description: Render Lumis HTML safely in Phoenix and LiveView templates.
 
 ```heex
 {Phoenix.HTML.raw(
-  Lumis.highlight!(source, formatter: {:html_inline, language: "elixir", theme: "dracula"})
+  Lumis.highlight!(source, formatter: {:html_inline, language: "elixir", theme: "catppuccin_frappe"})
 )}
 ```
 

--- a/docs/content/recipes/rainbow-brackets.mdx
+++ b/docs/content/recipes/rainbow-brackets.mdx
@@ -21,11 +21,11 @@ Turn it on when you build the formatter:
 import {highlight} from '@lumis-sh/lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
 const html = await highlight(
   'foo(bar([1, 2], {a: 3}))',
-  htmlInline({language: javascript, theme: dracula, rainbowBrackets: true})
+  htmlInline({language: javascript, theme: frappe, rainbowBrackets: true})
 )
 ```
 
@@ -39,7 +39,7 @@ let html = highlight(
     "foo(bar([1, 2], {a: 3}))",
     HtmlInlineBuilder::new()
         .language(Language::JavaScript)
-        .theme(Some(themes::get("dracula").unwrap()))
+        .theme(Some(themes::get("catppuccin_frappe").unwrap()))
         .rainbow_brackets(true)
         .build()
         .unwrap(),
@@ -52,7 +52,7 @@ let html = highlight(
 ```elixir
 Lumis.highlight!(
   "foo(bar([1, 2], {a: 3}))",
-  formatter: {:html_inline, language: "javascript", theme: "dracula", rainbow_brackets: true}
+  formatter: {:html_inline, language: "javascript", theme: "catppuccin_frappe", rainbow_brackets: true}
 )
 ```
 

--- a/docs/content/recipes/repeated-highlighting-javascript.mdx
+++ b/docs/content/recipes/repeated-highlighting-javascript.mdx
@@ -11,12 +11,12 @@ description: Reuse a JavaScript highlighter for repeated synchronous highlights.
 import {createHighlighter} from '@lumis-sh/lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import {bundledLanguages} from '@lumis-sh/lumis/bundles/web'
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
 const hl = await createHighlighter({languages: [bundledLanguages]})
 await hl.loadLanguage('javascript')
 
-const html = hl.highlight('const x = 1', htmlInline({language: 'javascript', theme: dracula}))
+const html = hl.highlight('const x = 1', htmlInline({language: 'javascript', theme: frappe}))
 ```
 
 See [JavaScript](/usage/javascript) for the reusable highlighter workflow.

--- a/docs/content/recipes/terminal-output.mdx
+++ b/docs/content/recipes/terminal-output.mdx
@@ -17,9 +17,9 @@ import TabItem from '@theme/TabItem';
 import {highlight} from '@lumis-sh/lumis'
 import {terminal} from '@lumis-sh/lumis/formatters'
 import rust from '@lumis-sh/lumis/langs/rust'
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
-const ansi = await highlight('fn main() {}', terminal({language: rust, theme: dracula}))
+const ansi = await highlight('fn main() {}', terminal({language: rust, theme: frappe}))
 console.log(ansi)
 ```
 
@@ -33,7 +33,7 @@ let ansi = highlight(
     "fn main() {}",
     TerminalBuilder::new()
         .language(Language::Rust)
-        .theme(Some(themes::get("dracula").unwrap()))
+        .theme(Some(themes::get("catppuccin_frappe").unwrap()))
         .build()
         .unwrap(),
 );
@@ -45,7 +45,7 @@ println!("{}", ansi);
   <TabItem value="cli" label="CLI">
 
 ```bash
-lumis highlight main.rs --theme dracula
+lumis highlight main.rs --theme catppuccin_frappe
 ```
 
   </TabItem>

--- a/docs/content/recipes/wrap-output-with-custom-html.mdx
+++ b/docs/content/recipes/wrap-output-with-custom-html.mdx
@@ -18,7 +18,7 @@ const html = await highlight(
   'const x = 1',
   htmlInline({
     language: javascript,
-    theme: dracula,
+    theme: frappe,
     header: {openTag: '<figure><figcaption>index.js</figcaption>', closeTag: '</figure>'},
   })
 )
@@ -34,7 +34,7 @@ let html = highlight(
     "fn main() {}",
     HtmlInlineBuilder::new()
         .language(Language::Rust)
-        .theme(Some(themes::get("dracula").unwrap()))
+        .theme(Some(themes::get("catppuccin_frappe").unwrap()))
         .header(Some(HtmlElement {
             open_tag: "<figure><figcaption>main.rs</figcaption>".to_string(),
             close_tag: "</figure>".to_string(),
@@ -52,7 +52,7 @@ Lumis.highlight!(
   "const x = 1",
   formatter: {:html_inline,
     language: "javascript",
-    theme: "dracula",
+    theme: "catppuccin_frappe",
     header: %{open_tag: "<figure><figcaption>index.js</figcaption>", close_tag: "</figure>"}
   }
 )

--- a/docs/content/usage/cli-highlight.mdx
+++ b/docs/content/usage/cli-highlight.mdx
@@ -18,8 +18,8 @@ Use `lumis highlight` when you want highlighted output from a file or stdin.
 
 ```bash
 lumis highlight main.rs
-lumis highlight index.js --theme dracula
-lumis highlight index.js --formatter html-inline --theme dracula
+lumis highlight index.js --theme catppuccin_frappe
+lumis highlight index.js --formatter html-inline --theme catppuccin_frappe
 ```
 
 Terminal output is the default formatter, so `--formatter terminal` is optional. When `--theme` is omitted, Lumis uses the configured theme or automatically matches the terminal background; if detection fails, it renders without a theme.
@@ -28,7 +28,7 @@ Terminal output is the default formatter, so `--formatter terminal` is optional.
 
 ```bash
 cat main.rs | lumis highlight --language rust
-echo 'const x = 1' | lumis highlight --language javascript --formatter html-inline --theme dracula
+echo 'const x = 1' | lumis highlight --language javascript --formatter html-inline --theme catppuccin_frappe
 ```
 
 Use `--language` when piping content with no filename hint.
@@ -47,10 +47,10 @@ lumis highlight main.txt --language rust
 ## Formatter selection
 
 ```bash
-lumis highlight main.rs --theme dracula
-lumis highlight main.rs --formatter html-inline --theme dracula
+lumis highlight main.rs --theme catppuccin_frappe
+lumis highlight main.rs --formatter html-inline --theme catppuccin_frappe
 lumis highlight main.rs --formatter html-linked
-lumis highlight main.rs --formatter html-multi-themes --themes light:github_light --themes dark:github_dark
+lumis highlight main.rs --formatter html-multi-themes --themes light:catppuccin_latte --themes dark:catppuccin_frappe
 lumis highlight main.rs --formatter bbcode-scoped
 ```
 

--- a/docs/content/usage/css-builder.mdx
+++ b/docs/content/usage/css-builder.mdx
@@ -224,13 +224,13 @@ That produces selectors like this:
 
 ```css
 html[data-theme="dark"] .lumis {
-  color: #e6edf3;
+  color: #c6d0f5;
   background-color: var(--code-background);
   border-radius: 0.375rem;
   padding: 1rem;
 }
 html[data-theme="dark"] .l-keyword {
-  color: #ff7b72;
+  color: #ca9ee6;
 }
 ```
 

--- a/docs/content/usage/css-builder.mdx
+++ b/docs/content/usage/css-builder.mdx
@@ -42,9 +42,9 @@ Token selectors are fixed as `l-*` classes, matching the built-in `htmlLinked` f
 
 ```js
 import {buildCss} from '@lumis-sh/themes'
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
-const css = buildCss(dracula, {
+const css = buildCss(frappe, {
   scope: '.docs-theme',
   containerSelector: '.code-block',
   containerStyle: [
@@ -62,7 +62,7 @@ const css = buildCss(dracula, {
 ```rust
 use lumis::themes;
 
-let theme = themes::get("dracula").unwrap();
+let theme = themes::get("catppuccin_frappe").unwrap();
 
 let css = themes::CssBuilder::new(&theme)
     .scope(".docs-theme")
@@ -81,7 +81,7 @@ let css = themes::CssBuilder::new(&theme)
 
 ```elixir
 css =
-  Lumis.Theme.build_css!("dracula",
+  Lumis.Theme.build_css!("catppuccin_frappe",
     scope: ".docs-theme",
     container_selector: ".code-block",
     container_style: [
@@ -99,17 +99,17 @@ css =
 The output starts like this:
 
 ```css
-/* dracula
- * revision: ae752c13e95fb7c5f58da4b5123cb804ea7568ee
+/* catppuccin_frappe
+ * revision: e068ab5f8261f23f6f71ffd8791ae40315b77b9c
  */
 .docs-theme .code-block {
-  color: #f8f8f2;
+  color: #c6d0f5;
   background-color: var(--code-background);
   border-radius: 0.5rem;
   padding: 1rem;
 }
 .docs-theme .l-keyword {
-  color: #ff79c6;
+  color: #ca9ee6;
 }
 ```
 
@@ -120,9 +120,9 @@ The output starts like this:
 
 ```js
 import {buildCss} from '@lumis-sh/themes'
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
-const css = buildCss(dracula)
+const css = buildCss(frappe)
 ```
 
   </TabItem>
@@ -131,7 +131,7 @@ const css = buildCss(dracula)
 ```rust
 use lumis::themes;
 
-let theme = themes::get("dracula").unwrap();
+let theme = themes::get("catppuccin_frappe").unwrap();
 let css = themes::CssBuilder::new(&theme).build();
 ```
 
@@ -139,7 +139,7 @@ let css = themes::CssBuilder::new(&theme).build();
   <TabItem value="elixir" label="Elixir">
 
 ```elixir
-css = Lumis.Theme.build_css!("dracula")
+css = Lumis.Theme.build_css!("catppuccin_frappe")
 ```
 
   </TabItem>
@@ -148,18 +148,18 @@ css = Lumis.Theme.build_css!("dracula")
 The output starts with the theme name and revision, then the container `.lumis` rule, then token rules:
 
 ```css
-/* dracula
- * revision: ae752c13e95fb7c5f58da4b5123cb804ea7568ee
+/* catppuccin_frappe
+ * revision: e068ab5f8261f23f6f71ffd8791ae40315b77b9c
  */
 .lumis {
-  color: #f8f8f2;
-  background-color: #282a36;
+  color: #c6d0f5;
+  background-color: #303446;
 }
 .l-keyword {
-  color: #ff79c6;
+  color: #ca9ee6;
 }
 .l-string {
-  color: #f1fa8c;
+  color: #a6d189;
 }
 ```
 
@@ -172,9 +172,9 @@ Use `scope` when the same page needs more than one theme, or when a code block s
 
 ```js
 import {buildCss} from '@lumis-sh/themes'
-import githubDark from '@lumis-sh/themes/github_dark'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
-const css = buildCss(githubDark, {
+const css = buildCss(frappe, {
   scope: 'html[data-theme="dark"]',
   containerStyle: [
     ['background-color', 'var(--code-background)'],
@@ -190,7 +190,7 @@ const css = buildCss(githubDark, {
 ```rust
 use lumis::themes;
 
-let theme = themes::get("github_dark").unwrap();
+let theme = themes::get("catppuccin_frappe").unwrap();
 
 let css = themes::CssBuilder::new(&theme)
     .scope("html[data-theme=\"dark\"]")
@@ -207,7 +207,7 @@ let css = themes::CssBuilder::new(&theme)
 
 ```elixir
 css =
-  Lumis.Theme.build_css!("github_dark",
+  Lumis.Theme.build_css!("catppuccin_frappe",
     scope: ~s(html[data-theme="dark"]),
     container_style: [
       {"background-color", "var(--code-background)"},
@@ -242,7 +242,7 @@ The container rule uses `.lumis` by default. Change it when your rendered HTML u
   <TabItem value="javascript" label="JavaScript">
 
 ```js
-const css = buildCss(dracula, {
+const css = buildCss(frappe, {
   containerSelector: '.code-block',
 })
 ```
@@ -260,7 +260,7 @@ let css = themes::CssBuilder::new(&theme)
   <TabItem value="elixir" label="Elixir">
 
 ```elixir
-css = Lumis.Theme.build_css!("dracula", container_selector: ".code-block")
+css = Lumis.Theme.build_css!("catppuccin_frappe", container_selector: ".code-block")
 ```
 
   </TabItem>
@@ -270,11 +270,11 @@ That changes only the container rule selector:
 
 ```css
 .code-block {
-  color: #f8f8f2;
-  background-color: #282a36;
+  color: #c6d0f5;
+  background-color: #303446;
 }
 .l-keyword {
-  color: #ff79c6;
+  color: #ca9ee6;
 }
 ```
 

--- a/docs/content/usage/css-theme-files.mdx
+++ b/docs/content/usage/css-theme-files.mdx
@@ -6,7 +6,7 @@ description: Use Lumis CSS theme files with htmlLinked output in JavaScript, Eli
 keywords:
   - lumis css themes
   - html linked
-  - dracula.css
+  - catppuccin_frappe.css
   - themes css
 ---
 
@@ -22,7 +22,7 @@ The `htmlLinked` formatter emits CSS class names instead of inline styles. You p
 Import a stylesheet from `@lumis-sh/themes/css/<theme>.css`.
 
 ```js
-import '@lumis-sh/themes/css/dracula.css'
+import '@lumis-sh/themes/css/catppuccin_frappe.css'
 import {highlight} from '@lumis-sh/lumis'
 import {htmlLinked} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
@@ -35,7 +35,7 @@ const html = await highlight('const x = 1', htmlLinked({language: javascript}))
 Load the compiled CSS file directly:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/@lumis-sh/themes/dist/css/dracula.css">
+<link rel="stylesheet" href="https://unpkg.com/@lumis-sh/themes/dist/css/catppuccin_frappe.css">
 ```
 
 Available distribution folders:
@@ -51,11 +51,11 @@ Lumis ships CSS files under `priv/static/css/`.
 plug Plug.Static,
   at: "/themes",
   from: {:lumis, "priv/static/css/"},
-  only: ["dracula.css"]
+  only: ["catppuccin_frappe.css"]
 ```
 
 ```heex title="layout"
-<link phx-track-static rel="stylesheet" href={~p"/themes/dracula.css"} />
+<link phx-track-static rel="stylesheet" href={~p"/themes/catppuccin_frappe.css"} />
 ```
 
 ## Repository-generated CSS

--- a/docs/content/usage/custom-formatters.mdx
+++ b/docs/content/usage/custom-formatters.mdx
@@ -64,7 +64,7 @@ import {createHighlighter, highlightIter} from '@lumis-sh/lumis'
 import type {Formatter} from '@lumis-sh/lumis/formatters'
 import {openPreTag, openCodeTag, closingTags, spanInline} from '@lumis-sh/lumis/formatters/html'
 import rust from '@lumis-sh/lumis/langs/rust'
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
 const hl = await createHighlighter({languages: [rust]})
 
@@ -73,12 +73,12 @@ const formatter: Formatter = {
   format(source) {
     const parts: string[] = []
 
-    parts.push(openPreTag({preClass: 'docs-demo', theme: dracula}))
+    parts.push(openPreTag({preClass: 'docs-demo', theme: frappe}))
     parts.push(openCodeTag(this.language))
 
-    highlightIter(source, this.language, dracula, (text, language, _range, scope, _style) => {
+    highlightIter(source, this.language, frappe, (text, language, _range, scope, _style) => {
       if (scope) {
-        parts.push(spanInline(text, {language, scope, theme: dracula}))
+        parts.push(spanInline(text, {language, scope, theme: frappe}))
       } else {
         parts.push(text)
       }

--- a/docs/content/usage/elixir-integration.mdx
+++ b/docs/content/usage/elixir-integration.mdx
@@ -18,7 +18,7 @@ keywords:
 Use [`highlight/2`](https://hexdocs.pm/lumis/Lumis.html#highlight/2) when invalid user input, formatter options, or language detection should stay in the normal control flow.
 
 ```elixir
-case Lumis.highlight(source, formatter: {:html_inline, language: "elixir", theme: "github_light"}) do
+case Lumis.highlight(source, formatter: {:html_inline, language: "elixir", theme: "catppuccin_latte"}) do
   {:ok, html} -> html
   {:error, reason} -> handle_error(reason)
 end
@@ -34,7 +34,7 @@ uncolored output.
 Use [`highlight!/2`](https://hexdocs.pm/lumis/Lumis.html#highlight!/2) when failures should raise immediately, such as in scripts, trusted internal code, or examples.
 
 ```elixir
-html = Lumis.highlight!(source, formatter: {:html_inline, language: "elixir", theme: "github_light"})
+html = Lumis.highlight!(source, formatter: {:html_inline, language: "elixir", theme: "catppuccin_latte"})
 ```
 
 `highlight!/2` returns the highlighted output or raises.
@@ -67,7 +67,7 @@ Lumis.highlight!("""
 defmodule Demo do
 end
 ```
-""", formatter: {:html_inline, language: "markdown", theme: "github_light"})
+""", formatter: {:html_inline, language: "markdown", theme: "catppuccin_latte"})
 ````
 
 A language that cannot be fetched leaves its own block plain rather than failing
@@ -191,7 +191,7 @@ Lumis.available_themes()
 Lumis.loaded_languages()
 
 Lumis.Languages.get("js")
-Lumis.Theme.get("github_light")
+Lumis.Theme.get("catppuccin_latte")
 ```
 
 `Lumis.Languages.get/2` and `Lumis.Theme.get/2` look one up by name, returning
@@ -204,7 +204,7 @@ See [`Lumis`](https://hexdocs.pm/lumis/Lumis.html), [`Lumis.Languages`](https://
 Highlighted HTML must be rendered as raw HTML in templates.
 
 ```elixir
-code = Lumis.highlight!(source, formatter: {:html_inline, language: "elixir", theme: "github_light"})
+code = Lumis.highlight!(source, formatter: {:html_inline, language: "elixir", theme: "catppuccin_latte"})
 ```
 
 ```heex
@@ -230,7 +230,7 @@ Then pass the resulting theme struct into the formatter options.
 
 ```elixir
 # validate options before passing to highlight
-Lumis.validate_options!(formatter: {:html_inline, language: "elixir", theme: "dracula"})
+Lumis.validate_options!(formatter: {:html_inline, language: "elixir", theme: "catppuccin_frappe"})
 
 # inspect defaults
 Lumis.default_options()

--- a/docs/content/usage/formatters.mdx
+++ b/docs/content/usage/formatters.mdx
@@ -47,11 +47,11 @@ Self-contained output with no external CSS.
 import {highlight} from '@lumis-sh/lumis';
 import {htmlInline} from '@lumis-sh/lumis/formatters';
 import javascript from '@lumis-sh/lumis/langs/javascript';
-import dracula from '@lumis-sh/themes/dracula';
+import frappe from '@lumis-sh/themes/catppuccin_frappe';
 
 const html = await highlight(
   'const x = 1',
-  htmlInline({language: javascript, theme: dracula, preClass: 'code-block'})
+  htmlInline({language: javascript, theme: frappe, preClass: 'code-block'})
 );
 ```
 
@@ -63,7 +63,7 @@ use lumis::{highlight, HtmlInlineBuilder, languages::Language, themes};
 
 let formatter = HtmlInlineBuilder::new()
     .language(Language::Rust)
-    .theme(Some(themes::get("dracula").unwrap()))
+    .theme(Some(themes::get("catppuccin_frappe").unwrap()))
     .pre_class(Some("code-block".to_string()))
     .build()
     .unwrap();
@@ -77,7 +77,7 @@ let html = highlight("fn main() {}", formatter);
 ```elixir
 Lumis.highlight!(
   "fn main() {}",
-  formatter: {:html_inline, language: "rust", theme: "dracula", pre_class: "code-block"}
+  formatter: {:html_inline, language: "rust", theme: "catppuccin_frappe", pre_class: "code-block"}
 )
 ```
 
@@ -94,7 +94,7 @@ var lumis = Lumis.builder().build();
 
 var highlighter = lumis.highlighter()
     .withLang(Lang.RUST)
-    .withTheme(Theme.DRACULA)
+    .withTheme(Theme.CATPPUCCIN_FRAPPE)
     .withFormatter(Formatter.HTML_INLINE)
     .build();
 
@@ -106,7 +106,7 @@ lumis.close();
   <TabItem value="cli" label="CLI">
 
 ```bash
-lumis highlight main.rs --formatter html-inline --theme dracula
+lumis highlight main.rs --formatter html-inline --theme catppuccin_frappe
 ```
 
   </TabItem>
@@ -120,7 +120,7 @@ Smaller HTML. Pair with a CSS theme file.
   <TabItem value="javascript" label="JavaScript">
 
 ```js
-import '@lumis-sh/themes/css/dracula.css';
+import '@lumis-sh/themes/css/catppuccin_frappe.css';
 import {highlight} from '@lumis-sh/lumis';
 import {htmlLinked} from '@lumis-sh/lumis/formatters';
 import javascript from '@lumis-sh/lumis/langs/javascript';
@@ -196,14 +196,14 @@ One block, multiple themes via CSS custom properties.
 import {highlight} from '@lumis-sh/lumis';
 import {htmlMultiThemes} from '@lumis-sh/lumis/formatters';
 import javascript from '@lumis-sh/lumis/langs/javascript';
-import githubLight from '@lumis-sh/themes/github_light';
-import githubDark from '@lumis-sh/themes/github_dark';
+import latte from '@lumis-sh/themes/catppuccin_latte';
+import frappe from '@lumis-sh/themes/catppuccin_frappe';
 
 const html = await highlight(
   'const x = 1',
   htmlMultiThemes({
     language: javascript,
-    themes: {light: githubLight, dark: githubDark},
+    themes: {light: latte, dark: frappe},
     defaultTheme: 'light-dark()',
   })
 );
@@ -217,8 +217,8 @@ use lumis::{highlight, HtmlMultiThemesBuilder, languages::Language, themes};
 use std::collections::HashMap;
 
 let mut theme_map = HashMap::new();
-theme_map.insert("light".to_string(), themes::get("github_light").unwrap());
-theme_map.insert("dark".to_string(), themes::get("github_dark").unwrap());
+theme_map.insert("light".to_string(), themes::get("catppuccin_latte").unwrap());
+theme_map.insert("dark".to_string(), themes::get("catppuccin_frappe").unwrap());
 
 let formatter = HtmlMultiThemesBuilder::new()
     .language(Language::Javascript)
@@ -238,7 +238,7 @@ Lumis.highlight!(
   "const x = 1",
   formatter: {:html_multi_themes,
     language: "javascript",
-    themes: [light: "github_light", dark: "github_dark"],
+    themes: [light: "catppuccin_latte", dark: "catppuccin_frappe"],
     default_theme: "light-dark()"
   }
 )
@@ -257,7 +257,7 @@ var lumis = Lumis.builder().build();
 
 var highlighter = lumis.highlighter()
     .withLang(Lang.RUST)
-    .withTheme(Theme.DRACULA)
+    .withTheme(Theme.CATPPUCCIN_FRAPPE)
     .withFormatter(Formatter.TERMINAL)
     .build();
 
@@ -271,8 +271,8 @@ lumis.close();
 ```bash
 lumis highlight main.rs \
   --formatter html-multi-themes \
-  --themes light:github_light \
-  --themes dark:github_dark \
+  --themes light:catppuccin_latte \
+  --themes dark:catppuccin_frappe \
   --default-theme light-dark()
 ```
 
@@ -292,11 +292,11 @@ ANSI output for the terminal.
 import {highlight} from '@lumis-sh/lumis';
 import {terminal} from '@lumis-sh/lumis/formatters';
 import javascript from '@lumis-sh/lumis/langs/javascript';
-import dracula from '@lumis-sh/themes/dracula';
+import frappe from '@lumis-sh/themes/catppuccin_frappe';
 
 const ansi = await highlight(
   'const x = 1',
-  terminal({language: javascript, theme: dracula})
+  terminal({language: javascript, theme: frappe})
 );
 ```
 
@@ -308,7 +308,7 @@ use lumis::{highlight, TerminalBuilder, languages::Language, themes};
 
 let formatter = TerminalBuilder::new()
     .language(Language::Rust)
-    .theme(Some(themes::get("dracula").unwrap()))
+    .theme(Some(themes::get("catppuccin_frappe").unwrap()))
     .build()
     .unwrap();
 
@@ -322,7 +322,7 @@ println!("{}", ansi);
 ```elixir
 Lumis.highlight!(
   "fn main() {}",
-  formatter: {:terminal, language: "rust", theme: "dracula"}
+  formatter: {:terminal, language: "rust", theme: "catppuccin_frappe"}
 )
 ```
 
@@ -339,7 +339,7 @@ var lumis = Lumis.builder().build();
 
 var highlighter = lumis.highlighter()
     .withLang(Lang.RUST)
-    .withTheme(Theme.DRACULA)
+    .withTheme(Theme.CATPPUCCIN_FRAPPE)
     .withFormatter(Formatter.TERMINAL)
     .build();
 
@@ -351,7 +351,7 @@ lumis.close();
   <TabItem value="cli" label="CLI">
 
 ```bash
-lumis highlight main.rs --theme dracula
+lumis highlight main.rs --theme catppuccin_frappe
 ```
 
   </TabItem>

--- a/docs/content/usage/formatters/html-inline.mdx
+++ b/docs/content/usage/formatters/html-inline.mdx
@@ -222,11 +222,11 @@ The two go together; clap rejects one without the other.
 HTML Inline emits the full block structure with inline styles on each token:
 
 ```html
-<pre class="lumis" style="background-color: #282c34; color: #abb2bf;">
+<pre class="lumis" style="background-color: #303446; color: #c6d0f5;">
   <code class="language-rust" translate="no" tabindex="0">
     <div class="l-line" data-line="1">
-      <span style="color: #e5c07b;">fn</span>
-      <span style="color: #61afef;">main</span>
+      <span style="color: #ca9ee6;">fn</span>
+      <span style="color: #8caaee;">main</span>
     </div>
   </code>
 </pre>

--- a/docs/content/usage/formatters/html-inline.mdx
+++ b/docs/content/usage/formatters/html-inline.mdx
@@ -36,9 +36,9 @@ Self-contained HTML with inline styles on each token. No external CSS required.
 import {highlight} from '@lumis-sh/lumis'
 import {htmlInline} from '@lumis-sh/lumis/formatters'
 import rust from '@lumis-sh/lumis/langs/rust'
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
-const html = await highlight('fn main() {}', htmlInline({language: rust, theme: dracula}))
+const html = await highlight('fn main() {}', htmlInline({language: rust, theme: frappe}))
 ```
 
   </TabItem>
@@ -51,7 +51,7 @@ let html = highlight(
     "fn main() {}",
     HtmlInlineBuilder::new()
         .language(Language::Rust)
-        .theme(Some(themes::get("dracula").unwrap()))
+        .theme(Some(themes::get("catppuccin_frappe").unwrap()))
         .build()
         .unwrap(),
 );
@@ -63,7 +63,7 @@ let html = highlight(
 ```elixir
 Lumis.highlight!(
   "fn main() {}",
-  formatter: {:html_inline, language: "rust", theme: "dracula"}
+  formatter: {:html_inline, language: "rust", theme: "catppuccin_frappe"}
 )
 ```
 
@@ -80,7 +80,7 @@ var lumis = Lumis.builder().build();
 
 var highlighter = lumis.highlighter()
     .withLang(Lang.RUST)
-    .withTheme(Theme.DRACULA)
+    .withTheme(Theme.CATPPUCCIN_FRAPPE)
     .withFormatter(Formatter.HTML_INLINE)
     .build();
 
@@ -93,7 +93,7 @@ lumis.close();
   <TabItem value="cli" label="CLI">
 
 ```bash
-lumis highlight main.rs --formatter html-inline --theme dracula
+lumis highlight main.rs --formatter html-inline --theme catppuccin_frappe
 ```
 
   </TabItem>
@@ -107,7 +107,7 @@ lumis highlight main.rs --formatter html-inline --theme dracula
 ```js
 const html = await highlight(
   'const x = 1',
-  htmlInline({language: javascript, theme: dracula, preClass: 'code-block', includeHighlights: true})
+  htmlInline({language: javascript, theme: frappe, preClass: 'code-block', includeHighlights: true})
 )
 ```
 
@@ -117,7 +117,7 @@ const html = await highlight(
 ```rust
 let formatter = HtmlInlineBuilder::new()
     .language(Language::Javascript)
-    .theme(Some(themes::get("dracula").unwrap()))
+    .theme(Some(themes::get("catppuccin_frappe").unwrap()))
     .pre_class(Some("code-block".to_string()))
     .include_highlights(true)
     .build()
@@ -132,7 +132,7 @@ let html = highlight("const x = 1", formatter);
 ```elixir
 Lumis.highlight!(
   "const x = 1",
-  formatter: {:html_inline, language: "javascript", theme: "dracula", pre_class: "code-block", include_highlights: true}
+  formatter: {:html_inline, language: "javascript", theme: "catppuccin_frappe", pre_class: "code-block", include_highlights: true}
 )
 ```
 
@@ -145,7 +145,7 @@ Lumis.highlight!(
   <TabItem value="cli" label="CLI">
 
 ```bash
-lumis highlight app.js -f html-inline -t dracula --pre-class my-code --include-highlights
+lumis highlight app.js -f html-inline -t catppuccin_frappe --pre-class my-code --include-highlights
 ```
 
   </TabItem>
@@ -161,7 +161,7 @@ const html = await highlight(
   'const x = 1',
   htmlInline({
     language: javascript,
-    theme: dracula,
+    theme: frappe,
     header: {openTag: '<figure><figcaption>index.js</figcaption>', closeTag: '</figure>'},
   })
 )
@@ -175,7 +175,7 @@ use lumis::formatters::html::HtmlElement;
 
 let formatter = HtmlInlineBuilder::new()
     .language(Language::Javascript)
-    .theme(Some(themes::get("dracula").unwrap()))
+    .theme(Some(themes::get("catppuccin_frappe").unwrap()))
     .header(Some(HtmlElement {
         open_tag: "<figure><figcaption>index.js</figcaption>".to_string(),
         close_tag: "</figure>".to_string(),
@@ -194,7 +194,7 @@ Lumis.highlight!(
   "const x = 1",
   formatter: {:html_inline,
     language: "javascript",
-    theme: "dracula",
+    theme: "catppuccin_frappe",
     header: %{open_tag: "<figure><figcaption>index.js</figcaption>", close_tag: "</figure>"}
   }
 )

--- a/docs/content/usage/formatters/html-linked.mdx
+++ b/docs/content/usage/formatters/html-linked.mdx
@@ -33,7 +33,7 @@ Class-based HTML that pairs with a CSS theme file. Smaller output than inline st
   <TabItem value="javascript" label="JavaScript">
 
 ```js
-import '@lumis-sh/themes/css/dracula.css'
+import '@lumis-sh/themes/css/catppuccin_frappe.css'
 import {highlight} from '@lumis-sh/lumis'
 import {htmlLinked} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'

--- a/docs/content/usage/formatters/html-multi-themes.mdx
+++ b/docs/content/usage/formatters/html-multi-themes.mdx
@@ -36,14 +36,14 @@ One HTML block that supports multiple themes via CSS custom properties. Useful f
 import {highlight} from '@lumis-sh/lumis'
 import {htmlMultiThemes} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
-import githubLight from '@lumis-sh/themes/github_light'
-import githubDark from '@lumis-sh/themes/github_dark'
+import latte from '@lumis-sh/themes/catppuccin_latte'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
 const html = await highlight(
   'const x = 1',
   htmlMultiThemes({
     language: javascript,
-    themes: {light: githubLight, dark: githubDark},
+    themes: {light: latte, dark: frappe},
     defaultTheme: 'light-dark()',
   })
 )
@@ -57,8 +57,8 @@ use lumis::{highlight, HtmlMultiThemesBuilder, languages::Language, themes};
 use std::collections::HashMap;
 
 let mut theme_map = HashMap::new();
-theme_map.insert("light".to_string(), themes::get("github_light").unwrap());
-theme_map.insert("dark".to_string(), themes::get("github_dark").unwrap());
+theme_map.insert("light".to_string(), themes::get("catppuccin_latte").unwrap());
+theme_map.insert("dark".to_string(), themes::get("catppuccin_frappe").unwrap());
 
 let html = highlight(
     "const x = 1",
@@ -79,7 +79,7 @@ Lumis.highlight!(
   "const x = 1",
   formatter: {:html_multi_themes,
     language: "javascript",
-    themes: [light: "github_light", dark: "github_dark"],
+    themes: [light: "catppuccin_latte", dark: "catppuccin_frappe"],
     default_theme: "light-dark()"
   }
 )
@@ -96,8 +96,8 @@ HTML Multi-Themes is not currently supported in `lumis4j`.
 ```bash
 lumis highlight main.rs \
   --formatter html-multi-themes \
-  --themes light:github_light \
-  --themes dark:github_dark \
+  --themes light:catppuccin_latte \
+  --themes dark:catppuccin_frappe \
   --default-theme light-dark()
 ```
 
@@ -116,7 +116,7 @@ const html = await highlight(
   'const x = 1',
   htmlMultiThemes({
     language: javascript,
-    themes: {light: githubLight, dark: githubDark},
+    themes: {light: latte, dark: frappe},
     cssVariablePrefix: '--code',
   })
 )
@@ -144,7 +144,7 @@ Lumis.highlight!(
   "const x = 1",
   formatter: {:html_multi_themes,
     language: "javascript",
-    themes: [light: "github_light", dark: "github_dark"],
+    themes: [light: "catppuccin_latte", dark: "catppuccin_frappe"],
     css_variable_prefix: "--code"
   }
 )
@@ -161,8 +161,8 @@ HTML Multi-Themes is not currently supported in `lumis4j`.
 ```bash
 lumis highlight index.js \
   --formatter html-multi-themes \
-  --themes light:github_light \
-  --themes dark:github_dark \
+  --themes light:catppuccin_latte \
+  --themes dark:catppuccin_frappe \
   --css-variable-prefix "--code"
 ```
 

--- a/docs/content/usage/formatters/html-multi-themes.mdx
+++ b/docs/content/usage/formatters/html-multi-themes.mdx
@@ -184,10 +184,10 @@ Controls what color values appear inline (not just as CSS variables):
 HTML Multi-Themes keeps the same HTML structure, but each token carries CSS variables for one or more themes:
 
 ```html
-<pre class="lumis" style="--lumis-light-bg:#ffffff; --lumis-dark-bg:#0d1117;">
+<pre class="lumis" style="--lumis-light-bg:#eff1f5; --lumis-dark-bg:#303446;">
   <code class="language-javascript" translate="no" tabindex="0">
     <div class="l-line" data-line="1">
-      <span style="--lumis-light:#cf222e; --lumis-dark:#ff7b72; color: light-dark(var(--lumis-light), var(--lumis-dark));">const</span>
+      <span style="--lumis-light:#8839ef; --lumis-dark:#ca9ee6; color: light-dark(var(--lumis-light), var(--lumis-dark));">const</span>
     </div>
   </code>
 </pre>

--- a/docs/content/usage/formatters/terminal.mdx
+++ b/docs/content/usage/formatters/terminal.mdx
@@ -35,11 +35,11 @@ ANSI escape codes for shell output.
 import {highlight} from '@lumis-sh/lumis'
 import {terminal} from '@lumis-sh/lumis/formatters'
 import javascript from '@lumis-sh/lumis/langs/javascript'
-import dracula from '@lumis-sh/themes/dracula'
+import frappe from '@lumis-sh/themes/catppuccin_frappe'
 
 const ansi = await highlight(
   'const x = 1',
-  terminal({language: javascript, theme: dracula, background: 'theme', width: 120}),
+  terminal({language: javascript, theme: frappe, background: 'theme', width: 120}),
 )
 console.log(ansi)
 ```
@@ -54,7 +54,7 @@ let ansi = highlight(
     "fn main() {}",
     TerminalBuilder::new()
         .language(Language::Rust)
-        .theme(Some(themes::get("dracula").unwrap()))
+        .theme(Some(themes::get("catppuccin_frappe").unwrap()))
         .background(TerminalBackground::Theme)
         .width(Some(120))
         .build()
@@ -70,7 +70,7 @@ println!("{}", ansi);
 ```elixir
 Lumis.highlight!(
   "fn main() {}",
-  formatter: {:terminal, language: "rust", theme: "dracula", background: :theme, width: 120}
+  formatter: {:terminal, language: "rust", theme: "catppuccin_frappe", background: :theme, width: 120}
 )
 ```
 
@@ -87,7 +87,7 @@ var lumis = Lumis.builder().build();
 
 var highlighter = lumis.highlighter()
     .withLang(Lang.JAVASCRIPT)
-    .withTheme(Theme.DRACULA)
+    .withTheme(Theme.CATPPUCCIN_FRAPPE)
     .withFormatter(Formatter.TERMINAL)
     .build();
 
@@ -101,10 +101,10 @@ lumis.close();
   <TabItem value="cli" label="CLI">
 
 ```bash
-lumis highlight main.rs --theme dracula
-# same as: lumis highlight main.rs --formatter terminal --theme dracula
-lumis highlight main.rs --theme dracula --background theme
-lumis highlight main.rs -b '#282a36' -w 120
+lumis highlight main.rs --theme catppuccin_frappe
+# same as: lumis highlight main.rs --formatter terminal --theme catppuccin_frappe
+lumis highlight main.rs --theme catppuccin_frappe --background theme
+lumis highlight main.rs -b '#303446' -w 120
 ```
 
   </TabItem>

--- a/docs/content/usage/formatters/terminal.mdx
+++ b/docs/content/usage/formatters/terminal.mdx
@@ -115,7 +115,7 @@ lumis highlight main.rs -b '#303446' -w 120
 Terminal output is plain text wrapped in ANSI escape sequences:
 
 ```text
-\x1b[38;2;229;192;123mfn\x1b[0m \x1b[38;2;97;175;239mmain\x1b[0m() {}
+\x1b[38;2;202;158;230mfn\x1b[0m \x1b[38;2;140;170;238mmain\x1b[0m() {}
 ```
 
 - the source stays as terminal text, not HTML

--- a/docs/content/usage/highlight.mdx
+++ b/docs/content/usage/highlight.mdx
@@ -29,11 +29,11 @@ This is the core Lumis workflow: choose a language, choose a formatter, then ren
 import {highlight} from '@lumis-sh/lumis';
 import {htmlInline} from '@lumis-sh/lumis/formatters';
 import javascript from '@lumis-sh/lumis/langs/javascript';
-import dracula from '@lumis-sh/themes/dracula';
+import frappe from '@lumis-sh/themes/catppuccin_frappe';
 
 const html = await highlight(
   'const x = 1',
-  htmlInline({language: javascript, theme: dracula})
+  htmlInline({language: javascript, theme: frappe})
 );
 ```
 
@@ -43,7 +43,7 @@ const html = await highlight(
 ```rust
 use lumis::{highlight, HtmlInlineBuilder, languages::Language, themes};
 
-let theme = themes::get("dracula").unwrap();
+let theme = themes::get("catppuccin_frappe").unwrap();
 
 let formatter = HtmlInlineBuilder::new()
     .language(Language::Javascript)
@@ -60,7 +60,7 @@ let html = highlight("const x = 1", formatter);
 ```elixir
 Lumis.highlight!(
   "const x = 1",
-  formatter: {:html_inline, language: "javascript", theme: "dracula"}
+  formatter: {:html_inline, language: "javascript", theme: "catppuccin_frappe"}
 )
 ```
 
@@ -76,7 +76,7 @@ var lumis = Lumis.builder().build();
 
 var highlighter = lumis.highlighter()
     .withLang(Lang.JAVASCRIPT)
-    .withTheme(Theme.DRACULA)
+    .withTheme(Theme.CATPPUCCIN_FRAPPE)
     .build();
 
 var html = highlighter.highlight("const x = 1").string();
@@ -88,7 +88,7 @@ var html = highlighter.highlight("const x = 1").string();
 ```bash
 lumis highlight index.js \
   --language javascript \
-  --theme dracula
+  --theme catppuccin_frappe
 ```
 
   </TabItem>

--- a/docs/content/usage/java.mdx
+++ b/docs/content/usage/java.mdx
@@ -35,7 +35,7 @@ var lumis = Lumis.builder().build();
 
 var highlighter = lumis.highlighter()
     .withLang(Lang.JAVASCRIPT)
-    .withTheme(Theme.DRACULA)
+    .withTheme(Theme.CATPPUCCIN_FRAPPE)
     .build();
 
 var html = highlighter.highlight("const x = 1").string();
@@ -51,7 +51,7 @@ Lang.JAVASCRIPT
 Lang.ELIXIR
 Lang.PYTHON
 
-Theme.DRACULA
+Theme.CATPPUCCIN_FRAPPE
 Theme.GITHUB_DARK
 Theme.CATPPUCCIN_MOCHA
 Theme.ONEDARK

--- a/docs/content/usage/javascript-runtime.mdx
+++ b/docs/content/usage/javascript-runtime.mdx
@@ -24,9 +24,9 @@ Use [`highlight()`](https://www.npmjs.com/package/@lumis-sh/lumis) when you just
 import { highlight } from "@lumis-sh/lumis";
 import { htmlInline } from "@lumis-sh/lumis/formatters";
 import javascript from "@lumis-sh/lumis/langs/javascript";
-import dracula from "@lumis-sh/themes/dracula";
+import frappe from "@lumis-sh/themes/catppuccin_frappe";
 
-const html = await highlight("const x = 1", htmlInline({ language: javascript, theme: dracula }));
+const html = await highlight("const x = 1", htmlInline({ language: javascript, theme: frappe }));
 ```
 
 `highlight()` uses a shared default runtime, so loaded languages and global WASM resolver changes are process-wide.
@@ -39,11 +39,11 @@ Use [`createHighlighter()`](https://www.npmjs.com/package/@lumis-sh/lumis) when 
 import { createHighlighter } from "@lumis-sh/lumis";
 import { htmlInline } from "@lumis-sh/lumis/formatters";
 import javascript from "@lumis-sh/lumis/langs/javascript";
-import dracula from "@lumis-sh/themes/dracula";
+import frappe from "@lumis-sh/themes/catppuccin_frappe";
 
 const hl = await createHighlighter({ languages: [javascript] });
 
-const html = hl.highlight("const x = 1", htmlInline({ language: javascript, theme: dracula }));
+const html = hl.highlight("const x = 1", htmlInline({ language: javascript, theme: frappe }));
 ```
 
 This creates an isolated highlighter unless you intentionally rely on the global resolver.
@@ -78,7 +78,7 @@ You can register a language now and load it only when needed.
 import { createHighlighter } from "@lumis-sh/lumis";
 import { htmlInline } from "@lumis-sh/lumis/formatters";
 import { bundledLanguages } from "@lumis-sh/lumis/bundles/web";
-import dracula from "@lumis-sh/themes/dracula";
+import frappe from "@lumis-sh/themes/catppuccin_frappe";
 
 const hl = await createHighlighter({ languages: [bundledLanguages] });
 
@@ -86,7 +86,7 @@ await hl.loadLanguage(bundledLanguages.javascript);
 
 const html = hl.highlight(
   "const x = 1",
-  htmlInline({ language: bundledLanguages.javascript, theme: dracula }),
+  htmlInline({ language: bundledLanguages.javascript, theme: frappe }),
 );
 ```
 
@@ -105,11 +105,11 @@ Load languages once with `createHighlighter()`, then call `hl.highlight()` synch
 import { createHighlighter } from "@lumis-sh/lumis";
 import { htmlInline } from "@lumis-sh/lumis/formatters";
 import javascript from "@lumis-sh/lumis/langs/javascript";
-import dracula from "@lumis-sh/themes/dracula";
+import frappe from "@lumis-sh/themes/catppuccin_frappe";
 
 const hl = await createHighlighter({ languages: [javascript] });
 
-const html = hl.highlight("const x = 1", htmlInline({ language: javascript, theme: dracula }));
+const html = hl.highlight("const x = 1", htmlInline({ language: javascript, theme: frappe }));
 ```
 
 ## Language references
@@ -134,7 +134,7 @@ Detection methods:
 - Emacs mode lines
 
 ```ts
-const html = await highlight(source, htmlInline({ theme: dracula }));
+const html = await highlight(source, htmlInline({ theme: frappe }));
 ```
 
 Useful when rendering user-provided content or pasted snippets.
@@ -193,7 +193,7 @@ yourself, or use a bundle such as `@lumis-sh/wasm-bundle-web`:
 ```ts
 const hl = await createHighlighter({ languages: [html, css, javascript] });
 
-const htmlOutput = hl.highlight(source, htmlInline({ language: html, theme: dracula }));
+const htmlOutput = hl.highlight(source, htmlInline({ language: html, theme: frappe }));
 ```
 
 See [Highlighting loads what a document needs](/advanced/wasm-and-cdn#highlighting-loads-what-a-document-needs).

--- a/docs/content/usage/line-highlighting.mdx
+++ b/docs/content/usage/line-highlighting.mdx
@@ -32,13 +32,13 @@ Line highlighting lets you emphasize key lines without changing the rest of the 
 import {highlight} from '@lumis-sh/lumis';
 import {htmlInline} from '@lumis-sh/lumis/formatters';
 import javascript from '@lumis-sh/lumis/langs/javascript';
-import dracula from '@lumis-sh/themes/dracula';
+import frappe from '@lumis-sh/themes/catppuccin_frappe';
 
 const html = await highlight(
   'line 1\nline 2\nline 3\nline 4',
   htmlInline({
     language: javascript,
-    theme: dracula,
+    theme: frappe,
     highlightLines: {lines: [1, [3, 4]], style: 'theme'},
   })
 );
@@ -61,7 +61,7 @@ let highlight_lines = HighlightLines {
 
 let formatter = HtmlInlineBuilder::new()
     .language(Language::PlainText)
-    .theme(Some(themes::get("dracula").unwrap()))
+    .theme(Some(themes::get("catppuccin_frappe").unwrap()))
     .highlight_lines(Some(highlight_lines))
     .build()
     .unwrap();
@@ -77,7 +77,7 @@ Lumis.highlight!(
   "line 1\nline 2\nline 3\nline 4",
   formatter: {:html_inline,
     language: "plaintext",
-    theme: "dracula",
+    theme: "catppuccin_frappe",
     highlight_lines: %{
       lines: [1, 3..4],
       style: :theme
@@ -112,13 +112,13 @@ lumis highlight main.rs --formatter html-inline --highlight-lines 1,3-5,10
 import {highlight} from '@lumis-sh/lumis';
 import {htmlInline} from '@lumis-sh/lumis/formatters';
 import javascript from '@lumis-sh/lumis/langs/javascript';
-import dracula from '@lumis-sh/themes/dracula';
+import frappe from '@lumis-sh/themes/catppuccin_frappe';
 
 const html = await highlight(
   'line 1\nline 2\nline 3\nline 4',
   htmlInline({
     language: javascript,
-    theme: dracula,
+    theme: frappe,
     highlightLines: {
       lines: [2, [4, 4]],
       style: 'background-color: rgba(255, 221, 87, 0.18); border-left: 3px solid #ffd54f;',
@@ -144,7 +144,7 @@ let highlight_lines = HighlightLines {
 
 let formatter = HtmlInlineBuilder::new()
     .language(Language::PlainText)
-    .theme(Some(themes::get("dracula").unwrap()))
+    .theme(Some(themes::get("catppuccin_frappe").unwrap()))
     .highlight_lines(Some(highlight_lines))
     .build()
     .unwrap();
@@ -160,7 +160,7 @@ Lumis.highlight!(
   "line 1\nline 2\nline 3\nline 4",
   formatter: {:html_inline,
     language: "plaintext",
-    theme: "dracula",
+    theme: "catppuccin_frappe",
     highlight_lines: %{
       lines: [2, 4],
       style: "background-color: rgba(255, 221, 87, 0.18); border-left: 3px solid #ffd54f;"
@@ -184,7 +184,7 @@ the inline style explicitly:
 ```js
 htmlInline({
   language: javascript,
-  theme: dracula,
+  theme: frappe,
   highlightLines: {lines: [2], style: null, class: 'bg-yellow-500'},
 })
 ```

--- a/docs/content/usage/rust-advanced.mdx
+++ b/docs/content/usage/rust-advanced.mdx
@@ -79,7 +79,7 @@ Use this when you need byte ranges, scopes, and per-token callbacks.
 ```rust
 use lumis::{highlight::highlight_iter, languages::Language, themes};
 
-highlight_iter(source, Language::Rust, themes::get("github_light").ok(), |text, language, range, scope, style| {
+highlight_iter(source, Language::Rust, themes::get("catppuccin_latte").ok(), |text, language, range, scope, style| {
     println!("{:?} {:?} {} {:?}", text, language, scope, range);
     println!("fg={:?} bold={} italic={}", style.fg, style.bold, style.italic);
     Ok::<_, std::io::Error>(())
@@ -95,7 +95,7 @@ Rust can generate linked CSS directly.
 ```rust
 use lumis::themes;
 
-let theme = themes::get("github_light").unwrap();
+let theme = themes::get("catppuccin_latte").unwrap();
 let css = theme.css(true);
 ```
 

--- a/docs/content/usage/themes.mdx
+++ b/docs/content/usage/themes.mdx
@@ -6,7 +6,7 @@ description: Use built-in Neovim themes, load custom theme JSON, or generate new
 keywords:
   - lumis themes
   - neovim themes
-  - dracula
+  - catppuccin
   - custom themes
 ---
 
@@ -23,10 +23,10 @@ Lumis themes come from the Neovim ecosystem. You can use the built-in collection
   <TabItem value="javascript" label="JavaScript">
 
 ```js
-import dracula from '@lumis-sh/themes/dracula';
+import frappe from '@lumis-sh/themes/catppuccin_frappe';
 
-console.log(dracula.name);
-console.log(dracula.appearance);
+console.log(frappe.name);
+console.log(frappe.appearance);
 ```
 
   </TabItem>
@@ -35,14 +35,14 @@ console.log(dracula.appearance);
 ```rust
 use lumis::themes;
 
-let theme = themes::get("dracula").unwrap();
+let theme = themes::get("catppuccin_frappe").unwrap();
 ```
 
   </TabItem>
   <TabItem value="elixir" label="Elixir">
 
 ```elixir
-theme = Lumis.Theme.get("github_light")
+theme = Lumis.Theme.get("catppuccin_latte")
 theme.name
 ```
 
@@ -52,7 +52,7 @@ theme.name
 ```java
 import io.roastedroot.lumis4j.core.Theme;
 
-var theme = Theme.DRACULA;
+var theme = Theme.CATPPUCCIN_FRAPPE;
 ```
 
   </TabItem>

--- a/docs/content/usage/wasm-and-cdn.mdx
+++ b/docs/content/usage/wasm-and-cdn.mdx
@@ -265,7 +265,7 @@ For multiple languages, install a bundle package such as `@lumis-sh/wasm-bundle-
 import { createHighlighter } from "@lumis-sh/lumis";
 import { htmlInline } from "@lumis-sh/lumis/formatters";
 import elixir from "@lumis-sh/lumis/langs/elixir";
-import githubLight from "@lumis-sh/themes/github_light";
+import latte from "@lumis-sh/themes/catppuccin_latte";
 import "@lumis-sh/wasm-elixir";
 
 const hl = await createHighlighter({
@@ -274,7 +274,7 @@ const hl = await createHighlighter({
 
 const html = hl.highlight(
   "defmodule Demo do\nend",
-  htmlInline({ language: elixir, theme: githubLight }),
+  htmlInline({ language: elixir, theme: latte }),
 );
 ```
 
@@ -289,7 +289,7 @@ See [`packages/javascript/lumis/examples/npm-wasm-node`](https://github.com/lean
 import { createHighlighter } from "@lumis-sh/lumis";
 import { htmlInline } from "@lumis-sh/lumis/formatters";
 import { bundledLanguages } from "@lumis-sh/lumis/bundles/web";
-import githubLight from "@lumis-sh/themes/github_light";
+import latte from "@lumis-sh/themes/catppuccin_latte";
 import "@lumis-sh/wasm-bundle-web";
 
 const hl = await createHighlighter({
@@ -299,8 +299,8 @@ const hl = await createHighlighter({
 await hl.loadLanguage(bundledLanguages.javascript);
 
 const html = hl.highlight(
-  'const theme = "github-light"',
-  htmlInline({ language: bundledLanguages.javascript, theme: githubLight }),
+  'const theme = "catppuccin-latte"',
+  htmlInline({ language: bundledLanguages.javascript, theme: latte }),
 );
 ```
 
@@ -313,7 +313,7 @@ Use this when you want one package in `package.json` to cover a whole preset. Lu
 import { createHighlighter, withWasm } from "@lumis-sh/lumis";
 import { htmlInline } from "@lumis-sh/lumis/formatters";
 import elixir from "@lumis-sh/lumis/langs/elixir";
-import githubLight from "@lumis-sh/themes/github_light";
+import latte from "@lumis-sh/themes/catppuccin_latte";
 import elixirWasm from "@lumis-sh/wasm-elixir";
 
 const elixirFromNpm = withWasm(elixir, elixirWasm);
@@ -324,7 +324,7 @@ const hl = await createHighlighter({
 
 const html = hl.highlight(
   "defmodule Demo do\nend",
-  htmlInline({ language: elixirFromNpm, theme: githubLight }),
+  htmlInline({ language: elixirFromNpm, theme: latte }),
 );
 ```
 
@@ -340,7 +340,7 @@ import { createHighlighter, withWasmBundle } from "@lumis-sh/lumis";
 import { htmlInline } from "@lumis-sh/lumis/formatters";
 import { bundledLanguages } from "@lumis-sh/lumis/bundles/web";
 import { bundledWasms } from "@lumis-sh/wasm-bundle-web";
-import githubLight from "@lumis-sh/themes/github_light";
+import latte from "@lumis-sh/themes/catppuccin_latte";
 
 const languages = withWasmBundle(bundledLanguages, bundledWasms);
 
@@ -351,8 +351,8 @@ const hl = await createHighlighter({
 await hl.loadLanguage(languages.javascript);
 
 const html = hl.highlight(
-  'const theme = "github-light"',
-  htmlInline({ language: languages.javascript, theme: githubLight }),
+  'const theme = "catppuccin-latte"',
+  htmlInline({ language: languages.javascript, theme: latte }),
 );
 ```
 
@@ -445,9 +445,9 @@ preset bundles.
   import { highlight } from "https://esm.sh/@lumis-sh/lumis";
   import { htmlInline } from "https://esm.sh/@lumis-sh/lumis/formatters";
   import javascript from "https://esm.sh/@lumis-sh/lumis/langs/javascript";
-  import dracula from "https://esm.sh/@lumis-sh/themes/dracula";
+  import frappe from "https://esm.sh/@lumis-sh/themes/catppuccin_frappe";
 
-  const html = await highlight("const x = 1", htmlInline({ language: javascript, theme: dracula }));
+  const html = await highlight("const x = 1", htmlInline({ language: javascript, theme: frappe }));
 </script>
 ```
 

--- a/docs/plugins/remark-lumis.cjs
+++ b/docs/plugins/remark-lumis.cjs
@@ -74,8 +74,8 @@ function loadFormatter() {
     const themesRoot = packageRoot("@lumis-sh/themes");
     formatterPromise = Promise.all([
       dynamicImport(lumisRoot + "/dist/formatters.js"),
-      dynamicImport(themesRoot + "/dist/themes/github_light.js"),
-      dynamicImport(themesRoot + "/dist/themes/github_dark.js"),
+      dynamicImport(themesRoot + "/dist/themes/catppuccin_latte.js"),
+      dynamicImport(themesRoot + "/dist/themes/catppuccin_frappe.js"),
     ]).then(([fmt, light, dark]) => ({
       htmlMultiThemes: fmt.htmlMultiThemes,
       light: light.default,


### PR DESCRIPTION
Split out of #1286 so the docs sweep can be read on its own. No logic — theme names and the output blocks that quote them.

The docs site highlighted its own code blocks in GitHub light/dark through `remark-lumis`, while the examples inside those blocks taught Dracula. Neither matched the rest of the site. Both now use the Latte/Frappé pair the website standardised on.

## The rule applied

Each example keeps the light or dark intent its author picked, rather than every single-theme example being forced to one flavour:

- `dracula` → `catppuccin_frappe`
- `github_light` → `catppuccin_latte`, `github_dark` → `catppuccin_frappe`
- light/dark pairs → `catppuccin_latte` + `catppuccin_frappe`
- JavaScript bindings → `latte` / `frappe`, matching how the website's own snippets name them
- `docs/plugins/remark-lumis.cjs` → renders the docs site in the same pair

## Deliberately unchanged

- **`reference/themes.md`** — the catalog. `dracula`, `dracula_soft` and the seven `github_*` variants are entries documenting what ships.
- **The `themes generate` examples.** `github_light` there names the upstream Neovim colorscheme in `projekt0n/github-nvim-theme` being read from, not a Lumis theme id.
- **The Prism fallback** in `docusaurus.config.ts`. Docusaurus uses Prism for the `plaintext`/`text`/`xml` blocks `remark-lumis` skips, and `prism-react-renderer` ships no Catppuccin, so that stays Dracula in dark mode.
- **The formatter table in `architecture.md`**, which is theme-agnostic — its neighbouring row uses placeholder `#333`/`#ccc`.

## Things a find-and-replace would have broken

- **Blocks that quote rendered output**, in `css-builder.mdx`, `html-multi-themes.mdx`, `html-inline.mdx` and `terminal.mdx`. Renaming an identifier would have left a CSS header reading `/* frappe` with Dracula's revision hash, or GitHub colours beside a Catppuccin input. All values come from the checked-in `css/catppuccin_latte.css` and `css/catppuccin_frappe.css`.
- **Theme ids in forms the path/quote rules missed** — the short `-t` and `-c` flags, `lumis themes show`, prose, a frontmatter keyword. Each briefly became an invalid id.
- **`Theme.DRACULA`** is an external API; `Theme.CATPPUCCIN_FRAPPE` was confirmed to exist in `roastedroot/lumis4j` before the Java examples were rewritten.

## Verification

- Docusaurus build succeeds.
- Built HTML carries Latte in light (`#4c4f69`, `#8839ef`, `#40a02b`) and Frappé in dark (`--lumis-dark:#c6d0f5`, `#ca9ee6`), with no GitHub or Dracula colours left.
- Every hex in `docs/content` is checked against the Latte and Frappé palettes; the only ones outside them are a user-defined theme in `custom-theme-from-json.mdx`, the line-highlight accent in `line-highlighting.mdx`, and the placeholder table in `architecture.md`.
- No example was newly broken: 12 snippets use a theme binding without importing it, but every one was already written that way — short snippets elide imports.

## Follow-ups, not in this PR

- `formatters.mdx` has a Java `Formatter.TERMINAL` snippet sitting under **HTML Multi-Themes**; it is already that way on `main`.
- Several snippets elide imports and an undefined `source`, so they are not standalone.
- The "Scope a stylesheet" section in `css-builder.mdx` says to use `scope` when a page needs more than one theme, and used to demonstrate that with a second theme. Everything on the page is Frappé now, so the contrast is gone.
- 11 READMEs and `CONTRIBUTING.md` still use Dracula in examples. `THEMES.md` is a catalog and should stay.