### PR TITLE
chore: classify generated and vendored files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,50 @@
+# Normalize conformance source fixtures across platforms.
 fixtures/conformance/**/source.txt text eol=lf
+
+# Generated documentation and source files.
+LANGUAGES.md linguist-generated
+THEMES.md linguist-generated
+benchmarks/README.md linguist-generated
+crates/lumis-cli/formatter-options.json linguist-generated
+crates/lumis-core/src/highlights.rs linguist-generated
+crates/lumis-wasm-runtime/src/catalog.rs linguist-generated
+docs/content/reference/themes.md linguist-generated
+packages/javascript/lumis/bundles/*.ts linguist-generated
+packages/javascript/lumis/src/highlights.ts linguist-generated
+packages/javascript/themes/themes/*.ts linguist-generated
+packages/javascript/wasm-bundle-*/README.md linguist-generated
+packages/javascript/wasm-bundle-*/index.d.ts linguist-generated
+packages/javascript/wasm-bundle-*/index.js linguist-generated
+packages/javascript/wasm-bundle-*/package.json linguist-generated
+queries/processed/** linguist-generated
+
+# Generated themes and formatter output.
+crates/lumis-core/themes/*.json linguist-generated
+crates/lumis/css/*.css linguist-generated
+css/*.css linguist-generated
+packages/elixir/lumis/priv/static/css/*.css linguist-generated
+themes/*.json linguist-generated
+
+# Generated test and website artifacts.
+fixtures/conformance/**/bbcode.txt linguist-generated
+fixtures/conformance/**/fixture.json linguist-generated
+fixtures/conformance/**/html-inline.html linguist-generated
+fixtures/conformance/**/html-linked.html linguist-generated
+fixtures/conformance/**/html-multi-themes.html linguist-generated
+fixtures/conformance/**/terminal.txt linguist-generated
+fixtures/parsers/*.wasm linguist-generated
+fixtures/test-parsers/*.wasm linguist-generated
+website/public/benchmark-data/** linguist-generated
+website/public/comparison-data/** linguist-generated
+
+# Third-party source retained in the repository.
+benchmarks/go_json_encode.go linguist-vendored
+benchmarks/livebook_core_components.ex linguist-vendored
+benchmarks/ripgrep_searcher.rs linguist-vendored
+benchmarks/shadcn_sidebar.tsx linguist-vendored
+benchmarks/webgpu_compute_reduce.html linguist-vendored
+crates/lumis/vendored_parsers/** linguist-vendored
+crates/lumis-wasm-runtime/src/tree_sitter_highlight.rs linguist-vendored
+packages/elixir/lumis/examples/nimble_publisher/assets/vendor/** linguist-vendored
+queries/upstream/** linguist-vendored
+samples/** linguist-vendored

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,7 @@ Large parts of the repository are generated from shared inputs such as `language
 - Edit the source inputs, not generated outputs, unless the generated file is the intended source.
 - For query changes, treat `queries/upstream/` as fetched source material, `queries/override/` as full replacements, and `queries/append/` as additive local patches.
 - Regenerate checked-in artifacts with the documented `mise run` workflows.
+- When generated or vendored files are added, removed, moved, or reclassified, update `.gitattributes` in the same change. For content-only updates, verify that its existing patterns still cover every affected path.
 - Keep Rust, JavaScript, Elixir, docs, fixtures, and generated metadata in sync.
 
 ## Verification


### PR DESCRIPTION
## Summary

- classify deterministic generated documentation, source, theme, fixture, parser, and website artifacts for GitHub Linguist
- classify upstream parsers, upstream queries, benchmark inputs, sample corpus, and bundled browser assets as vendored
- keep authored runtime code, local query overrides, bracket queries, conformance inputs, and website source detectable

## Why

Generated website and conformance HTML, generated theme CSS and TypeScript, fetched queries, and vendored source currently dominate the repository language totals. These attributes make the language breakdown represent Lumis-authored code and collapse generated files in diffs.

Inspired by rails/rails#58693.

## Validation

- every added attribute pattern matches tracked files
- git check-attr: 2,130 generated files and 758 vendored files, with no overlap
- generated-file header audit found no uncovered tracked files
- git diff --check