### PR TITLE
feat: opt into rainbow brackets from the flat token iterator

### DIFF
--- a/crates/lumis/src/highlight.rs
+++ b/crates/lumis/src/highlight.rs
@@ -6,7 +6,9 @@
 //! # Custom Formatters
 //!
 //! Custom formatters should implement [`Formatter`](crate::formatters::Formatter)
-//! and use [`highlight_iter()`] for streaming token access.
+//! and use [`highlight_iter()`] for per-token access, or
+//! [`highlight_iter_with_options()`] to opt into the scopes the built-in
+//! formatters produce.
 //!
 //! ```rust,no_run
 //! use lumis::{formatters::Formatter, highlight::highlight_iter};
@@ -48,7 +50,7 @@
 //! }
 //! ```
 //!
-//! ## Using the streaming API with a callback
+//! ## Using the token callback API
 //!
 //! ```rust
 //! use lumis::highlight::highlight_iter;
@@ -298,13 +300,11 @@ impl Highlighter {
     }
 }
 
-/// Streaming syntax highlighting with callback.
+/// Flat token iteration with a callback.
 ///
-/// Iterates over tree-sitter highlight events and calls `on_event_source` for each
-/// source-text event (i.e., each text segment).
-///
-/// This is a streaming API that processes tokens as they are produced by tree-sitter,
-/// avoiding the overhead of collecting all segments into a vector upfront.
+/// Walks the highlight events for `source` and calls `on_event_source` once per
+/// text segment, with the innermost scope and its resolved style, instead of
+/// returning the segments as a vector the way [`Highlighter::highlight`] does.
 ///
 /// # Arguments
 ///
@@ -342,6 +342,59 @@ pub fn highlight_iter<F, E>(
     source: &str,
     language: Language,
     theme: Option<Theme>,
+    on_event_source: F,
+) -> Result<(), HighlightError>
+where
+    F: FnMut(&str, Language, Range<usize>, &'static str, &Style) -> Result<(), E>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    highlight_iter_with_options(
+        source,
+        language,
+        theme,
+        HighlightOptions::default(),
+        on_event_source,
+    )
+}
+
+/// Flat token iteration with a callback, with options.
+///
+/// See [`highlight_iter`]. With [`HighlightOptions::rainbow_brackets`] the
+/// callback receives the `punctuation.bracket.rainbow.N` scopes the built-in
+/// formatters render, instead of a flat `punctuation.bracket`.
+///
+/// # Errors
+///
+/// Same as [`highlight_iter`].
+///
+/// # Examples
+///
+/// ```rust
+/// use lumis::highlight::{highlight_iter_with_options, HighlightOptions};
+/// use lumis::languages::Language;
+///
+/// let options = HighlightOptions { rainbow_brackets: true };
+/// let mut scopes = Vec::new();
+///
+/// highlight_iter_with_options(
+///     "fn main() { let x = (1); }",
+///     Language::Rust,
+///     None,
+///     options,
+///     |_text, _language, _range, scope, _style| {
+///         scopes.push(scope);
+///         Ok::<_, std::io::Error>(())
+///     },
+/// )
+/// .unwrap();
+///
+/// assert!(scopes.contains(&"punctuation.bracket.rainbow.1"));
+/// ```
+pub fn highlight_iter_with_options<F, E>(
+    source: &str,
+    language: Language,
+    theme: Option<Theme>,
+    options: HighlightOptions,
     mut on_event_source: F,
 ) -> Result<(), HighlightError>
 where
