### PR TITLE
Expose a NIF bridge for mdex_native

### DIFF
--- a/.github/workflows/elixir-release.yml
+++ b/.github/workflows/elixir-release.yml
@@ -45,6 +45,7 @@ jobs:
       project-name: lumis_nif
       project-dir: packages/elixir/lumis/native/lumis_nif
       working-directory: packages/elixir/lumis
+      nif-versions: '["2.16"]'
       r2-path: releases/download/${{ inputs.tag || github.ref_name }}
     secrets:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -217,6 +217,13 @@ In Elixir it is cheaper still, because loading is global to the VM. One
 `Runtime` lives in the NIF, so the first process to need a language pays, and
 every process after it does not.
 
+The Elixir NIF also owns the Lumis implementation used by MDEx. It exposes the
+versioned `lumis_mdex_bridge_v1` dynamic resource, and mdex_native calls that
+resource through NIF 2.16 instead of linking another copy of Lumis. The bridge
+passes only BEAM terms and keeps all allocation and rendering inside Lumis's
+NIF, so the two independently released libraries do not share Rust layouts or
+allocator-owned buffers.
+
 Browsers are the exception. `web-tree-sitter` loads asynchronously, so a parser
 cannot be fetched inside a synchronous walk; an injected language has to be
 loaded before the document mentioning it. Node runs the native addon

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -1114,4 +1114,7 @@ defmodule Lumis do
       when is_binary(language) and is_binary(source) do
     highlight!(source, language: language)
   end
+
+  @doc false
+  def __mdex_bridge__, do: Lumis.Native.mdex_bridge()
 end

--- a/packages/elixir/lumis/lib/lumis/native.ex
+++ b/packages/elixir/lumis/lib/lumis/native.ex
@@ -52,8 +52,7 @@ defmodule Lumis.Native do
       "x86_64-pc-windows-gnu" => other_variants,
       "x86_64-unknown-freebsd" => other_variants
     },
-    # We don't use any features of newer NIF versions, so 2.15 is enough.
-    nif_versions: ["2.15"],
+    nif_versions: ["2.16"],
     mode: mode,
     force_build: System.get_env("LUMIS_BUILD") in ["1", "true"]
 
@@ -77,4 +76,5 @@ defmodule Lumis.Native do
   def has_language(_name), do: :erlang.nif_error(:nif_not_loaded)
   def loaded_languages(), do: :erlang.nif_error(:nif_not_loaded)
   def highlight(_source, _options), do: :erlang.nif_error(:nif_not_loaded)
