### PR TITLE
fix(ci): authenticate release changelog generation

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -116,6 +116,7 @@ jobs:
 
       - name: Prepare release
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           PACKAGE: ${{ matrix.release.package }}
           VERSION: ${{ matrix.release.version }}
         run: |


### PR DESCRIPTION
## Summary

- export the workflow read-only GitHub token to the release preparation step
- keep branch and pull-request writes on the existing `CI_TOKEN` path
- prevent git-cliff GitHub metadata requests from exhausting the anonymous API limit

## Failure

Run 33252811711 planned releases successfully, then every package preparation job failed in git-cliff with HTTP 403 while paginating repository commits.

## Validation

- `mise run lint-workflows`
- reproduced the npm CLI git-cliff command with an authenticated `GITHUB_TOKEN`; changelog generation completed with PR metadata