### PR TITLE
chore: ignore automated PRs in CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+inheritance: true
+reviews:
+  auto_review:
+    ignore_title_keywords:
+      - "feat: update lang "
+      - "feat(themes): update themes"
+      - "feat: update default queries"
+      - "chore(release): "


### PR DESCRIPTION
## Summary

- skip automatic CodeRabbit reviews for language, theme, default-query, and release PR titles
- inherit existing CodeRabbit settings while applying the repository-level exclusions

## Validation

- parsed .coderabbit.yaml with Ruby YAML and yq
- verified all 12 matching open PR titles are excluded and a representative normal PR is not
- git diff --check