+  def mdex_bridge(), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/packages/elixir/lumis/mix.exs
+++ b/packages/elixir/lumis/mix.exs
@@ -8,7 +8,7 @@ defmodule Lumis.MixProject do
     [
       app: :lumis,
       version: @version,
-      elixir: "~> 1.15",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,
       package: package(),

--- a/packages/elixir/lumis/mix.exs
+++ b/packages/elixir/lumis/mix.exs
@@ -8,7 +8,7 @@ defmodule Lumis.MixProject do
     [
       app: :lumis,
       version: @version,
-      elixir: "~> 1.14",
+      elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,
       package: package(),

--- a/packages/elixir/lumis/native/lumis_nif/Cargo.toml
+++ b/packages/elixir/lumis/native/lumis_nif/Cargo.toml
@@ -14,10 +14,10 @@ crate-type = ["cdylib"]
 anyhow = "1"
 once_cell = "1.21"
 parking_lot = "0.12"
-rustler = "0.38"
+rustler = { version = "0.38", default-features = false }
 lumis-core = { version = "2.4.0", default-features = false, features = ["all-languages"] }
 lumis-wasm-runtime = "0.2.0"
 
 [features]
-default = ["nif_version_2_15"]
-nif_version_2_15 = ["rustler/nif_version_2_15"]
+default = ["nif_version_2_16"]
+nif_version_2_16 = ["rustler/nif_version_2_16"]

--- a/packages/elixir/lumis/native/lumis_nif/src/lib.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 
 mod elixir;
+mod mdex_bridge;
 
 use anyhow::{anyhow, Context, Result};
 use elixir::{ExCssOptions, ExFormatterOption, ExTheme};

--- a/packages/elixir/lumis/native/lumis_nif/src/mdex_bridge.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/mdex_bridge.rs
@@ -64,7 +64,9 @@ fn render_code_fence(
     // Comrak includes the code-fence terminator's newline in the literal. Its
     // adapter contract historically did not turn that into another visual line.
     let source = source.strip_suffix('\n').unwrap_or(source);
-    let language = Language::guess(language, source);
+    // A fence without an info string stays plain. Content detection would let a
+    // shebang or a doctype inside a bare fence pick a language MDEx never named.
+    let language = Language::guess(Some(language.unwrap_or("plaintext")), source);
     let formatter = formatter
         .unwrap_or_default()
         .with_mdex_attributes(attributes, render_unsafe);
@@ -362,15 +364,17 @@ fn parse_highlight_lines(spec: &str) -> Option<Vec<ExLineSpec>> {
         .map(str::trim)
         .filter(|part| !part.is_empty())
     {
+        // A part that does not parse is dropped on its own. One typo in a
+        // decorator must not silently turn off highlighting for the whole fence.
         if let Some((start, end)) = part.split_once('-') {
-            let start = start.trim().parse().ok()?;
-            let end = end.trim().parse().ok()?;
+            let (Ok(start), Ok(end)) = (start.trim().parse(), end.trim().parse()) else {
+                continue;
+            };
             if start == 0 || start > end {
                 continue;
             }
             lines.push(ExLineSpec::Range { start, end });
-        } else {
-            let line = part.parse().ok()?;
+        } else if let Ok(line) = part.parse() {
             if line > 0 {
                 lines.push(ExLineSpec::Single(line));
             }
@@ -384,12 +388,164 @@ fn parse_highlight_lines(spec: &str) -> Option<Vec<ExLineSpec>> {
 mod tests {
     use super::*;
 
+    fn render(
+        source: &str,
+        language: Option<&str>,
+        formatter: Option<ExFormatterOption>,
+        attributes: &[(&str, &str)],
+        render_unsafe: bool,
+    ) -> String {
+        let attributes = attributes
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect();
+
+        render_code_fence(source, language, formatter, &attributes, render_unsafe).unwrap()
+    }
+
     #[test]
     fn parses_single_lines_and_ranges() {
         let lines = parse_highlight_lines("1, 3-5, 0, 7-6").unwrap();
         assert_eq!(lines.len(), 2);
         assert!(matches!(lines[0], ExLineSpec::Single(1)));
         assert!(matches!(lines[1], ExLineSpec::Range { start: 3, end: 5 }));
+    }
+
+    #[test]
+    fn keeps_parsable_parts_when_one_part_is_malformed() {
+        let lines = parse_highlight_lines("1, oops, 3-5, 7-x").unwrap();
+        assert_eq!(lines.len(), 2);
+        assert!(matches!(lines[0], ExLineSpec::Single(1)));
+        assert!(matches!(lines[1], ExLineSpec::Range { start: 3, end: 5 }));
+    }
+
+    #[test]
+    fn omits_the_closing_tags_comrak_writes_itself() {
+        let html = render("hello\n", Some("plaintext"), None, &[], false);
+        assert!(html.starts_with("<pre"), "{html}");
+        assert!(!html.contains("</code></pre>"), "{html}");
+    }
+
+    #[test]
+    fn does_not_render_the_code_fence_terminator_as_a_line() {
+        let one_line = render("hello\n", Some("plaintext"), None, &[], false);
+        assert_eq!(one_line.matches("data-line=").count(), 1, "{one_line}");
+    }
+
+    #[test]
+    fn a_fence_without_an_info_string_stays_plain() {
+        let html = render("#!/usr/bin/env python\nx = 1\n", None, None, &[], false);
+        assert!(html.contains("language-plaintext"), "{html}");
+        assert!(!html.contains("language-python"), "{html}");
+    }
+
+    #[test]
+    fn decorator_attributes_override_the_formatter() {
+        let html = render(
+            "hello\n",
+            Some("plaintext"),
+            None,
+            &[("pre_class", "custom-class"), ("highlight_lines", "1")],
+            false,
+        );
+
+        assert!(html.contains("custom-class"), "{html}");
+        assert!(html.contains("background-color: #3b4252;"), "{html}");
+    }
+
+    #[test]
+    fn a_light_theme_decorator_picks_the_light_line_background() {
+        let html = render(
+            "hello\n",
+            Some("plaintext"),
+            None,
+            &[("theme", "github_light"), ("highlight_lines", "1")],
+            false,
+        );
+
+        assert!(html.contains("background-color: #e7eaf0;"), "{html}");
+    }
+
+    #[test]
+    fn escapes_decorator_attributes_in_the_rendered_html() {
+        let injection = "x\" onmouseover=\"alert(1)";
+        let html = render(
+            "hello\n",
+            Some("plaintext"),
+            None,
+            &[
+                ("pre_class", injection),
+                ("highlight_lines", "1"),
+                ("highlight_lines_class", injection),
+                ("highlight_lines_style", injection),
+            ],
+            false,
+        );
+
+        assert!(!html.contains("onmouseover=\"alert(1)"), "{html}");
+        assert!(html.contains("&quot;"), "{html}");
+    }
+
+    #[test]
+    fn preserves_decorator_attributes_when_rendering_unsafe() {
+        let html = render(
+            "hello\n",
+            Some("plaintext"),
+            None,
+            &[
+                ("highlight_lines", "1"),
+                ("highlight_lines_style", "color: red;"),
+            ],
+            true,
+        );
+
+        assert!(html.contains("color: red;"), "{html}");
+    }
+
+    #[test]
+    fn a_linked_formatter_defaults_the_highlighted_line_class() {
+        let formatter = ExFormatterOption::HtmlLinked {
+            pre_class: None,
+            rainbow_brackets: false,
+            highlight_lines: None,
+            header: None,
+        };
+        let html = render(
+            "hello\n",
+            Some("plaintext"),
+            Some(formatter),
+            &[("highlight_lines", "1")],
+            false,
+        );
+
+        assert!(html.contains("highlighted"), "{html}");
+    }
+
+    #[test]
+    fn an_out_of_range_highlight_line_highlights_nothing() {
+        let html = render(
+            "hello\n",
+            Some("plaintext"),
+            None,
+            &[("highlight_lines", "5-9")],
+            false,
+        );
+
+        assert!(!html.contains("background-color: #3b4252;"), "{html}");
+    }
+
+    #[test]
+    fn a_header_never_survives_the_bridge() {
+        // Comrak writes the closing tags, so an outer header could never be closed.
+        let html = render(
+            "hello\n",
+            Some("plaintext"),
+            None,
+            &[("pre_class", "plain")],
+            false,
+        );
+
+        assert!(html.starts_with("<pre"), "{html}");
     }
 
     #[test]

--- a/packages/elixir/lumis/native/lumis_nif/src/mdex_bridge.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/mdex_bridge.rs
@@ -104,15 +104,7 @@ impl ExFormatterOption {
         attributes: &HashMap<String, String>,
         render_unsafe: bool,
     ) -> Self {
-        let pre_class = || {
-            attributes.get("pre_class").map(|class| {
-                if render_unsafe {
-                    class.clone()
-                } else {
-                    html::escape(class)
-                }
-            })
-        };
+        let pre_class = || mdex_attribute(attributes, "pre_class", render_unsafe);
 
         match self {
             Self::HtmlInline {
@@ -137,7 +129,7 @@ impl ExFormatterOption {
                     include_highlights = true;
                 }
                 if let Some(lines) =
-                    inline_highlight_lines(attributes, Some(line_background(&theme)))
+                    inline_highlight_lines(attributes, Some(line_background(&theme)), render_unsafe)
                 {
                     highlight_lines = Some(lines);
                 }
@@ -163,7 +155,7 @@ impl ExFormatterOption {
                 if let Some(class) = pre_class() {
                     formatter_pre_class = Some(class);
                 }
-                if let Some(lines) = linked_highlight_lines(attributes) {
+                if let Some(lines) = linked_highlight_lines(attributes, render_unsafe) {
                     highlight_lines = Some(lines);
                 }
 
@@ -194,6 +186,7 @@ impl ExFormatterOption {
                 if let Some(lines) = inline_highlight_lines(
                     attributes,
                     Some(line_background_from_name(attributes.get("theme"))),
+                    render_unsafe,
                 ) {
                     highlight_lines = Some(lines);
                 } else if let Some(lines) = highlight_lines.as_mut() {
@@ -227,8 +220,11 @@ impl ExFormatterOption {
                 if let Some(theme_name) = attributes.get("theme") {
                     theme = Some(ThemeOrString::String(theme_name.clone()));
                 }
-                let highlight_lines =
-                    inline_highlight_lines(attributes, Some(line_background(&theme)));
+                let highlight_lines = inline_highlight_lines(
+                    attributes,
+                    Some(line_background(&theme)),
+                    render_unsafe,
+                );
 
                 Self::HtmlInline {
                     theme,
@@ -246,7 +242,7 @@ impl ExFormatterOption {
                 italic: false,
                 include_highlights: attributes.contains_key("include_highlights"),
                 rainbow_brackets,
-                highlight_lines: inline_highlight_lines(attributes, None),
+                highlight_lines: inline_highlight_lines(attributes, None, render_unsafe),
                 header: None,
             },
         }
@@ -256,6 +252,7 @@ impl ExFormatterOption {
 fn inline_highlight_lines(
     attributes: &HashMap<String, String>,
     default_style: Option<String>,
+    render_unsafe: bool,
 ) -> Option<ExHtmlInlineHighlightLines> {
     let lines = parse_highlight_lines(attributes.get("highlight_lines")?)?;
     let style = attributes
@@ -263,7 +260,7 @@ fn inline_highlight_lines(
         .map(|style| match style.as_str() {
             "theme" => ExHtmlInlineHighlightLinesStyle::Theme,
             style => ExHtmlInlineHighlightLinesStyle::Style {
-                style: style.to_string(),
+                style: escape_mdex_attribute(style, render_unsafe),
             },
         })
         .or_else(|| default_style.map(|style| ExHtmlInlineHighlightLinesStyle::Style { style }));
@@ -271,8 +268,26 @@ fn inline_highlight_lines(
     Some(ExHtmlInlineHighlightLines {
         lines,
         style,
-        class: attributes.get("highlight_lines_class").cloned(),
+        class: mdex_attribute(attributes, "highlight_lines_class", render_unsafe),
     })
+}
+
+fn mdex_attribute(
+    attributes: &HashMap<String, String>,
+    name: &str,
+    render_unsafe: bool,
+) -> Option<String> {
+    attributes
+        .get(name)
+        .map(|value| escape_mdex_attribute(value, render_unsafe))
+}
+
+fn escape_mdex_attribute(value: &str, render_unsafe: bool) -> String {
+    if render_unsafe {
+        value.to_string()
+    } else {
+        html::escape(value)
+    }
 }
 
 fn line_background(theme: &Option<ThemeOrString>) -> String {
@@ -330,12 +345,11 @@ fn flatten_events(source: &str, events: Vec<HighlightEvent>) -> Vec<HighlightEve
 
 fn linked_highlight_lines(
     attributes: &HashMap<String, String>,
+    render_unsafe: bool,
 ) -> Option<ExHtmlLinkedHighlightLines> {
     Some(ExHtmlLinkedHighlightLines {
         lines: parse_highlight_lines(attributes.get("highlight_lines")?)?,
-        class: attributes
-            .get("highlight_lines_class")
-            .cloned()
+        class: mdex_attribute(attributes, "highlight_lines_class", render_unsafe)
             .unwrap_or_else(|| "highlighted".to_string()),
     })
 }
@@ -414,5 +428,66 @@ mod tests {
                 HighlightEvent::End,
             ]
         );
+    }
+
+    #[test]
+    fn escapes_decorator_attributes_in_safe_rendering() {
+        let attributes = HashMap::from([
+            ("highlight_lines".to_string(), "1".to_string()),
+            (
+                "highlight_lines_style".to_string(),
+                "color: red;\" onmouseover=\"alert(1)".to_string(),
+            ),
+            (
+                "highlight_lines_class".to_string(),
+                "line\" onmouseover=\"alert(1)".to_string(),
+            ),
+        ]);
+
+        let inline = inline_highlight_lines(&attributes, None, false).unwrap();
+        assert!(matches!(
+            inline.style,
+            Some(ExHtmlInlineHighlightLinesStyle::Style { style })
+                if style == html::escape(&attributes["highlight_lines_style"])
+        ));
+        assert_eq!(
+            inline.class,
+            Some(html::escape(&attributes["highlight_lines_class"]))
+        );
+
+        let linked = linked_highlight_lines(&attributes, false).unwrap();
+        assert_eq!(
+            linked.class,
+            html::escape(&attributes["highlight_lines_class"])
+        );
+    }
+
+    #[test]
+    fn preserves_decorator_attributes_in_unsafe_rendering() {
+        let attributes = HashMap::from([
+            ("highlight_lines".to_string(), "1".to_string()),
+            (
+                "highlight_lines_style".to_string(),
+                "color: red;\" onmouseover=\"alert(1)".to_string(),
+            ),
+            (
+                "highlight_lines_class".to_string(),
+                "line\" onmouseover=\"alert(1)".to_string(),
+            ),
+        ]);
+
+        let inline = inline_highlight_lines(&attributes, None, true).unwrap();
+        assert!(matches!(
+            inline.style,
+            Some(ExHtmlInlineHighlightLinesStyle::Style { style })
+                if style == attributes["highlight_lines_style"]
+        ));
+        assert_eq!(
+            inline.class.as_deref(),
+            Some(attributes["highlight_lines_class"].as_str())
+        );
+
+        let linked = linked_highlight_lines(&attributes, true).unwrap();
+        assert_eq!(linked.class, attributes["highlight_lines_class"]);
     }
 }

--- a/packages/elixir/lumis/native/lumis_nif/src/mdex_bridge.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/mdex_bridge.rs
@@ -1,0 +1,418 @@
+use std::collections::HashMap;
+
+use lumis_core::events::HighlightEvent;
+use lumis_core::formatter::html;
+use lumis_core::languages::Language;
+use lumis_wasm_runtime::RuntimeError;
+use rustler::{Encoder, Resource, ResourceArc, Term};
+
+use crate::elixir::{
+    ExAppearance, ExFormatterOption, ExHtmlInlineHighlightLines, ExHtmlInlineHighlightLinesStyle,
+    ExHtmlLinkedHighlightLines, ExLineSpec, ThemeOrString,
+};
+
+pub struct MdexBridge;
+
+#[rustler::resource_impl(name = "lumis_mdex_bridge_v1")]
+impl Resource for MdexBridge {
+    const IMPLEMENTS_DYNCALL: bool = true;
+
+    unsafe fn dyncall<'a>(&'a self, env: rustler::Env<'a>, call_data: *mut rustler::sys::c_void) {
+        let call_term = &mut *call_data.cast::<usize>();
+        let request = Term::new(env, *call_term);
+
+        *call_term = match request.decode::<MdexRequest>() {
+            Ok((source, language, formatter, attributes, render_unsafe)) => {
+                match render_code_fence(
+                    &source,
+                    language.as_deref(),
+                    formatter,
+                    &attributes,
+                    render_unsafe,
+                ) {
+                    Ok(output) => (crate::ok(), output).encode(env).as_c_arg(),
+                    Err(reason) => (crate::error(), reason).encode(env).as_c_arg(),
+                }
+            }
+            Err(_) => (crate::error(), "invalid MDEx bridge request")
+                .encode(env)
+                .as_c_arg(),
+        };
+    }
+}
+
+type MdexRequest = (
+    String,
+    Option<String>,
+    Option<ExFormatterOption>,
+    HashMap<String, String>,
+    bool,
+);
+
+#[rustler::nif]
+pub fn mdex_bridge() -> ResourceArc<MdexBridge> {
+    ResourceArc::new(MdexBridge)
+}
+
+fn render_code_fence(
+    source: &str,
+    language: Option<&str>,
+    formatter: Option<ExFormatterOption>,
+    attributes: &HashMap<String, String>,
+    render_unsafe: bool,
+) -> Result<String, String> {
+    // Comrak includes the code-fence terminator's newline in the literal. Its
+    // adapter contract historically did not turn that into another visual line.
+    let source = source.strip_suffix('\n').unwrap_or(source);
+    let language = Language::guess(language, source);
+    let formatter = formatter
+        .unwrap_or_default()
+        .with_mdex_attributes(attributes, render_unsafe);
+    let (formatter, rainbow_brackets) = formatter.into_formatter(language)?;
+
+    let events = if language == Language::PlainText {
+        vec![HighlightEvent::Source {
+            start: 0,
+            end: source.len(),
+        }]
+    } else {
+        let executor = crate::executor().map_err(|reason| format!("{reason:#}"))?;
+        match executor.highlight(source, language.id_name(), rainbow_brackets) {
+            Ok(events) => flatten_events(source, events),
+            Err(RuntimeError::LanguageNotLoaded(language)) => {
+                return Err(format!("language {language} is not loaded"));
+            }
+            Err(runtime_error) => return Err(runtime_error.to_string()),
+        }
+    };
+
+    let mut output = Vec::new();
+    formatter
+        .render(source, &events, &mut output)
+        .map_err(|error| error.to_string())?;
+    let output = String::from_utf8(output).map_err(|error| error.to_string())?;
+
+    output
+        .strip_suffix("</code></pre>")
+        .map(str::to_owned)
+        .ok_or_else(|| "Lumis formatter did not produce HTML code-fence output".to_string())
+}
+
+impl ExFormatterOption {
+    fn with_mdex_attributes(
+        self,
+        attributes: &HashMap<String, String>,
+        render_unsafe: bool,
+    ) -> Self {
+        let pre_class = || {
+            attributes.get("pre_class").map(|class| {
+                if render_unsafe {
+                    class.clone()
+                } else {
+                    html::escape(class)
+                }
+            })
+        };
+
+        match self {
+            Self::HtmlInline {
+                mut theme,
+                pre_class: mut formatter_pre_class,
+                italic,
+                mut include_highlights,
+                rainbow_brackets,
+                mut highlight_lines,
+                header: _,
+            } => {
+                if theme.is_none() {
+                    theme = Some(ThemeOrString::String("onedark".to_string()));
+                }
+                if let Some(theme_name) = attributes.get("theme") {
+                    theme = Some(ThemeOrString::String(theme_name.clone()));
+                }
+                if let Some(class) = pre_class() {
+                    formatter_pre_class = Some(class);
+                }
+                if attributes.contains_key("include_highlights") {
+                    include_highlights = true;
+                }
+                if let Some(lines) =
+                    inline_highlight_lines(attributes, Some(line_background(&theme)))
+                {
+                    highlight_lines = Some(lines);
+                }
+
+                Self::HtmlInline {
+                    theme,
+                    pre_class: formatter_pre_class,
+                    italic,
+                    include_highlights,
+                    rainbow_brackets,
+                    highlight_lines,
+                    // Comrak owns the closing tags, so an outer header cannot be
+                    // closed by its syntax-highlighter adapter contract.
+                    header: None,
+                }
+            }
+            Self::HtmlLinked {
+                pre_class: mut formatter_pre_class,
+                rainbow_brackets,
+                mut highlight_lines,
+                header: _,
+            } => {
+                if let Some(class) = pre_class() {
+                    formatter_pre_class = Some(class);
+                }
+                if let Some(lines) = linked_highlight_lines(attributes) {
+                    highlight_lines = Some(lines);
+                }
+
+                Self::HtmlLinked {
+                    pre_class: formatter_pre_class,
+                    rainbow_brackets,
+                    highlight_lines,
+                    header: None,
+                }
+            }
+            Self::HtmlMultiThemes {
+                themes,
+                default_theme,
+                css_variable_prefix,
+                pre_class: mut formatter_pre_class,
+                italic,
+                mut include_highlights,
+                rainbow_brackets,
+                mut highlight_lines,
+                header: _,
+            } => {
+                if let Some(class) = pre_class() {
+                    formatter_pre_class = Some(class);
+                }
+                if attributes.contains_key("include_highlights") {
+                    include_highlights = true;
+                }
+                if let Some(lines) = inline_highlight_lines(
+                    attributes,
+                    Some(line_background_from_name(attributes.get("theme"))),
+                ) {
+                    highlight_lines = Some(lines);
+                } else if let Some(lines) = highlight_lines.as_mut() {
+                    if matches!(lines.style, Some(ExHtmlInlineHighlightLinesStyle::Theme)) {
+                        lines.style = Some(ExHtmlInlineHighlightLinesStyle::Style {
+                            style: line_background_from_name(attributes.get("theme")),
+                        });
+                    }
+                }
+
+                Self::HtmlMultiThemes {
+                    themes,
+                    default_theme,
+                    css_variable_prefix,
+                    pre_class: formatter_pre_class,
+                    italic,
+                    include_highlights,
+                    rainbow_brackets,
+                    highlight_lines,
+                    header: None,
+                }
+            }
+            Self::Terminal {
+                mut theme,
+                rainbow_brackets,
+                ..
+            } => {
+                if theme.is_none() {
+                    theme = Some(ThemeOrString::String("onedark".to_string()));
+                }
+                if let Some(theme_name) = attributes.get("theme") {
+                    theme = Some(ThemeOrString::String(theme_name.clone()));
+                }
+                let highlight_lines =
+                    inline_highlight_lines(attributes, Some(line_background(&theme)));
+
+                Self::HtmlInline {
+                    theme,
+                    pre_class: pre_class(),
+                    italic: false,
+                    include_highlights: attributes.contains_key("include_highlights"),
+                    rainbow_brackets,
+                    highlight_lines,
+                    header: None,
+                }
+            }
+            Self::BbcodeScoped { rainbow_brackets } => Self::HtmlInline {
+                theme: None,
+                pre_class: pre_class(),
+                italic: false,
+                include_highlights: attributes.contains_key("include_highlights"),
+                rainbow_brackets,
+                highlight_lines: inline_highlight_lines(attributes, None),
+                header: None,
+            },
+        }
+    }
+}
+
+fn inline_highlight_lines(
+    attributes: &HashMap<String, String>,
+    default_style: Option<String>,
+) -> Option<ExHtmlInlineHighlightLines> {
+    let lines = parse_highlight_lines(attributes.get("highlight_lines")?)?;
+    let style = attributes
+        .get("highlight_lines_style")
+        .map(|style| match style.as_str() {
+            "theme" => ExHtmlInlineHighlightLinesStyle::Theme,
+            style => ExHtmlInlineHighlightLinesStyle::Style {
+                style: style.to_string(),
+            },
+        })
+        .or_else(|| default_style.map(|style| ExHtmlInlineHighlightLinesStyle::Style { style }));
+
+    Some(ExHtmlInlineHighlightLines {
+        lines,
+        style,
+        class: attributes.get("highlight_lines_class").cloned(),
+    })
+}
+
+fn line_background(theme: &Option<ThemeOrString>) -> String {
+    let is_light = match theme {
+        Some(ThemeOrString::Theme(theme)) => theme.appearance == ExAppearance::Light,
+        Some(ThemeOrString::String(name)) => lumis_core::themes::get(name)
+            .map(|theme| theme.appearance == lumis_core::themes::Appearance::Light)
+            .unwrap_or_else(|_| name.to_lowercase().contains("light")),
+        None => false,
+    };
+
+    if is_light {
+        "background-color: #e7eaf0;".to_string()
+    } else {
+        "background-color: #3b4252;".to_string()
+    }
+}
+
+fn line_background_from_name(theme: Option<&String>) -> String {
+    let theme = theme.map(|name| ThemeOrString::String(name.clone()));
+    line_background(&theme)
+}
+
+fn flatten_events(source: &str, events: Vec<HighlightEvent>) -> Vec<HighlightEvent> {
+    let mut flattened = Vec::with_capacity(events.len());
+    let mut scopes = Vec::new();
+
+    for event in events {
+        match event {
+            HighlightEvent::Start {
+                scope_index,
+                language,
+            } => scopes.push((scope_index, language)),
+            HighlightEvent::End => {
+                scopes.pop();
+            }
+            HighlightEvent::Source { start, end } => {
+                let text = source.get(start..end).unwrap_or_default();
+                if text.trim().is_empty() || scopes.is_empty() {
+                    flattened.push(HighlightEvent::Source { start, end });
+                } else if let Some((scope_index, language)) = scopes.last() {
+                    flattened.push(HighlightEvent::Start {
+                        scope_index: *scope_index,
+                        language: language.clone(),
+                    });
+                    flattened.push(HighlightEvent::Source { start, end });
+                    flattened.push(HighlightEvent::End);
+                }
+            }
+        }
+    }
+
+    flattened
+}
+
+fn linked_highlight_lines(
+    attributes: &HashMap<String, String>,
+) -> Option<ExHtmlLinkedHighlightLines> {
+    Some(ExHtmlLinkedHighlightLines {
+        lines: parse_highlight_lines(attributes.get("highlight_lines")?)?,
+        class: attributes
+            .get("highlight_lines_class")
+            .cloned()
+            .unwrap_or_else(|| "highlighted".to_string()),
+    })
+}
+
+fn parse_highlight_lines(spec: &str) -> Option<Vec<ExLineSpec>> {
+    let mut lines = Vec::new();
+
+    for part in spec
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+    {
+        if let Some((start, end)) = part.split_once('-') {
+            let start = start.trim().parse().ok()?;
+            let end = end.trim().parse().ok()?;
+            if start == 0 || start > end {
+                continue;
+            }
+            lines.push(ExLineSpec::Range { start, end });
+        } else {
+            let line = part.parse().ok()?;
+            if line > 0 {
+                lines.push(ExLineSpec::Single(line));
+            }
+        }
+    }
+
+    Some(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_single_lines_and_ranges() {
+        let lines = parse_highlight_lines("1, 3-5, 0, 7-6").unwrap();
+        assert_eq!(lines.len(), 2);
+        assert!(matches!(lines[0], ExLineSpec::Single(1)));
+        assert!(matches!(lines[1], ExLineSpec::Range { start: 3, end: 5 }));
+    }
+
+    #[test]
+    fn flattens_nested_scopes_to_the_innermost_non_whitespace_scope() {
+        let events = vec![
+            HighlightEvent::Start {
+                scope_index: 1,
+                language: "elixir".to_string(),
+            },
+            HighlightEvent::Source { start: 0, end: 1 },
+            HighlightEvent::Start {
+                scope_index: 2,
+                language: "elixir".to_string(),
+            },
+            HighlightEvent::Source { start: 1, end: 2 },
+            HighlightEvent::End,
+            HighlightEvent::Source { start: 2, end: 3 },
+            HighlightEvent::End,
+        ];
+
+        assert_eq!(
+            flatten_events("a b", events),
+            vec![
+                HighlightEvent::Start {
+                    scope_index: 1,
+                    language: "elixir".to_string(),
+                },
+                HighlightEvent::Source { start: 0, end: 1 },
+                HighlightEvent::End,
+                HighlightEvent::Source { start: 1, end: 2 },
+                HighlightEvent::Start {
+                    scope_index: 1,
+                    language: "elixir".to_string(),
+                },
+                HighlightEvent::Source { start: 2, end: 3 },
+                HighlightEvent::End,
+            ]
+        );
+    }
+}

--- a/packages/elixir/lumis/test/lumis_test.exs
+++ b/packages/elixir/lumis/test/lumis_test.exs
@@ -1507,4 +1507,8 @@ defmodule Lumis.LumisTest do
       end
     end
   end
+
+  test "exposes the MDEx bridge resource" do
+    assert is_reference(Lumis.__mdex_bridge__())
+  end
 end


### PR DESCRIPTION
## Summary

- expose a versioned `lumis_mdex_bridge_v1` dynamic resource for mdex_native
- preserve the existing MDEx code-fence formatting and decorator semantics inside Lumis
- move the Elixir package and release artifacts to NIF 2.16 while keeping the approved Elixir 1.15 minimum

This is the provider half of leandrocp/mdex_native#55. mdex_native calls the resource through `enif_dynamic_resource_call`, so it no longer needs to link a second Lumis implementation.

## Validation

- `cargo test --manifest-path packages/elixir/lumis/native/lumis_nif/Cargo.toml` (6 passed)
- `cargo clippy --manifest-path packages/elixir/lumis/native/lumis_nif/Cargo.toml -- -Dwarnings`
- `LUMIS_BUILD=1 mix test` (172 passed)
- `mise run elixir-nif-lock-check`
- mdex_native CI exercised default, Lumis, and Syntect source builds plus the cloned MDEx suite against the exact three PR heads (2 E2E passed, 1 excluded)
- all three PR SHAs built from source and rendered successfully in Linux ARM64 with Elixir 1.15.8, OTP 24.3.4.17, and NIF 2.16
