### PR TITLE
chore: refresh packaged NIF lockfile

### DIFF
--- a/packages/elixir/lumis/native/lumis_nif/Cargo.lock
+++ b/packages/elixir/lumis/native/lumis_nif/Cargo.lock
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "lumis-wasm-runtime"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "544a8809eefaab1402fbe0e3cfaacb93146bab95d968f3540a25a1f4054ba608"
+checksum = "b19dfdab518688ba8605277e74d210af62c67d59b515e678507cf74d21dfd82e"
 dependencies = [
  "etcetera",
  "lumis-core",
@@ -759,7 +759,7 @@ dependencies = [
  "tree-sitter",
  "typed-arena",
  "ureq",
- "wasmparser 0.255.0",
+ "wasmparser 0.258.0",
  "wasmtime",
 ]
 
@@ -1586,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.255.0"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e329ef4b5d46e73b91d3ac6924417cad55a8cbbf869c199283383427c3320b"
+checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
 dependencies = [
  "bitflags",
  "hashbrown 0.17.1",


### PR DESCRIPTION
`packages/elixir/lumis/native/lumis_nif/Cargo.lock` re-resolved against
the versions just published to crates.io.

The packaged NIF resolves the lumis crates from the registry, so this
can only happen after `cargo publish`. Merge it before tagging
`hex-lumis`.

This PR was created automatically by the rust-release workflow.