### PR TITLE
chore(themes): update generated PR title

### DIFF
--- a/.github/workflows/gen-themes.yml
+++ b/.github/workflows/gen-themes.yml
@@ -90,7 +90,7 @@ jobs:
             packages/elixir/lumis/priv/static/css
             packages/javascript/themes/themes
           commit-message: "feat(themes): update generated themes"
-          title: "feat(themes): update generated themes"
+          title: "feat(themes): update themes"
           body-path: .github/gen-themes-pr-body.md
           branch: gen-themes
           delete-branch: true


### PR DESCRIPTION
Changes the automated theme update PR title from `feat(themes): update generated themes` to `feat(themes): update themes`. The generated commit message remains unchanged.