@@ -349,32 +402,29 @@ where
     E: std::error::Error + Send + Sync + 'static,
 {
     let mut ts_highlighter = TSHighlighter::new();
-    let events = ts_highlighter
-        .highlight(language.config(), source.as_bytes(), None, |injected| {
-            Some(Language::guess(Some(injected), "").config())
-        })
-        .map_err(|e| HighlightError::HighlighterInit(format!("{:?}", e)))?;
+    let events =
+        highlight_events_with(&mut ts_highlighter, source, language, options, |injected| {
+            Some(Language::guess(Some(injected), ""))
+        })?;
 
     let mut style_stack: Vec<Style> = vec![Style::default()];
     let mut scope_stack: Vec<&'static str> = vec![""];
     let mut language_stack = vec![language];
 
     for event in events {
-        let event = event.map_err(|e| HighlightError::EventProcessing(format!("{:?}", e)))?;
-
         match event {
-            HighlightEvent::HighlightStart {
-                highlight,
+            CoreHighlightEvent::Start {
+                scope_index,
                 language: lang,
             } => {
-                let scope = HIGHLIGHT_NAMES[highlight.0];
+                let scope = HIGHLIGHT_NAMES.get(scope_index).copied().unwrap_or("");
                 let injected_language = Language::guess(Some(&lang), "");
                 let new_style = resolve_style(theme.as_ref(), scope, injected_language.id_name());
                 style_stack.push(new_style);
                 scope_stack.push(scope);
                 language_stack.push(injected_language);
             }
-            HighlightEvent::Source { start, end } => {
+            CoreHighlightEvent::Source { start, end } => {
                 let text = &source[start..end];
                 if !text.is_empty() {
                     let default_style = Style::default();
@@ -391,7 +441,7 @@ where
                     .map_err(|e| HighlightError::EventProcessing(e.to_string()))?;
                 }
             }
-            HighlightEvent::HighlightEnd => {
+            CoreHighlightEvent::End => {
                 if style_stack.len() > 1 {
                     style_stack.pop();
                 }
@@ -880,6 +930,65 @@ mod tests {
 
         assert!(count > 0, "Expected at least some segments");
         assert!(has_colors, "Expected at least some segments with colors");
+    }
+
+    fn iter_scopes(code: &str, options: HighlightOptions) -> Vec<&'static str> {
+        let mut scopes = Vec::new();
+        highlight_iter_with_options(
+            code,
+            Language::Rust,
+            None,
+            options,
+            |_text, _language, _range, scope, _style| {
+                scopes.push(scope);
+                Ok::<_, std::io::Error>(())
+            },
+        )
+        .unwrap();
+        scopes
+    }
+
+    #[test]
+    fn highlight_iter_reports_rainbow_bracket_scopes_when_enabled() {
+        let code = "fn main() { let x = (1); }";
+
+        let plain = iter_scopes(code, HighlightOptions::default());
+        assert!(plain.contains(&"punctuation.bracket"));
+        assert!(!plain
+            .iter()
+            .any(|scope| scope.starts_with("punctuation.bracket.rainbow")));
+
+        let rainbow = iter_scopes(
+            code,
+            HighlightOptions {
+                rainbow_brackets: true,
+            },
+        );
+        assert!(rainbow.contains(&"punctuation.bracket.rainbow.1"));
+        assert!(rainbow.contains(&"punctuation.bracket.rainbow.2"));
+    }
+
+    #[test]
+    fn highlight_iter_with_rainbow_brackets_preserves_source_text() {
+        let code = "fn main() { let x = (1); }";
+        let mut text = String::new();
+
+        highlight_iter_with_options(
+            code,
+            Language::Rust,
+            None,
+            HighlightOptions {
+                rainbow_brackets: true,
+            },
+            |token, _language, range, _scope, _style| {
+                assert_eq!(&code[range], token);
+                text.push_str(token);
+                Ok::<_, std::io::Error>(())
+            },
+        )
+        .unwrap();
+
+        assert_eq!(text, code);
     }
 
     #[test]

--- a/docs/content/usage/custom-formatters.mdx
+++ b/docs/content/usage/custom-formatters.mdx
@@ -92,6 +92,39 @@ const formatter: Formatter = {
 const html = hl.highlight('fn main() {}', formatter)
 ```
 
+## Highlight options
+
+The built-in formatters take options that change which scopes highlighting
+produces. Custom formatters take the same options, as a trailing argument to the
+token iterator.
+
+<Tabs groupId="runtime" queryString="lang" defaultValue="javascript">
+  <TabItem value="javascript" label="JavaScript">
+
+```ts
+highlightIter(source, this.language, frappe, (text, language, _range, scope) => {
+  // scope is punctuation.bracket.rainbow.1 .. .6 on bracket pairs
+}, {rainbowBrackets: true})
+```
+
+  </TabItem>
+  <TabItem value="rust" label="Rust">
+
+```rust
+use lumis::highlight::{highlight_iter_with_options, HighlightOptions};
+
+let options = HighlightOptions { rainbow_brackets: true };
+
+highlight_iter_with_options(source, self.language, self.theme.clone(), options, |text, language, _range, scope, _style| {
+    // scope is punctuation.bracket.rainbow.1 .. .6 on bracket pairs
+    write!(output, "{}", span_inline(text, Some(language), scope, self.theme.as_ref(), false, false))
+})
+.map_err(io::Error::other)?;
+```
+
+  </TabItem>
+</Tabs>
+
 ## Nested events instead of flat tokens
 
 `highlightIter` / `highlight_iter` hand you one callback per token. When the

--- a/docs/content/usage/rust-advanced.mdx
+++ b/docs/content/usage/rust-advanced.mdx
@@ -88,6 +88,20 @@ highlight_iter(source, Language::Rust, themes::get("catppuccin_latte").ok(), |te
 
 This is also the base for advanced custom formatters.
 
+`highlight_iter_with_options()` takes the same callback plus a `HighlightOptions`, so a custom formatter can opt into the scopes the built-in formatters produce:
+
+```rust
+use lumis::{highlight::{highlight_iter_with_options, HighlightOptions}, languages::Language};
+
+let options = HighlightOptions { rainbow_brackets: true };
+
+highlight_iter_with_options(source, Language::Rust, None, options, |text, _language, _range, scope, _style| {
+    // scope is punctuation.bracket.rainbow.1 .. .6 on bracket pairs
+    println!("{scope}: {text}");
+    Ok::<_, std::io::Error>(())
+}).unwrap();
+```
+
 ## [CSS generation from themes](https://docs.rs/lumis/latest/lumis/themes/struct.Theme.html)
 
 Rust can generate linked CSS directly.

--- a/packages/javascript/lumis/src/core/highlighter.ts
+++ b/packages/javascript/lumis/src/core/highlighter.ts
@@ -42,6 +42,7 @@ export interface Highlighter {
     language: LanguageRef | undefined,
     theme: Theme | undefined,
     onToken: HighlightCallback,
+    options?: HighlightOptions,
   ): void;
   /** Load a language by object, lazy handle, or string ID from a registered bundle. No-op if already loaded. */
   loadLanguage(language: Language | LazyLanguage | string): Promise<void>;
@@ -184,9 +185,10 @@ function runHighlightIter(
   language: LanguageRef | undefined,
   theme: Theme | undefined,
   onToken: HighlightCallback,
+  options: HighlightOptions = {},
 ): void {
   const loaded = resolveLoadedLanguage(runtime, language);
-  const events = runtime.highlightEvents(source, loaded);
+  const events = runtime.highlightEvents(source, loaded, options);
   const bytes = encoder.encode(source);
   const scopeStack: Array<{ scope: string; language: string }> = [];
 
@@ -247,15 +249,19 @@ function requireCurrentRuntime(fnName: string): RuntimeLike {
  * Sync free function usable inside {@link Formatter.format}. For top-level
  * (non-formatter) iteration, use `hl.highlightIter` on a {@link Highlighter}
  * instance instead.
+ *
+ * `options.rainbowBrackets` reports `punctuation.bracket.rainbow.N` scopes,
+ * the same ones the built-in formatters render.
  */
 export function highlightIter(
   source: string,
   language: LanguageRef | undefined,
   theme: Theme | undefined,
   onToken: HighlightCallback,
+  options: HighlightOptions = {},
 ): void {
   const runtime = requireCurrentRuntime("highlightIter");
-  runHighlightIter(runtime, source, detectLanguageRef(source, language), theme, onToken);
+  runHighlightIter(runtime, source, detectLanguageRef(source, language), theme, onToken, options);
 }
 
 /**
@@ -577,8 +583,15 @@ export function createHighlighterModule(factory: HighlighterModuleFactory) {
           const detectedRef = detectLanguageRef(source, fmt.language);
           return runFormatter(runtime, source, fmt, detectedRef);
         },
-        highlightIter: (source, language, theme, onToken) =>
-          runHighlightIter(runtime, source, detectLanguageRef(source, language), theme, onToken),
+        highlightIter: (source, language, theme, onToken, options) =>
+          runHighlightIter(
+            runtime,
+            source,
+            detectLanguageRef(source, language),
+            theme,
+            onToken,
+            options,
+          ),
         async loadLanguage(input) {
           await loadHighlighterLanguage(input, runtime, lazyRegistry);
         },

--- a/packages/javascript/lumis/src/types.ts
+++ b/packages/javascript/lumis/src/types.ts
@@ -351,12 +351,20 @@ export type HighlightEvent =
  *   console.log(`${scope}: ${text}`)
  * })
  * ```
+ *
+ * Pass {@link HighlightOptions} last to opt into the same scopes the built-in
+ * formatters produce:
+ *
+ * ```ts
+ * highlightIter(source, javascript, dracula, onToken, {rainbowBrackets: true})
+ * ```
  */
 export type HighlightIterFn = (
   source: string,
   language: LanguageRef | undefined,
   theme: Theme | undefined,
   onToken: HighlightCallback,
+  options?: HighlightOptions,
 ) => void;
 
 /**

--- a/packages/javascript/lumis/test/custom-formatter.test.ts
+++ b/packages/javascript/lumis/test/custom-formatter.test.ts
@@ -91,6 +91,62 @@ describe("custom formatter", () => {
     expect(output).toContain('class="language-json"');
   }, 30_000);
 
+  it("reports rainbow bracket scopes when highlightIter asks for them", async () => {
+    const hl = await createHighlighter({ languages: [json] });
+    const source = '{"outer":{"inner":[1]}}';
+
+    const collect = (options?: { rainbowBrackets?: boolean }): string[] => {
+      const scopes: string[] = [];
+      const formatter: Formatter = {
+        language: json,
+        format(src: string) {
+          highlightIter(
+            src,
+            this.language,
+            undefined,
+            (_text, _language, _range, scope) => {
+              scopes.push(scope);
+            },
+            options,
+          );
+          return "";
+        },
+      };
+      hl.highlight(source, formatter);
+      return scopes;
+    };
+
+    const plain = collect();
+    expect(plain).toContain("punctuation.bracket");
+    expect(plain.some((scope) => scope.startsWith("punctuation.bracket.rainbow"))).toBe(false);
+
+    const rainbow = collect({ rainbowBrackets: true });
+    expect(rainbow).toContain("punctuation.bracket.rainbow.1");
+    expect(rainbow).toContain("punctuation.bracket.rainbow.2");
+  }, 30_000);
+
+  it("reports rainbow bracket scopes from hl.highlightIter", async () => {
+    const hl = await createHighlighter({ languages: [json] });
+    const source = '{"outer":{"inner":[1]}}';
+
+    const scopes: string[] = [];
+    let text = "";
+    hl.highlightIter(
+      source,
+      json,
+      undefined,
+      (token, _language, range, scope) => {
+        expect(source.slice(range.start, range.end)).toBe(token);
+        scopes.push(scope);
+        text += token;
+      },
+      { rainbowBrackets: true },
+    );
+
+    expect(text).toBe(source);
+    expect(scopes).toContain("punctuation.bracket.rainbow.1");
+  }, 30_000);
+
   it("restores the outer runtime after nested formatter calls", async () => {
     const outerHighlighter = await createHighlighter({ languages: [json] });
     const innerHighlighter = await createHighlighter({ languages: [diff] });


### PR DESCRIPTION
Closes #1096.

`highlightIter` / `highlight_iter` exposed no options, so a custom formatter built on the flat callback API only ever saw `punctuation.bracket`, while the built-in formatters rendered `punctuation.bracket.rainbow.N`. The workaround was to call `highlightEvents` and flatten the event stream by hand.

## Rust

`highlight_iter_with_options(source, language, theme, options, callback)`, matching the existing `highlight_events` / `highlight_events_with_options` pair. `highlight_iter` delegates to it with `HighlightOptions::default()`.

```rust
let options = HighlightOptions { rainbow_brackets: true };
highlight_iter_with_options(source, Language::Rust, None, options, |text, _lang, _range, scope, _style| {
    // scope is punctuation.bracket.rainbow.1 .. .6 on bracket pairs
    Ok::<_, std::io::Error>(())
})?;
```

Both entry points now walk the same `lumis_core` event stream that `highlight_events_with` produces, so the rainbow overlay stays in one place instead of being repeated per entry point.

## JavaScript

`HighlightOptions` becomes a trailing argument on the free function and on the `Highlighter` method:

```ts
highlightIter(source, this.language, theme, onToken, {rainbowBrackets: true})
hl.highlightIter(source, json, theme, onToken, {rainbowBrackets: true})
```

The options are forwarded to the same `runtime.highlightEvents` call the built-in formatters make, so the native and Wasm runtimes both get it without new plumbing.

## Tests

- Rust: rainbow scopes appear only when enabled, and the callback still reconstructs the source byte for byte with the overlay applied.
- JavaScript: same two checks through the free function inside `format()` and through `hl.highlightIter`.

Both new guards were confirmed red before the fix: dropping the options argument in `runHighlightIter` fails the JS pair, and passing `HighlightOptions::default()` in `highlight_iter_with_options` fails the Rust one.

## Docs

`/formatters/custom` gains a "Highlight options" section with runtime tabs, and `/rust/advanced` documents `highlight_iter_with_options`.