### PR TITLE
ci: release each package from its own pull request

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,8 +15,9 @@ jobs:
   benchmark:
     name: Benchmark / ${{ matrix.label }}
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     continue-on-error: true
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -84,8 +85,9 @@ jobs:
   comparison:
     name: Comparison assets are current
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -124,8 +126,9 @@ jobs:
     needs: benchmark
     if: >-
       ${{ always() &&
-          (github.event_name != 'push' ||
-           !startsWith(github.event.head_commit.message, 'chore(release):')) }}
+          !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     continue-on-error: true
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -47,8 +47,9 @@ on:
 jobs:
   conformance:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     name: Conformance (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/elixir-nif-rust.yml
+++ b/.github/workflows/elixir-nif-rust.yml
@@ -27,8 +27,9 @@ jobs:
   standalone-lock:
     name: Standalone packaged NIF lockfile
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -44,8 +45,9 @@ jobs:
 
   test:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     uses: leandrocp/github-actions/.github/workflows/rust-test.yml@main
     with:
       manifest-path: 'packages/elixir/lumis/native/lumis_nif/Cargo.toml'
@@ -57,8 +59,9 @@ jobs:
       stable-os-versions: ${{ github.event_name == 'pull_request' && '["ubuntu-22.04"]' || '["ubuntu-22.04", "windows-2022", "macos-14"]' }}
   lint:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     uses: leandrocp/github-actions/.github/workflows/rust-lint.yml@main
     with:
       manifest-path: 'packages/elixir/lumis/native/lumis_nif/Cargo.toml'

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -27,8 +27,9 @@ defaults:
 jobs:
   test:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     uses: leandrocp/github-actions/.github/workflows/elixir-test.yml@main
     with:
       working-directory: packages/elixir/lumis
@@ -41,8 +42,9 @@ jobs:
       pairs: "${{ github.event_name == 'pull_request' && '[{\"name\": \"OTP 29.x, Elixir 1.20.x\", \"elixir\": \"1.20.x\", \"otp\": \"29.x\"}]' || '[{\"name\": \"OTP 25.1, Elixir 1.15.0\", \"elixir\": \"1.15.0\", \"otp\": \"25.1\"}, {\"name\": \"OTP 29.x, Elixir 1.20.x\", \"elixir\": \"1.20.x\", \"otp\": \"29.x\"}, {\"name\": \"OTP 29, Elixir main\", \"elixir\": \"main-otp-29\", \"otp\": \"maint-29\"}]' }}"
   lint:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     uses: leandrocp/github-actions/.github/workflows/elixir-lint.yml@main
     with:
       working-directory: packages/elixir/lumis

--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -53,8 +53,9 @@ on:
 jobs:
   lint:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -85,8 +86,9 @@ jobs:
 
   test:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,8 +34,9 @@ permissions:
 jobs:
   actionlint:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -46,8 +47,9 @@ jobs:
 
   lua:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -57,8 +59,9 @@ jobs:
   rust-outside-workspace:
     name: Rust crates outside the workspace
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/queries.yml
+++ b/.github/workflows/queries.yml
@@ -53,8 +53,9 @@ env:
 jobs:
   portability:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     name: Portability
     runs-on: ubuntu-latest
     steps:
@@ -87,8 +88,9 @@ jobs:
   # because that is 113 builds.
   compile:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     name: Compile queries (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     # llvm takes about eight minutes to compile through the WASI SDK; vim and
@@ -207,8 +209,9 @@ jobs:
   # its memory on a runner.
   compile-published:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     name: Compile queries (published parsers, shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,144 @@
+name: Prepare Releases
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# The branches and the pull requests are pushed with CI_TOKEN, and checkout keeps
+# no credentials, so GITHUB_TOKEN only ever reads this repository.
+permissions:
+  contents: read
+
+jobs:
+  # Deliberately not skipped on `chore(release):` commits, unlike the branch
+  # workflows. Merging a release pull request is the push that changes the plan
+  # the most: the package that just landed leaves it, and every other open pull
+  # request has to be rebuilt on top of the merge.
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      releases: ${{ steps.plan.outputs.releases }}
+    steps:
+      # `mise run release-plan` reads every package tag and every commit since
+      # it, so the whole history has to be here.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+
+      - name: Plan releases
+        id: plan
+        run: |
+          set -euo pipefail
+          mise run release-plan | tee "$RUNNER_TEMP/plan.txt"
+          releases="$(jq -Rc -s '
+            split("\n")
+            | map(select(length > 0) | split(" ") | {package: .[0], version: .[1]})
+          ' "$RUNNER_TEMP/plan.txt")"
+          echo "Planned releases: $releases"
+          echo "releases=$releases" >> "$GITHUB_OUTPUT"
+
+      # A package that drops out of the plan has been released, or is waiting for
+      # its tag, so its pull request is stale and no job below will close it.
+      # Deleting the branch closes it.
+      - name: Close pull requests for packages that no longer need one
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: |
+          set -euo pipefail
+          mise run release-packages | cut -d'|' -f1 > "$RUNNER_TEMP/packages.txt"
+          cut -d' ' -f1 "$RUNNER_TEMP/plan.txt" > "$RUNNER_TEMP/planned.txt"
+          gh api "repos/$GITHUB_REPOSITORY/git/matching-refs/heads/release/" \
+            --jq '.[].ref | sub("^refs/heads/"; "")' > "$RUNNER_TEMP/branches.txt"
+          while read -r branch; do
+            package="${branch#release/}"
+            if ! grep -qxF "$package" "$RUNNER_TEMP/packages.txt"; then continue; fi
+            if grep -qxF "$package" "$RUNNER_TEMP/planned.txt"; then continue; fi
+            echo "Deleting $branch"
+            gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/heads/$branch"
+          done < "$RUNNER_TEMP/branches.txt"
+
+  prepare:
+    needs: plan
+    if: needs.plan.outputs.releases != '[]'
+    name: ${{ matrix.release.package }}
+    runs-on: ubuntu-latest
+    # `hex-lumis` fails here by design while a crate release it requires has been
+    # merged into `main` but not published yet, and it is the only package that
+    # can. Every other package failing is a real failure and fails the run. See
+    # RELEASE.md, "Elixir package".
+    continue-on-error: ${{ matrix.release.package == 'hex-lumis' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ${{ fromJson(needs.plan.outputs.releases) }}
+
+    steps:
+      # Each package is prepared on its own branch off `main`, never on top of
+      # another package's preparation, so the whole history is needed again for
+      # the changelog `git-cliff` writes.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
+      - name: Install cargo-edit
+        uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2.87.0
+        with:
+          tool: cargo-edit
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "lts/*"
+
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+
+      # Only a crate release builds `crates/dev`, through
+      # `mise run check-crate-deps --fix`. Caching the other jobs would store an
+      # empty target directory under the same key.
+      - name: Cache Rust dependencies
+        if: startsWith(matrix.release.package, 'cargo-')
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          workspaces: "crates/dev -> target"
+          shared-key: release-prepare-dev
+
+      - name: Prepare release
+        env:
+          PACKAGE: ${{ matrix.release.package }}
+          VERSION: ${{ matrix.release.version }}
+        run: |
+          set -euo pipefail
+          mise run release-prepare "$PACKAGE" "$VERSION"
+          git status --short
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+          commit-message: "chore(release): ${{ matrix.release.package }} ${{ matrix.release.version }}"
+          title: "chore(release): ${{ matrix.release.package }} ${{ matrix.release.version }}"
+          body: |
+            Version bump and changelog entry for `${{ matrix.release.package }}`.
+
+            Merging this publishes it. `release-tag.yml` reads the merge commit,
+            pushes `${{ matrix.release.package }}/v${{ matrix.release.version }}`,
+            and that tag starts the publish workflow.
+
+            When several of these are open, merge them one at a time in the order
+            under [Publish order](https://github.com/leandrocp/lumis/blob/main/RELEASE.md#publish-order),
+            and let each publish finish before merging the next.
+
+            This PR was created automatically by the release-prepare workflow.
+          branch: release/${{ matrix.release.package }}
+          delete-branch: true
+          base: main

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -28,6 +28,7 @@ jobs:
       # it, so the whole history has to be here.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -86,6 +87,7 @@ jobs:
       # the changelog `git-cliff` writes.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,72 @@
+name: Tag Releases
+
+# Keyed by commit rather than by workflow. Each run tags the commit it was
+# triggered by and nothing else, so there is nothing to serialise, and a group
+# shared across commits would cancel a queued run when a second release landed
+# behind it -- losing that package's tag, and its publish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    if: startsWith(github.event.head_commit.message, 'chore(release):')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # `mise run release-version` reads manifests with sed and jq, so none of
+      # the pinned tools have to be downloaded here.
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          install: false
+
+      # The tag is created with CI_TOKEN rather than GITHUB_TOKEN because a ref
+      # GITHUB_TOKEN pushes raises no events, and the publish workflows are what
+      # this exists to start.
+      - name: Tag the released package
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+          SUBJECT: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+          subject="${SUBJECT%%$'\n'*}"
+
+          # The whole subject has to be `chore(release): <package> <version>`,
+          # plus the `(#1234)` suffix a squash merge appends. Matching a prefix
+          # instead would read a release out of a subject that carries anything
+          # else as well, and publish it.
+          pattern='^chore\(release\): ([a-z0-9-]+) ([0-9]+\.[0-9]+\.[0-9]+[0-9A-Za-z.+-]*)( \(#[0-9]+\))?$'
+          if [[ ! "$subject" =~ $pattern ]]; then
+            echo "Not a release subject: $subject" >&2
+            exit 1
+          fi
+          package="${BASH_REMATCH[1]}"
+          version="${BASH_REMATCH[2]}"
+
+          declared="$(mise run release-version "$package")"
+          if [ "$declared" != "$version" ]; then
+            echo "$subject claims $version, but $package declares $declared" >&2
+            exit 1
+          fi
+
+          tag="$package/v$version"
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "$tag already exists"
+            exit 0
+          fi
+
+          gh api -X POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/tags/$tag" -f sha="$GITHUB_SHA"
+          echo "Pushed $tag" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -63,7 +63,12 @@ jobs:
 
           tag="$package/v$version"
           if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
-            echo "$tag already exists"
+            tagged_sha="$(git rev-parse "refs/tags/$tag^{commit}")"
+            if [ "$tagged_sha" != "$GITHUB_SHA" ]; then
+              echo "$tag points to $tagged_sha, not release commit $GITHUB_SHA" >&2
+              exit 1
+            fi
+            echo "$tag already points to $GITHUB_SHA"
             exit 0
           fi
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,8 +39,9 @@ on:
 jobs:
   test-lumis:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     uses: leandrocp/github-actions/.github/workflows/rust-test.yml@main
     with:
       msrv: '1.91'
@@ -49,8 +50,9 @@ jobs:
       stable-os-versions: ${{ github.event_name == 'pull_request' && '["ubuntu-22.04"]' || '["ubuntu-22.04", "windows-2022", "macos-14"]' }}
   test-lumis-build:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     uses: leandrocp/github-actions/.github/workflows/rust-test.yml@main
     with:
       msrv: '1.91'
@@ -59,8 +61,9 @@ jobs:
       stable-os-versions: ${{ github.event_name == 'pull_request' && '["ubuntu-22.04"]' || '["ubuntu-22.04", "windows-2022", "macos-14"]' }}
   test-lumis-core:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     uses: leandrocp/github-actions/.github/workflows/rust-test.yml@main
     with:
       msrv: '1.91'
@@ -69,8 +72,9 @@ jobs:
       stable-os-versions: ${{ github.event_name == 'pull_request' && '["ubuntu-22.04"]' || '["ubuntu-22.04", "windows-2022", "macos-14"]' }}
   test-lumis-cli:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     uses: leandrocp/github-actions/.github/workflows/rust-test.yml@main
     with:
       msrv: '1.91'
@@ -79,8 +83,9 @@ jobs:
       stable-os-versions: ${{ github.event_name == 'pull_request' && '["ubuntu-22.04"]' || '["ubuntu-22.04", "windows-2022", "macos-14"]' }}
   test-lumis-wasm-runtime:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     uses: leandrocp/github-actions/.github/workflows/rust-test.yml@main
     with:
       msrv: '1.91'
@@ -89,8 +94,9 @@ jobs:
       stable-os-versions: ${{ github.event_name == 'pull_request' && '["ubuntu-22.04"]' || '["ubuntu-22.04", "windows-2022", "macos-14"]' }}
   check-language-catalog:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -105,8 +111,9 @@ jobs:
           --locked --no-default-features -- gen-language-catalog --check
   test-packaged-parsers:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     strategy:
       fail-fast: false
       matrix:
@@ -243,8 +250,9 @@ jobs:
   synced-manifest:
     name: Synced formatter-options manifest
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -283,8 +291,9 @@ jobs:
 
   lint:
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
     uses: leandrocp/github-actions/.github/workflows/rust-lint.yml@main
     with:
       msrv: '1.91'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,11 +373,12 @@ For language, theme, query, docs-generation, or bundle changes, run the relevant
 
 ## Release discipline
 
-Releases are prepared locally with `mise run release-prepare` and published from tags.
+Releases are prepared by `release-prepare.yml` on every push to `main`, which opens or updates one pull request per package that needs one, and published when a maintainer merges one: `release-tag.yml` turns the merge commit into the package tag the publish workflows run from. `mise run release-prepare` does the same preparation locally.
 
 - Do not hand-edit versions or changelog release sections in normal feature work.
 - Follow `RELEASE.md` for release-specific tasks.
-- Write the release commit subject as `chore(release): <package> <version>`. CI keys on that prefix to skip itself, so a different spelling silently runs every workflow against a commit that was already green.
+- Write the release commit subject as `chore(release): <package> <version>` and nothing else. The `(#1234)` suffix a squash merge appends is the one addition `release-tag.yml` tolerates. That subject is the whole interface: CI skips on the prefix, and `release-tag.yml` reads the package and version out of it to decide what to publish. A different spelling runs every workflow against a change that was already green, and ships nothing.
+- Adding a releasable package is a row in `mise run release-packages`. Nothing else holds a per-package list, so a second copy of that table is a bug waiting to drift.
 - If a change affects packaging, tags, publish behavior, or release metadata expectations, treat it as a release-sensitive change and review the release docs before touching anything.
 
 ## Commit messages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,15 +99,16 @@ The browser task installs the required Chromium, Firefox, and WebKit builds befo
 
 ## Releases
 
-Releases are prepared locally and published from tags.
+Releases are prepared by `release-prepare.yml`, one pull request per package, and published when one of those pull requests is merged.
 
-- Run `mise run release-needed` to list packages with non-chore path-scoped commits since their latest package tag.
-- Prepare each release with `mise run release-prepare <package> <version>`.
-- `mise run release-prepare` updates only the target package version file and prepends the next changelog entry.
+- Every push to `main` opens or updates one `chore(release): <package> <version>` pull request per package that `mise run release-plan` says needs one, on branch `release/<package>`.
+- Merging one is what ships it: `release-tag.yml` reads the merge commit and pushes `<package>/v<version>`, which starts the publish workflow. Merge one at a time, in publish order, and let each publish finish first.
+- Run `mise run release-plan` to see the same list locally, and `mise run release-needed` for the commits behind it.
+- Prepare a release by hand with `mise run release-prepare <package> <version>`, then commit it to `main` with that same subject; the tagging is automatic either way.
+- `mise run release-prepare` bumps the target package version file and prepends the next changelog entry, and also rewrites dependent manifests and lockfiles. Review and commit everything it touches.
 - If dependent manifests must move together, update them separately in the same release commit. `npm-lumis` is the exception: it also bumps the native crate, the `@lumis-sh/lumis-native` selector and all platform packages, because the release workflow publishes them under the same version first.
 - A `version` requirement on a lumis crate must equal that crate's version in this repository. `mise run release-prepare` keeps them in step, rewriting dependent manifests beyond the package being released, so review and commit every file it touches. `mise run check-crate-deps` reports drift and `--fix` repairs it. Apart from `crates/autumnus`, no build here resolves those requirements, so that check is the only thing that can catch them. See [Crate version requirements](RELEASE.md#crate-version-requirements).
-- Maintainers commit the release prep changes, then push package tags such as `cargo-lumis-cli/v0.2.0`.
-- Pushing a package tag triggers the publish workflows.
+- The package tag, such as `cargo-lumis-cli/v0.2.0`, is pushed by `release-tag.yml` rather than by hand, and pushing it triggers the publish workflows.
 
 Do not hand-edit release versions or changelog sections when `mise run release-prepare` can generate them.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -426,8 +426,9 @@ Example:
 mise run release-prepare cargo-lumis-cli 0.2.0
 ```
 
-`release-prepare` updates only the target package version file and prepends the next changelog entry with `git-cliff`.
-
-If a release requires dependent manifests to move in lockstep, update those files separately and commit them with the release prep.
+`release-prepare` updates the target package version file and prepends the next
+changelog entry with `git-cliff`. Cargo releases also rewrite dependent
+manifests and lockfiles, and `hex-lumis` refreshes the packaged NIF lockfile.
+Review and commit every file the task touches.
 
 `npm-lumis` is the one exception: it additionally bumps `native/Cargo.toml`, the `@lumis-sh/lumis-native` selector, and all platform packages, because the release workflow publishes them under the same version before the main package. See [JavaScript packages](#javascript-packages).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,26 @@
 # Release
 
-Releases are prepared locally and published from tags.
+Releases are prepared and published by workflows, one pull request per package.
+Merging a release pull request is what ships that package.
 
 ## TLDR
+
+Every push to `main` runs `release-prepare.yml`, which opens or updates one pull
+request per package that needs a release, titled
+`chore(release): <package> <version>` on branch `release/<package>`.
+
+Merge the ones you want to ship, one at a time and in
+[publish order](#publish-order). `release-tag.yml` reads each merge commit,
+pushes `<package>/v<version>`, and that tag starts the publish workflow.
+
+Merging is the decision. Until then a pull request is a proposal you can edit,
+ignore, or close on its own, and a package you do not merge is not released.
+
+## Preparing a release by hand
+
+The workflow runs the same tasks you would, and they still work on their own. The
+package's own pull request, if one is open, closes itself on the next push to
+`main`, because the version file is then ahead of the latest tag.
 
 ```sh
 mise run release-needed
@@ -10,8 +28,6 @@ mise run release-prepare <package> <version>
 git add <changed-files>
 git commit -m "chore(release): <package> <version>"
 git push origin main
-git tag <package>/v<version>
-git push origin <package>/v<version>
 ```
 
 Example:
@@ -22,30 +38,125 @@ mise run release-prepare cargo-lumis-cli 0.2.0
 git add crates/lumis-cli/Cargo.toml crates/lumis-cli/CHANGELOG.md
 git commit -m "chore(release): cargo-lumis-cli 0.2.0"
 git push origin main
-git tag cargo-lumis-cli/v0.2.0
-git push origin cargo-lumis-cli/v0.2.0
 ```
 
-- Run `mise run release-needed` first to decide which packages ship together. It ignores `chore` commits.
+The push is the publish. `release-tag.yml` reads that subject and pushes
+`cargo-lumis-cli/v0.2.0` for you, exactly as it would for a merged pull request.
+
+- Run `mise run release-needed` first to decide which packages ship together. It ignores `chore` commits. `mise run release-plan` answers the narrower question the workflow asks, and prints the version each package would get.
 - Pass the bare version to `mise run release-prepare`, for example `0.2.0`, not `v0.2.0`.
-- Include `v` only in the git tag, for example `cargo-lumis-cli/v0.2.0`.
-- Review each changed manifest and `CHANGELOG.md` after `mise run release-prepare`.
-- If one released package depends on another released package, update the dependent manifest in the same commit. See [Crate version requirements](#crate-version-requirements).
-- Push package tags in dependency order.
-- Watch the tag-triggered publish workflows after pushing tags.
-- Keep the commit subject exactly `chore(release): <package> <version>`. See [CI on the release commit](#ci-on-the-release-commit).
+- Review every file `mise run release-prepare` touches, not just the target package's manifest and `CHANGELOG.md`. See [Crate version requirements](#crate-version-requirements).
+- One release per commit. The subject names one package, so a commit bumping two releases only one of them.
+- Push releases in dependency order, one at a time, and let each publish finish before the next.
+- Write the commit subject as `chore(release): <package> <version>` and nothing else, except the `(#1234)` suffix a squash merge appends, which `release-tag.yml` strips. The subject decides whether CI skips and whether the release publishes at all. See [CI on the release commit](#ci-on-the-release-commit) and [Tagging](#tagging).
+
+## The release pull requests
+
+`release-prepare.yml` runs on every push to `main` and opens one pull request per
+package. Each is prepared independently, so you choose which packages ship and
+which sit; the order you merge them in is still [publish order](#publish-order),
+because that is dependency order and nothing enforces it for you.
+
+Every branch is rebuilt from `main` on every run rather than added to, and each
+one is prepared on a fresh checkout of `main` rather than on top of another
+package's preparation. Two consequences follow, and together they are what makes
+a pull request per package work at all:
+
+- **Each pull request always describes what would ship right now.** A package
+  that stops needing a release has its branch deleted, which closes its pull
+  request.
+- **Overlap resolves itself as you merge.** Preparing a crate rewrites the
+  version requirement other crates state for it, so two crate releases genuinely
+  touch some of the same files. Merging one rebuilds every other branch on top of
+  it, so the remaining pull requests carry the merged state rather than a stale
+  copy of it. This is why `release-prepare.yml` does not carry the
+  `chore(release):` guard the branch workflows do: the merge of a release pull
+  request is the push that changes the plan the most.
+
+`mise run release-plan` decides which packages get one. For each package in
+`mise run release-packages`, in that order, it takes the latest `<package>/v*`
+tag and asks `git-cliff --bumped-version` what the commits since then add up to,
+using the same `--include-path` scoping and the same `cliff.toml` that write the
+changelog. Three things make a package sit the round out:
+
+- **`git-cliff` has nothing to bump.** Only the commit types `cliff.toml` groups
+  count, so a package whose only new commits are `build(deps)` gets no pull
+  request. `mise run release-needed` still lists it, because it filters on
+  `chore` alone; releasing on a dependency bump is a judgement call, and the
+  automation does not make it for you. Prepare that one by hand.
+- **The version file is ahead of the latest tag.** That is a merged release
+  waiting for its tag. Preparing again would write a second changelog section for
+  a version that already has one, so `release-plan` skips the package and says so
+  until the tag is pushed.
+- **No `<package>/v*` tag exists.** `git-cliff` has no base to bump from, so cut
+  the first release by hand.
+
+The title and the commit message are both `chore(release): <package> <version>`,
+the subject a hand-prepared release uses, so squash-merging one produces the
+commit [CI on the release commit](#ci-on-the-release-commit) skips and
+[Tagging](#tagging) reads, give or take the `(#1234)` suffix GitHub appends. The
+body is the same few lines for every package apart from the name and the
+version.
+
+Everything about a package is derived from its name and its first path in
+`mise run release-packages`: `cargo-`, `npm-` and `hex-` select
+`Cargo.toml`, `package.json` or `mix.exs`, and the directory also holds the
+`CHANGELOG.md` and, for a crate, names the cargo package. Adding a package is
+therefore one row, as long as it follows that layout.
+
+## Tagging
+
+`release-tag.yml` runs on every push to `main` whose head commit subject starts
+with `chore(release):`, which is every merged release pull request and every
+hand-prepared release. It reads `<package> <version>` out of the subject, checks
+that the package exists and that its manifest really declares that version, and
+creates `<package>/v<version>` on the merge commit. Anything it cannot read, or a
+version the manifest disagrees with, fails the job rather than guessing.
+
+Two details that are load-bearing:
+
+- **The tag is created with `CI_TOKEN`, not `GITHUB_TOKEN`.** A ref pushed with
+  `GITHUB_TOKEN` raises no events, so the publish workflow the tag exists to
+  start would never run.
+- **The subject is the input.** `chore(release): <package> <version>` is what
+  `release-prepare.yml` writes and what a hand-prepared release must write, so
+  the spelling rule in [CI on the release commit](#ci-on-the-release-commit) now
+  decides whether a release publishes as well as whether CI skips.
+
+Merge one release at a time and let its publish finish before merging the next.
+Nothing enforces [publish order](#publish-order); merge order is publish order.
+
+One release per push, too. The workflow reads `github.event.head_commit`, so a
+push carrying two release commits tags only the last one, and the other ships
+nothing until its tag is pushed by hand. Merging pull requests one at a time
+gives that for free; batching commits locally does not.
 
 ## CI on the release commit
 
 A release commit is a version bump and a changelog entry on top of a commit CI
-already passed, so every branch workflow skips itself when the pushed head
-commit's subject starts with `chore(release):`:
+already passed, so every branch workflow skips itself for one, on the push and on
+the pull request that carries it:
 
 ```yaml
     if: >-
-      ${{ github.event_name != 'push' ||
-          !startsWith(github.event.head_commit.message, 'chore(release):') }}
+      ${{ !startsWith(github.event.head_commit.message, 'chore(release):') &&
+          !(github.event.pull_request.head.repo.full_name == github.repository &&
+            startsWith(github.event.pull_request.head.ref, 'release/')) }}
 ```
+
+Both halves are needed. The head commit covers the push, whether it came from a
+merged release pull request or from a hand-prepared release, and the branch covers
+the pull request itself, where there is no head commit to read. Without the second
+half, `Standalone packaged NIF lockfile` fails on every release pull request that
+bumps a crate, for exactly the reason below.
+
+**The second half keys on the branch rather than the title, and it must stay that
+way.** A title is contributor-controlled: anyone able to open a pull request could
+name it `chore(release): …` and skip the entire matrix on a change that had never
+been tested. A `release/*` branch in this repository is not, because only
+`release-prepare.yml` and people with push access can create one, which is the
+same set that could already skip CI by writing `chore(release):` in a commit
+subject. Widening the guard past that set gives a stranger the same power.
 
 Two consequences worth knowing:
 
@@ -63,7 +174,9 @@ Two consequences worth knowing:
   the package tag points at, so pushing `<package>/v<version>` would skip the
   publish workflow the release exists to trigger.
 
-Tag-triggered workflows carry no such guard, and must not grow one.
+Tag-triggered workflows carry no such guard, and must not grow one. Neither does
+`release-prepare.yml`, for the reason in
+[The release pull requests](#the-release-pull-requests).
 
 One branch job is exempt: `crate-deps` in `rust.yml`. `mise run check-crate-deps`
 reads manifests rather than the registry, so it passes on the bump commit, and
@@ -237,6 +350,14 @@ re-resolves the lockfile, and three places run it or check it:
 A red `Standalone packaged NIF lockfile` job on `main` means the refresh has not
 landed yet. Merge the pull request, or run the fix locally and commit the result.
 
+`hex-lumis` is therefore the one package whose job in `release-prepare.yml` can
+fail: while a crate release it requires is merged into `main` but not published,
+the fix has no version to resolve. That job is `continue-on-error`, so the failure
+shows in the run without turning it red or touching any other package's pull
+request, and the existing `hex-lumis` pull request, if there is one, stays as it
+was. Nothing is stuck: publishing the crate and merging `refresh-nif-lock` pushes
+to `main`, and the next run prepares `hex-lumis` against the published version.
+
 `elixir-release.yml` uploads the precompiled NIFs to a GitHub Release and syncs
 the same files to Cloudflare R2 under `releases/download/<tag>`, served from
 `https://artifacts.lumis.sh`. The R2 step fails the release if any of
@@ -253,11 +374,19 @@ If a release fails before any registry accepts the new version:
 
 1. Delete every package tag from the failed attempt.
 2. Fix the mistake on `main`.
-3. Run `mise run release-prepare <package> <version>` again for each affected package.
-4. Commit the updated changelog and version bump.
-5. Push the corrected package tags in dependency order.
+3. Push the corrected package tags in dependency order.
 
-If any registry already published the version, do not reuse it. Cut a new patch release instead.
+Push them by hand. The bump and the changelog are already on `main`, so nothing
+reopens a pull request to merge: with the tag deleted, the version file is ahead
+of the latest tag, which is exactly the state `release-plan` skips. `release-tag.yml`
+only reacts to a `chore(release):` commit arriving on `main`, and there is no new
+one, so the tag push is yours to make. It starts the publish workflow either way.
+
+If any registry already published the version, do not reuse it. Cut a new patch
+release instead. `release-plan` will not propose one, because the version file
+matches the tag again, so run `mise run release-prepare <package> <version>` and
+commit it to `main` with the usual `chore(release): <package> <version>` subject;
+tagging and publishing then happen on their own.
 
 ## Tag format
 

--- a/mise.lock
+++ b/mise.lock
@@ -46,6 +46,45 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_
 url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924919"
 provenance = "github-attestations"
 
+[[tools.git-cliff]]
+version = "2.13.1"
+backend = "aqua:orhun/git-cliff"
+
+[tools.git-cliff."platforms.linux-arm64"]
+checksum = "sha256:9619b7f0c584229f8a2331c1905afe88bd938bdc9102926c2073836a42f02455"
+url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850077"
+
+[tools.git-cliff."platforms.linux-arm64-musl"]
+checksum = "sha256:4054c124b926c117f3fa048939bc8be0a954f29f3b6f367627e8cb22c1971882"
+url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850720"
+
+[tools.git-cliff."platforms.linux-x64"]
+checksum = "sha256:9a1263f24e59a2f508c7b3d3283c9dea94a8bf697f96dbc18cc783cac6284546"
+url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850439"
+
+[tools.git-cliff."platforms.linux-x64-musl"]
+checksum = "sha256:200d2535da6d9703f3bcc8a4d159c3b55eacdb01cf2148c55b3eee9dd04d5249"
+url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850671"
+
+[tools.git-cliff."platforms.macos-arm64"]
+checksum = "sha256:21547ae4a0421164070ab75c2522864ea5565858a011fabc5f583061b20f1226"
+url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405849885"
+
+[tools.git-cliff."platforms.macos-x64"]
+checksum = "sha256:6e60ae390d375cecb9d8008c49f0e724a8dfe40390b532ef5501e421d2cc8acb"
+url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405850193"
+
+[tools.git-cliff."platforms.windows-x64"]
+checksum = "sha256:3ae3a5549e85c7ad5b20192ebcfee4371269deca51255f6f2f2e051c6541f5ca"
+url = "https://github.com/orhun/git-cliff/releases/download/v2.13.1/git-cliff-2.13.1-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/orhun/git-cliff/releases/assets/405851866"
+
 [[tools.python]]
 version = "3.11.15"
 backend = "core:python"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 actionlint = "1.7.12"
+git-cliff = "2.13.1"
 python = "3.11"
 stylua = "2.5.2"
 tree-sitter = "0.26"
@@ -61,12 +62,13 @@ check_bin node "https://nodejs.org"
 check_bin pnpm "https://pnpm.io/installation"
 check_bin mise "https://mise.jdx.dev/getting-started.html"
 check_bin mix "https://elixir-lang.org/install.html"
+check_bin jq "https://jqlang.org/download"
 check_bin stylua "run 'mise install'"
+check_bin git-cliff "run 'mise install'"
 echo ""
 
 echo "Checking optional tools..."
 check_tree_sitter_cli
-check_bin git-cliff "https://git-cliff.org"
 check_bin nvim "https://neovim.io (needed for theme generation)"
 echo ""
 
@@ -881,37 +883,44 @@ set -euo pipefail
 cargo run --manifest-path crates/dev/Cargo.toml -- list-themes
 '''
 
+[tasks.'release-packages']
+description = "List every releasable package and the commit paths that scope its release"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+cat <<'TABLE'
+cargo-lumis-core|crates/lumis-core
+cargo-lumis-build|crates/lumis-build
+cargo-lumis-wasm-runtime|crates/lumis-wasm-runtime
+cargo-lumis|crates/lumis
+cargo-lumis-cli|crates/lumis-cli|crates/lumis-wasm-runtime
+npm-themes|packages/javascript/themes
+npm-lumis|packages/javascript/lumis|crates/lumis|crates/lumis-core|crates/lumis-wasm-runtime
+npm-markdown-it-lumis|packages/javascript/markdown-it-lumis
+npm-rehype-lumis|packages/javascript/rehype-lumis
+npm-react|packages/javascript/react
+npm-cli|packages/javascript/cli|crates/lumis-cli|crates/lumis-wasm-runtime
+npm-wasm-bundle-web|packages/javascript/wasm-bundle-web
+npm-wasm-bundle-web-extra|packages/javascript/wasm-bundle-web-extra
+npm-wasm-bundle-system|packages/javascript/wasm-bundle-system
+npm-wasm-bundle-backend|packages/javascript/wasm-bundle-backend
+npm-wasm-bundle-full|packages/javascript/wasm-bundle-full
+hex-lumis|packages/elixir/lumis
+TABLE
+'''
+
 [tasks.'release-needed']
 description = "List packages with non-chore path-scoped commits since their latest release tag"
 run = '''
 #!/usr/bin/env bash
 set -euo pipefail
-packages=(
-    "cargo-lumis-core|crates/lumis-core"
-    "cargo-lumis-build|crates/lumis-build"
-    "cargo-lumis-wasm-runtime|crates/lumis-wasm-runtime"
-    "cargo-lumis|crates/lumis"
-    "cargo-lumis-cli|crates/lumis-cli|crates/lumis-wasm-runtime"
-    "npm-themes|packages/javascript/themes"
-    "npm-lumis|packages/javascript/lumis|crates/lumis|crates/lumis-core|crates/lumis-wasm-runtime"
-    "npm-markdown-it-lumis|packages/javascript/markdown-it-lumis"
-    "npm-rehype-lumis|packages/javascript/rehype-lumis"
-    "npm-react|packages/javascript/react"
-    "npm-cli|packages/javascript/cli|crates/lumis-cli|crates/lumis-wasm-runtime"
-    "npm-wasm-bundle-web|packages/javascript/wasm-bundle-web"
-    "npm-wasm-bundle-web-extra|packages/javascript/wasm-bundle-web-extra"
-    "npm-wasm-bundle-system|packages/javascript/wasm-bundle-system"
-    "npm-wasm-bundle-backend|packages/javascript/wasm-bundle-backend"
-    "npm-wasm-bundle-full|packages/javascript/wasm-bundle-full"
-    "hex-lumis|packages/elixir/lumis"
-)
-
+table="$(mise run release-packages)"
 found=0
 
-for entry in "${packages[@]}"; do
+while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
     package="${entry%%|*}"
-    paths="${entry#*|}"
-    IFS='|' read -r -a package_paths <<< "$paths"
+    IFS='|' read -r -a package_paths <<< "${entry#*|}"
     tag="$(git tag --list "$package/v*" --sort=-version:refname | head -n1)"
 
     if [ -n "$tag" ]; then
@@ -935,11 +944,78 @@ for entry in "${packages[@]}"; do
         echo "  $line"
     done <<< "$commits"
     echo ""
-done
+done <<< "$table"
 
 if [ "$found" -eq 0 ]; then
     echo "No package-scoped commits found since the latest package tags."
 fi
+'''
+
+[tasks.'release-version']
+description = "Print the version a package's manifest declares in the working tree"
+usage = '''
+arg "<package>"
+'''
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+package="${usage_package?}"
+
+entry="$(mise run release-packages | awk -F'|' -v name="$package" '$1 == name')"
+if [ -z "$entry" ]; then
+    echo "Unknown package: $package" >&2
+    exit 1
+fi
+
+IFS='|' read -r -a package_paths <<< "${entry#*|}"
+directory="${package_paths[0]}"
+
+case "${package%%-*}" in
+    cargo) sed -n 's/^version = "\([^"]*\)"$/\1/p' "$directory/Cargo.toml" | head -n1 ;;
+    npm) jq -r .version "$directory/package.json" ;;
+    hex) sed -n 's/^  @version "\([^"]*\)"$/\1/p' "$directory/mix.exs" | head -n1 ;;
+esac
+'''
+
+[tasks.'release-plan']
+description = "Print the package and version of every release that can be prepared from the current branch"
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+table="$(mise run release-packages)"
+
+while IFS= read -r entry; do
+    [ -n "$entry" ] || continue
+    package="${entry%%|*}"
+    IFS='|' read -r -a package_paths <<< "${entry#*|}"
+
+    current="$(mise run release-version "$package")"
+
+    tag="$(git tag --list "$package/v*" --sort=-version:refname | head -n1)"
+    if [ -z "$tag" ]; then
+        printf 'skipping %s: no %s/v* tag yet, so the first release has to be cut by hand\n' "$package" "$package" >&2
+        continue
+    fi
+
+    if [ "$current" != "${tag#*/v}" ]; then
+        printf 'skipping %s: %s is already prepared and %s is still the latest tag\n' "$package" "$current" "$tag" >&2
+        continue
+    fi
+
+    include_args=()
+    for path in "${package_paths[@]}"; do
+        include_args+=(--include-path "$path/**/*")
+    done
+
+    next="$(git-cliff --config cliff.toml --tag-pattern "$package/v[0-9].*" --bumped-version "${include_args[@]}")"
+    next="${next#*/v}"
+
+    if [ "$next" = "$current" ]; then
+        continue
+    fi
+
+    printf '%s %s\n' "$package" "$next"
+done <<< "$table"
 '''
 
 [tasks.'release-prepare']
@@ -953,149 +1029,33 @@ run = '''
 set -euo pipefail
 package="${usage_package?}"
 version="${usage_version?}"
-case "$package" in
-    cargo-lumis)
-        manifest="crates/lumis/Cargo.toml"
-        changelog="crates/lumis/CHANGELOG.md"
-        include_path="crates/lumis/**/*"
-        kind="cargo"
-        cargo_package="lumis"
-        ;;
-    cargo-lumis-core)
-        manifest="crates/lumis-core/Cargo.toml"
-        changelog="crates/lumis-core/CHANGELOG.md"
-        include_path="crates/lumis-core/**/*"
-        kind="cargo"
-        cargo_package="lumis-core"
-        ;;
-    cargo-lumis-build)
-        manifest="crates/lumis-build/Cargo.toml"
-        changelog="crates/lumis-build/CHANGELOG.md"
-        include_path="crates/lumis-build/**/*"
-        kind="cargo"
-        cargo_package="lumis-build"
-        ;;
-    cargo-lumis-wasm-runtime)
-        manifest="crates/lumis-wasm-runtime/Cargo.toml"
-        changelog="crates/lumis-wasm-runtime/CHANGELOG.md"
-        include_path="crates/lumis-wasm-runtime/**/*"
-        kind="cargo"
-        cargo_package="lumis-wasm-runtime"
-        ;;
-    cargo-lumis-cli)
-        manifest="crates/lumis-cli/Cargo.toml"
-        changelog="crates/lumis-cli/CHANGELOG.md"
-        include_path="crates/lumis-cli/**/*"
-        kind="cargo"
-        cargo_package="lumis-cli"
-        ;;
-    npm-lumis)
-        manifest="packages/javascript/lumis/package.json"
-        changelog="packages/javascript/lumis/CHANGELOG.md"
-        include_path="packages/javascript/lumis/**/*"
-        kind="npm"
-        ;;
-    npm-markdown-it-lumis)
-        manifest="packages/javascript/markdown-it-lumis/package.json"
-        changelog="packages/javascript/markdown-it-lumis/CHANGELOG.md"
-        include_path="packages/javascript/markdown-it-lumis/**/*"
-        kind="npm"
-        ;;
-    npm-rehype-lumis)
-        manifest="packages/javascript/rehype-lumis/package.json"
-        changelog="packages/javascript/rehype-lumis/CHANGELOG.md"
-        include_path="packages/javascript/rehype-lumis/**/*"
-        kind="npm"
-        ;;
-    npm-react)
-        manifest="packages/javascript/react/package.json"
-        changelog="packages/javascript/react/CHANGELOG.md"
-        include_path="packages/javascript/react/**/*"
-        kind="npm"
-        ;;
-    npm-cli)
-        manifest="packages/javascript/cli/package.json"
-        changelog="packages/javascript/cli/CHANGELOG.md"
-        include_path="packages/javascript/cli/**/*"
-        kind="npm"
-        ;;
-    npm-themes)
-        manifest="packages/javascript/themes/package.json"
-        changelog="packages/javascript/themes/CHANGELOG.md"
-        include_path="packages/javascript/themes/**/*"
-        kind="npm"
-        ;;
-    npm-wasm-bundle-web)
-        manifest="packages/javascript/wasm-bundle-web/package.json"
-        changelog="packages/javascript/wasm-bundle-web/CHANGELOG.md"
-        include_path="packages/javascript/wasm-bundle-web/**/*"
-        kind="npm"
-        ;;
-    npm-wasm-bundle-web-extra)
-        manifest="packages/javascript/wasm-bundle-web-extra/package.json"
-        changelog="packages/javascript/wasm-bundle-web-extra/CHANGELOG.md"
-        include_path="packages/javascript/wasm-bundle-web-extra/**/*"
-        kind="npm"
-        ;;
-    npm-wasm-bundle-system)
-        manifest="packages/javascript/wasm-bundle-system/package.json"
-        changelog="packages/javascript/wasm-bundle-system/CHANGELOG.md"
-        include_path="packages/javascript/wasm-bundle-system/**/*"
-        kind="npm"
-        ;;
-    npm-wasm-bundle-backend)
-        manifest="packages/javascript/wasm-bundle-backend/package.json"
-        changelog="packages/javascript/wasm-bundle-backend/CHANGELOG.md"
-        include_path="packages/javascript/wasm-bundle-backend/**/*"
-        kind="npm"
-        ;;
-    npm-wasm-bundle-full)
-        manifest="packages/javascript/wasm-bundle-full/package.json"
-        changelog="packages/javascript/wasm-bundle-full/CHANGELOG.md"
-        include_path="packages/javascript/wasm-bundle-full/**/*"
-        kind="npm"
-        ;;
-    hex-lumis)
-        manifest="packages/elixir/lumis/mix.exs"
-        changelog="packages/elixir/lumis/CHANGELOG.md"
-        include_path="packages/elixir/lumis/**/*"
-        kind="hex"
-        ;;
-    *) echo "Unknown package: $package" >&2; exit 1 ;;
-esac
 
-tag="$package/v$version"
-include_args=(--include-path "$include_path")
-case "$package" in
-    cargo-lumis-cli)
-        include_args+=(--include-path "crates/lumis-wasm-runtime/**/*")
-        ;;
-    npm-cli)
-        include_args+=(
-            --include-path "crates/lumis-cli/**/*"
-            --include-path "crates/lumis-wasm-runtime/**/*"
-        )
-        ;;
-    npm-lumis)
-        include_args+=(
-            --include-path "crates/lumis/**/*"
-            --include-path "crates/lumis-core/**/*"
-            --include-path "crates/lumis-wasm-runtime/**/*"
-        )
-        ;;
-esac
+entry="$(mise run release-packages | awk -F'|' -v name="$package" '$1 == name')"
+if [ -z "$entry" ]; then
+    echo "Unknown package: $package" >&2
+    exit 1
+fi
 
-case "$kind" in
+IFS='|' read -r -a package_paths <<< "${entry#*|}"
+directory="${package_paths[0]}"
+changelog="$directory/CHANGELOG.md"
+
+include_args=()
+for path in "${package_paths[@]}"; do
+    include_args+=(--include-path "$path/**/*")
+done
+
+case "${package%%-*}" in
     cargo)
-        cargo set-version --manifest-path "$manifest" -p "$cargo_package" "$version"
+        cargo set-version --manifest-path "$directory/Cargo.toml" -p "${directory##*/}" "$version"
         mise run check-crate-deps --fix
         ;;
     npm)
-        npm --prefix "$(dirname "$manifest")" version --no-git-tag-version "$version"
+        npm --prefix "$directory" version --no-git-tag-version "$version"
         ;;
     hex)
         mise run elixir-nif-lock-check --fix
-        python3 -c 'from pathlib import Path; import re, sys; path = Path(sys.argv[1]); version = sys.argv[2]; content = path.read_text(); content = re.sub(r"@version \"[^\"]+\"", f"@version \"{version}\"", content, count=1); path.write_text(content)' "$manifest" "$version"
+        python3 -c 'from pathlib import Path; import re, sys; path = Path(sys.argv[1]); version = sys.argv[2]; content = path.read_text(); content = re.sub(r"@version \"[^\"]+\"", f"@version \"{version}\"", content, count=1); path.write_text(content)' "$directory/mix.exs" "$version"
         ;;
 esac
 
@@ -1112,6 +1072,6 @@ if [ "$package" = "npm-cli" ]; then
     done
 fi
 
-git-cliff --config cliff.toml --github-repo leandrocp/lumis --tag-pattern "$package/v[0-9].*" --tag "$tag" --prepend "$changelog" --strip header --unreleased "${include_args[@]}"
+git-cliff --config cliff.toml --github-repo leandrocp/lumis --tag-pattern "$package/v[0-9].*" --tag "$package/v$version" --prepend "$changelog" --strip header --unreleased "${include_args[@]}"
 printf 'Prepared %s %s\n' "$package" "$version"
 '''


### PR DESCRIPTION
Running `mise run release-prepare` by hand for every package that needs it, then remembering the dependency order and pushing tags, is the annoying part of shipping here. This automates all of it.

## What happens now

1. Every push to `main` runs `release-prepare.yml`. It works out which packages have unreleased changelog commits, prepares each one in its own matrix job, and opens or updates **one pull request per package** — titled and committed as `chore(release): <package> <version>`, on branch `release/<package>`.
2. **Merging one ships it.** `release-tag.yml` reads that subject off the merge commit, verifies it, and pushes `<package>/v<version>` — which starts the publish workflow that already existed.

So the release decision is "merge this PR", per package, in whatever order you want.

Against `main` as of this branch it would open eight:

| Pull request | Branch |
| --- | --- |
| `chore(release): cargo-lumis-core 2.5.0` | `release/cargo-lumis-core` |
| `chore(release): cargo-lumis-wasm-runtime 0.3.0` | `release/cargo-lumis-wasm-runtime` |
| `chore(release): cargo-lumis 0.14.0` | `release/cargo-lumis` |
| `chore(release): cargo-lumis-cli 0.6.0` | `release/cargo-lumis-cli` |
| `chore(release): npm-themes 0.4.0` | `release/npm-themes` |
| `chore(release): npm-lumis 0.8.0` | `release/npm-lumis` |
| `chore(release): npm-cli 0.7.0` | `release/npm-cli` |
| `chore(release): hex-lumis 0.8.0` | `release/hex-lumis` |

Nothing enforces publish order — merge order is publish order, one at a time.

## Tagging

`release-tag.yml` runs on any push to `main` whose head commit subject starts with `chore(release):`, so it covers merged PRs and hand-prepared releases alike. It refuses to guess: the subject must name a package the release table knows, and a version that package's manifest actually declares, or the job fails rather than tagging something nobody asked for. Re-running is a no-op once the tag exists.

The tag is created with `CI_TOKEN`, not `GITHUB_TOKEN` — a ref pushed with `GITHUB_TOKEN` raises no events, so the publish workflow would never start.

## Overlap between the PRs

Preparing a crate rewrites the version requirement its dependents state for it, so two crate releases genuinely touch some of the same files. Merging one is what resolves that: each package is prepared on a fresh checkout of `main`, never on top of another package's preparation, and every branch is rebuilt from `main` on every run.

This is also why `release-prepare.yml` does **not** carry the `chore(release):` skip guard the branch workflows do. Merging a release PR is the one push that most needs a re-plan: the package that just landed leaves the plan, and every other open PR gets rebuilt on the merge.

A package that leaves the plan has its branch deleted, which closes its PR.

## Deciding the version

`mise run release-plan` takes each package's latest `<package>/v*` tag and asks `git-cliff --bumped-version` what the commits since then add up to, reusing the same `--include-path` scoping and the same `cliff.toml` `[bump]` rules that already generate the changelog. No new semver logic.

A package sits the round out when git-cliff has nothing to bump (a package whose only new commits are `build(deps)` gets no PR, since `cliff.toml` does not changelog those), when its version file is already ahead of its latest tag (a merged release still waiting for its tag), or when it has no tag to bump from.

## CodeRabbit findings

All four addressed:

- **Contributor-controlled CI bypass.** Correct and serious — the guard keyed on `pull_request.title`, so anyone able to open a PR could title it `chore(release):` and skip the entire matrix. It now keys on a `release/*` head branch **in this repository**, which only `release-prepare.yml` or someone with push access can create — the same set that could already skip CI by writing `chore(release):` in a commit subject. RELEASE.md records why it must stay branch-based.
- **`continue-on-error: true` masked real failures.** Now `continue-on-error: ${{ matrix.release.package == 'hex-lumis' }}`; every other package failing fails the run.
- **CONTRIBUTING.md understated what `release-prepare` touches.** Fixed to say it also rewrites dependent manifests and lockfiles, and that all of it must be reviewed and committed.
- **`rust.yml` `synced-manifest` / `crate-deps`.** `crate-deps` is deliberately unguarded and stays that way — a release commit is the only commit that writes new `version` requirements, and it reads manifests rather than the registry. `synced-manifest` keeps the guard: `crates/lumis-cli/build.rs` re-syncs the fixture on build, and a version bump cannot desync it.

## One package table

`release-needed`, `release-plan`, `release-version` and `release-prepare` now read one table from `mise run release-packages`. Everything else derives from the package name and its directory — `cargo-`/`npm-`/`hex-` selects `Cargo.toml`/`package.json`/`mix.exs`, and the directory holds the changelog and names the cargo package. The 17-branch `case` in `release-prepare` is gone; adding a package is one row.

## Verification

- `mise run release-prepare` produces byte-identical diffs and file lists to the previous implementation, from a pristine `main`, for all eight packages currently due a release — covering cargo, npm, the `npm-lumis` and `npm-cli` lockstep cases, and hex.
- `mise run release-needed` output is byte-identical to before; `mise run release-plan` returns exactly those eight, in dependency order, unchanged after the `release-version` extraction.
- `release-tag.yml`'s subject parsing and validation exercised locally across squash-merge suffixes, multi-line bodies, unknown packages, unparseable subjects, version mismatch, tag-already-exists, and the create path.
- `mise run lint-workflows` passes.

Neither workflow has run on GitHub yet.
