### PR TITLE
chore(deps): group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,39 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      dependencies:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "tree-sitter-*"
+      - dependency-name: "wasmtime"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "mix"
     directory: "/packages/elixir/lumis"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      dependencies:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "tree-sitter-*"
 
@@ -24,13 +45,28 @@ updates:
     directory: "/packages/elixir/lumis/native/lumis_nif"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      dependencies:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "tree-sitter-*"
+      - dependency-name: "wasmtime"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/packages/javascript"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      dependencies:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "tree-sitter-*"
       - dependency-name: "@lumis-sh/wasm-*"


### PR DESCRIPTION
## Summary

- group routine updates into one PR per Dependabot ecosystem and directory
- wait seven days before proposing newly released versions
- ignore Wasmtime major updates in both Cargo configurations while continuing to allow compatible 36.x patches

## Rationale

GitHub cooldowns apply only to version updates, so security updates remain immediate.

Tree-sitter 0.26.12 depends on Wasmtime 36. PR #1309 resolves Wasmtime 36 and 48 together and fails because `WasmStore::new` requires the `tree_sitter::wasmtime::Engine` type. Major Wasmtime updates therefore need to follow Tree-sitter support.

`wasmparser` remains enabled. Lumis uses it independently to inspect parser exports, and PR #1308 passes the runtime and conformance suites.

## Validation

- parsed the YAML and asserted the policy for all five update configurations
- `git diff --check`