### PR TITLE
feat(elixir)!: require Elixir 1.15

### DIFF
--- a/packages/elixir/lumis/mix.exs
+++ b/packages/elixir/lumis/mix.exs
@@ -8,7 +8,7 @@ defmodule Lumis.MixProject do
     [
       app: :lumis,
       version: @version,
-      elixir: "~> 1.14",
+      elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       build_embedded: Mix.env() == :prod,
       package: package(),


### PR DESCRIPTION
## Summary

- require Elixir 1.15 or newer for the Hex package
- keep CI coverage on the exact minimum, Elixir 1.15.0 with OTP 25.1

## Validation

- `mise run lint-workflows`
- `mise run lint-elixir`
- `mise run test-elixir` (171 passed)