### PR TITLE
feat(elixir): HTML formatter helpers

### DIFF
--- a/crates/lumis-core/tests/annotation_composition.rs
+++ b/crates/lumis-core/tests/annotation_composition.rs
@@ -30,16 +30,8 @@ struct Case {
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 enum SyntaxEvent {
-    Start {
-        scope: String,
-        language: String,
-    },
-    Source {
-        #[serde(rename = "startByte")]
-        start_byte: usize,
-        #[serde(rename = "endByte")]
-        end_byte: usize,
-    },
+    Start { scope: String, language: String },
+    Source { start: usize, end: usize },
     End,
 }
 
@@ -92,12 +84,9 @@ fn render(source: &str, case: &Case) -> String {
                 scope_index: scope_index(scope),
                 language: language.clone(),
             },
-            SyntaxEvent::Source {
-                start_byte,
-                end_byte,
-            } => HighlightEvent::Source {
-                start: *start_byte,
-                end: *end_byte,
+            SyntaxEvent::Source { start, end } => HighlightEvent::Source {
+                start: *start,
+                end: *end,
             },
             SyntaxEvent::End => HighlightEvent::End,
         })

--- a/docs/content/usage/annotations.mdx
+++ b/docs/content/usage/annotations.mdx
@@ -146,7 +146,7 @@ const formatter: Formatter<Change> = {
       } else if (event.type === 'annotationEnd') {
         out.push(`</${open.pop()}>`)
       } else if (event.type === 'source') {
-        out.push(decoder.decode(bytes.subarray(event.startByte, event.endByte)))
+        out.push(decoder.decode(bytes.subarray(event.start, event.end)))
       }
       // 'start' and 'end' carry the syntax scopes
     }

--- a/docs/content/usage/custom-formatters.mdx
+++ b/docs/content/usage/custom-formatters.mdx
@@ -127,7 +127,7 @@ const formatter: Formatter = {
       } else if (event.type === 'end') {
         scopes.pop()
       } else if (event.type === 'source') {
-        const text = decoder.decode(bytes.subarray(event.startByte, event.endByte))
+        const text = decoder.decode(bytes.subarray(event.start, event.end))
         const scope = scopes[scopes.length - 1]
         parts.push(scope ? spanInline(text, {language: 'rust', scope, theme: frappe}) : text)
       }

--- a/docs/content/usage/custom-formatters.mdx
+++ b/docs/content/usage/custom-formatters.mdx
@@ -2,11 +2,12 @@
 sidebar_position: 3
 slug: /formatters/custom
 title: Custom Formatters
-description: Build your own output format on top of Lumis tokens in Rust and JavaScript.
+description: Build your own output format on top of Lumis tokens in Rust, JavaScript and Elixir.
 keywords:
   - lumis custom formatters
   - formatter trait
   - highlightIter
+  - Lumis.Formatter
   - custom html
 ---
 
@@ -140,6 +141,65 @@ const formatter: Formatter = {
 const html = hl.highlight('fn main() {}', formatter)
 ```
 
+## Elixir
+
+Implement the [`Lumis.Formatter`](https://hexdocs.pm/lumis/Lumis.Formatter.html)
+behaviour and pass the module as the formatter. Lumis highlights the source and
+hands `render/3` the event stream, with the resolved language in `options`.
+
+[`Lumis.Formatter.HTML`](https://hexdocs.pm/lumis/Lumis.Formatter.HTML.html) has
+the same pieces `lumis::formatters::html` and `@lumis-sh/lumis/formatters/html`
+do.
+
+```elixir
+defmodule MinimalHtmlFormatter do
+  @behaviour Lumis.Formatter
+
+  alias Lumis.Formatter.HTML
+
+  @impl true
+  def render(source, events, options) do
+    language = Keyword.fetch!(options, :language)
+    theme = Keyword.get(options, :theme)
+
+    # Resolving a scope against a theme is a table lookup, so build the table
+    # once here rather than crossing into Rust once per token.
+    attrs = HTML.span_attrs(theme: theme, language: language)
+
+    body =
+      Enum.map(events, fn
+        {:start, %{scope: scope}} ->
+          HTML.open_span(attrs, scope)
+
+        :end ->
+          "</span>"
+
+        {:source, %{start: start, end: stop}} ->
+          HTML.escape(binary_part(source, start, stop - start))
+
+        # Lumis adds event kinds as it grows. Render the ones you know and skip
+        # the rest, or a newer Lumis raises FunctionClauseError here.
+        _event ->
+          []
+      end)
+
+    [
+      HTML.open_pre_tag(theme: theme),
+      HTML.open_code_tag(language),
+      body,
+      HTML.closing_tags()
+    ]
+  end
+end
+
+Lumis.highlight!("defmodule App do\nend",
+  formatter: {MinimalHtmlFormatter, language: "elixir", theme: "github_light"}
+)
+```
+
+`render/3` returns iodata, so there is no need to flatten it into a binary;
+Lumis does that once at the end.
+
 ## Highlight options
 
 The built-in formatters take options that change which scopes highlighting
@@ -223,6 +283,7 @@ name JavaScript's event carries directly.
 | JavaScript | `@lumis-sh/lumis/formatters/ansi` | [source](https://github.com/leandrocp/lumis/blob/main/packages/javascript/lumis/src/formatter/ansi.ts) |
 | Rust | `lumis::formatters::html` | [docs.rs](https://docs.rs/lumis/latest/lumis/formatters/html/index.html) |
 | Rust | `lumis::formatters::ansi` | [docs.rs](https://docs.rs/lumis/latest/lumis/formatters/ansi/index.html) |
+| Elixir | `Lumis.Formatter.HTML` | [hexdocs](https://hexdocs.pm/lumis/Lumis.Formatter.HTML.html) |
 
 ## Tip
 

--- a/fixtures/annotation-composition.json
+++ b/fixtures/annotation-composition.json
@@ -26,8 +26,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 4
+          "start": 0,
+          "end": 4
         },
         {
           "type": "start",
@@ -36,16 +36,16 @@
         },
         {
           "type": "source",
-          "startByte": 4,
-          "endByte": 9
+          "start": 4,
+          "end": 9
         },
         {
           "type": "end"
         },
         {
           "type": "source",
-          "startByte": 9,
-          "endByte": 14
+          "start": 9,
+          "end": 14
         }
       ],
       "annotations": [],
@@ -57,8 +57,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 14
+          "start": 0,
+          "end": 14
         }
       ],
       "annotations": [
@@ -79,8 +79,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 4
+          "start": 0,
+          "end": 4
         },
         {
           "type": "start",
@@ -89,16 +89,16 @@
         },
         {
           "type": "source",
-          "startByte": 4,
-          "endByte": 9
+          "start": 4,
+          "end": 9
         },
         {
           "type": "end"
         },
         {
           "type": "source",
-          "startByte": 9,
-          "endByte": 14
+          "start": 9,
+          "end": 14
         }
       ],
       "annotations": [
@@ -119,8 +119,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 4
+          "start": 0,
+          "end": 4
         },
         {
           "type": "start",
@@ -129,16 +129,16 @@
         },
         {
           "type": "source",
-          "startByte": 4,
-          "endByte": 9
+          "start": 4,
+          "end": 9
         },
         {
           "type": "end"
         },
         {
           "type": "source",
-          "startByte": 9,
-          "endByte": 14
+          "start": 9,
+          "end": 14
         }
       ],
       "annotations": [
@@ -159,8 +159,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 4
+          "start": 0,
+          "end": 4
         },
         {
           "type": "start",
@@ -169,16 +169,16 @@
         },
         {
           "type": "source",
-          "startByte": 4,
-          "endByte": 9
+          "start": 4,
+          "end": 9
         },
         {
           "type": "end"
         },
         {
           "type": "source",
-          "startByte": 9,
-          "endByte": 14
+          "start": 9,
+          "end": 14
         }
       ],
       "annotations": [
@@ -199,8 +199,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 14
+          "start": 0,
+          "end": 14
         }
       ],
       "annotations": [
@@ -229,8 +229,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 14
+          "start": 0,
+          "end": 14
         }
       ],
       "annotations": [
@@ -259,8 +259,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 14
+          "start": 0,
+          "end": 14
         }
       ],
       "annotations": [
@@ -289,8 +289,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 14
+          "start": 0,
+          "end": 14
         }
       ],
       "annotations": [
@@ -319,8 +319,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 14
+          "start": 0,
+          "end": 14
         }
       ],
       "annotations": [
@@ -347,8 +347,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 21
+          "start": 0,
+          "end": 21
         }
       ],
       "annotations": [
@@ -375,8 +375,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 21
+          "start": 0,
+          "end": 21
         }
       ],
       "annotations": [
@@ -403,8 +403,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 16
+          "start": 0,
+          "end": 16
         }
       ],
       "annotations": [
@@ -425,8 +425,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 16
+          "start": 0,
+          "end": 16
         }
       ],
       "annotations": [
@@ -447,8 +447,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 14
+          "start": 0,
+          "end": 14
         }
       ],
       "annotations": [
@@ -469,8 +469,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 14
+          "start": 0,
+          "end": 14
         }
       ],
       "annotations": [
@@ -497,8 +497,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 4
+          "start": 0,
+          "end": 4
         }
       ],
       "annotations": [
@@ -519,8 +519,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 4
+          "start": 0,
+          "end": 4
         }
       ],
       "annotations": [
@@ -547,8 +547,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 2
+          "start": 0,
+          "end": 2
         }
       ],
       "annotations": [
@@ -569,8 +569,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 2
+          "start": 0,
+          "end": 2
         }
       ],
       "annotations": [
@@ -591,8 +591,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 4
+          "start": 0,
+          "end": 4
         },
         {
           "type": "start",
@@ -601,16 +601,16 @@
         },
         {
           "type": "source",
-          "startByte": 4,
-          "endByte": 9
+          "start": 4,
+          "end": 9
         },
         {
           "type": "end"
         },
         {
           "type": "source",
-          "startByte": 9,
-          "endByte": 14
+          "start": 9,
+          "end": 14
         }
       ],
       "annotations": [
@@ -631,8 +631,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 4
+          "start": 0,
+          "end": 4
         }
       ],
       "annotations": [
@@ -661,8 +661,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 4
+          "start": 0,
+          "end": 4
         }
       ],
       "annotations": [
@@ -691,8 +691,8 @@
       "events": [
         {
           "type": "source",
-          "startByte": 0,
-          "endByte": 4
+          "start": 0,
+          "end": 4
         }
       ],
       "annotations": [

--- a/packages/elixir/lumis/README.md
+++ b/packages/elixir/lumis/README.md
@@ -59,6 +59,10 @@ shebang. The theme is optional too, but there is no default: without one,
 Formatters decide the output: `:html_inline`, `:html_linked`,
 `:html_multi_themes`, `:terminal`, `:bbcode_scoped`, or your own.
 
+For your own, implement `Lumis.Formatter` and build the markup with
+`Lumis.Formatter.HTML`, which holds the same pieces the built-in HTML formatters
+are assembled from. See [custom formatters](https://lumis.sh/docs/formatters/custom).
+
 ## Parsers
 
 Highlighting downloads, verifies and loads whatever a document needs, including
@@ -101,6 +105,7 @@ to use the mirror when GitHub is down, see
 
 - [Elixir integration](https://lumis.sh/docs/usage/elixir) — configuration, releases, Phoenix
 - [Formatters](https://lumis.sh/docs/formatters) — every formatter and its options
+- [Custom formatters](https://lumis.sh/docs/formatters/custom) — render the event stream yourself
 - [Annotations](https://lumis.sh/docs/formatters/annotations) — compose your own ranges into the event stream
 - [Themes](https://lumis.sh/docs/themes) — the theme list, custom themes, CSS files
 - [Languages](https://lumis.sh/docs/reference/languages) — what is supported and how detection works

--- a/packages/elixir/lumis/examples/annotations.exs
+++ b/packages/elixir/lumis/examples/annotations.exs
@@ -10,13 +10,15 @@ defmodule MarkFormatter do
   @moduledoc false
   @behaviour Lumis.Formatter
 
+  alias Lumis.Formatter.HTML
+
   @impl true
   def render(source, events, _options) do
     # `:annotation_end` carries no payload, so keep a stack of what was opened.
     {output, []} =
       Enum.map_reduce(events, [], fn
         {:start, %{scope: scope}}, open ->
-          {~s(<span class="#{scope_class(scope)}">), open}
+          {"<span #{HTML.span_linked_attrs(scope)}>", open}
 
         :end, open ->
           {"</span>", open}
@@ -29,13 +31,13 @@ defmodule MarkFormatter do
 
         # A point opens and closes with nothing between it.
         {:annotation_start, %{data: %{type: :note, label: label}}}, open ->
-          {~s(<i data-note="#{escape(label)}">), ["i" | open]}
+          {~s(<i data-note="#{HTML.escape(label)}">), ["i" | open]}
 
         :annotation_end, [tag | open] ->
           {"</#{tag}>", open}
 
         {:source, %{start: start, end: stop}}, open ->
-          {escape(binary_part(source, start, stop - start)), open}
+          {HTML.escape(binary_part(source, start, stop - start)), open}
 
         # Lumis adds event kinds over time. Render the ones you know and skip
         # the rest, or a newer Lumis raises FunctionClauseError here.
@@ -44,18 +46,6 @@ defmodule MarkFormatter do
       end)
 
     output
-  end
-
-  defp scope_class(scope), do: "l-" <> String.replace(scope, ".", "-")
-
-  # Lumis has no Elixir HTML helpers yet — see leandrocp/lumis#1359.
-  defp escape(text) do
-    text
-    |> String.replace("&", "&amp;")
-    |> String.replace("<", "&lt;")
-    |> String.replace(">", "&gt;")
-    |> String.replace("\"", "&quot;")
-    |> String.replace("'", "&#39;")
   end
 end
 

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -1130,7 +1130,13 @@ defmodule Lumis do
       {:error, _reason} = error ->
         describe_highlight_error(error)
 
-      {:ok, events} ->
+      {:ok, language, events} ->
+        # `:language` is whatever the caller named, which is nothing when they
+        # let Lumis detect it. A formatter has to label its output, so it is
+        # handed the language highlighting actually used, the way Rust's
+        # `Formatter::language()` and JavaScript's `this.language` do.
+        formatter_options = Keyword.put(formatter_options, :language, language)
+
         output =
           formatter.render(source, events, formatter_options)
           |> IO.iodata_to_binary()

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -1133,8 +1133,7 @@ defmodule Lumis do
       {:ok, language, events} ->
         # `:language` is whatever the caller named, which is nothing when they
         # let Lumis detect it. A formatter has to label its output, so it is
-        # handed the language highlighting actually used, the way Rust's
-        # `Formatter::language()` and JavaScript's `this.language` do.
+        # handed the language highlighting actually used.
         formatter_options = Keyword.put(formatter_options, :language, language)
 
         output =

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -749,7 +749,7 @@ defmodule Lumis do
         class = hl[:class]
 
         opts
-        |> Keyword.put(:highlight_lines, %Lumis.HtmlInlineHighlightLines{
+        |> Keyword.put(:highlight_lines, %Lumis.HTMLInlineHighlightLines{
           lines: lines,
           style: style,
           class: class
@@ -774,7 +774,7 @@ defmodule Lumis do
         class = hl[:class] || "l-highlighted"
 
         opts
-        |> Keyword.put(:highlight_lines, %Lumis.HtmlLinkedHighlightLines{
+        |> Keyword.put(:highlight_lines, %Lumis.HTMLLinkedHighlightLines{
           lines: lines,
           class: class
         })
@@ -790,7 +790,7 @@ defmodule Lumis do
 
       %{open_tag: open_tag, close_tag: close_tag} ->
         opts
-        |> Keyword.put(:header, %Lumis.HtmlElement{
+        |> Keyword.put(:header, %Lumis.HTMLElement{
           open_tag: open_tag,
           close_tag: close_tag
         })

--- a/packages/elixir/lumis/lib/lumis/formatter.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter.ex
@@ -14,6 +14,20 @@ defmodule Lumis.Formatter do
   Without that clause a newer Lumis raises `FunctionClauseError` rather than
   rendering. The built-in formatters do the same thing with annotations, which
   they cannot render without knowing the caller's data.
+
+  ## Options
+
+  `render/3` receives the options the formatter was given, plus `:language`,
+  which is always the language highlighting **actually used**. A caller who
+  named none gets the detected one rather than `nil`, so a formatter can label
+  its output without running detection a second time:
+
+      def render(source, events, options) do
+        Lumis.Formatter.HTML.open_code_tag(Keyword.fetch!(options, :language))
+      end
+
+  This is the counterpart of `Formatter::language()` in Rust and `this.language`
+  in JavaScript.
   """
 
   @typedoc "A syntax or caller-provided annotation event."

--- a/packages/elixir/lumis/lib/lumis/formatter.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter.ex
@@ -25,9 +25,6 @@ defmodule Lumis.Formatter do
       def render(source, events, options) do
         Lumis.Formatter.HTML.open_code_tag(Keyword.fetch!(options, :language))
       end
-
-  This is the counterpart of `Formatter::language()` in Rust and `this.language`
-  in JavaScript.
   """
 
   @typedoc "A syntax or caller-provided annotation event."

--- a/packages/elixir/lumis/lib/lumis/formatter/html.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter/html.ex
@@ -2,14 +2,12 @@ defmodule Lumis.Formatter.HTML do
   @moduledoc """
   The HTML pieces the built-in formatters are assembled from.
 
-  The Elixir counterpart of `lumis::formatters::html` in Rust and
-  `@lumis-sh/lumis/formatters/html` in JavaScript. A module implementing
-  `Lumis.Formatter` gets an event stream and has to turn it into markup; these
-  are the parts of that job worth not writing again.
+  A module implementing `Lumis.Formatter` gets an event stream and has to turn
+  it into markup; these are the parts of that job worth not writing again.
 
-  Every function here calls into the same Rust that the built-in `:html_inline`
-  and `:html_linked` formatters call, so output built with them is styled by the
-  same theme stylesheets and escapes the same characters.
+  Every function here calls into the same code the built-in `:html_inline` and
+  `:html_linked` formatters use, so output built with them is styled by the same
+  theme stylesheets and escapes the same characters.
 
   ## Example
 
@@ -42,15 +40,6 @@ defmodule Lumis.Formatter.HTML do
           ]
         end
       end
-
-  ## Where the work happens
-
-  Everything below is Rust. What a formatter calls once per document crosses the
-  NIF boundary as a call; the two things it calls once per *token* — resolving a
-  scope to a class, and resolving a scope to a theme's inline style — cross once
-  per document as a table, because a NIF call per token to look up a constant
-  costs more than the highlighting did. `classes/0` and `span_attrs/1` return
-  those tables; `scope_to_class/1` and `open_span/2` read them.
   """
 
   alias Lumis.Native

--- a/packages/elixir/lumis/lib/lumis/formatter/html.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter/html.ex
@@ -1,0 +1,276 @@
+defmodule Lumis.Formatter.HTML do
+  @moduledoc """
+  The HTML pieces the built-in formatters are assembled from.
+
+  The Elixir counterpart of `lumis::formatters::html` in Rust and
+  `@lumis-sh/lumis/formatters/html` in JavaScript. A module implementing
+  `Lumis.Formatter` gets an event stream and has to turn it into markup; these
+  are the parts of that job worth not writing again.
+
+  Every function here calls into the same Rust that the built-in `:html_inline`
+  and `:html_linked` formatters call, so output built with them is styled by the
+  same theme stylesheets and escapes the same characters.
+
+  ## Example
+
+      defmodule MyFormatter do
+        @behaviour Lumis.Formatter
+
+        alias Lumis.Formatter.HTML
+
+        @impl true
+        def render(source, events, options) do
+          language = Keyword.fetch!(options, :language)
+          attrs = HTML.span_attrs(theme: Keyword.get(options, :theme), language: language)
+
+          body =
+            Enum.map(events, fn
+              {:start, %{scope: scope}} -> HTML.open_span(attrs, scope)
+              :end -> "</span>"
+              {:source, %{start: start, end: stop}} ->
+                HTML.escape(binary_part(source, start, stop - start))
+
+              # Lumis adds event kinds over time. Render the ones you know.
+              _event -> []
+            end)
+
+          [
+            HTML.open_pre_tag(theme: Keyword.get(options, :theme)),
+            HTML.open_code_tag(language),
+            body,
+            HTML.closing_tags()
+          ]
+        end
+      end
+
+  ## Where the work happens
+
+  Everything below is Rust. What a formatter calls once per document crosses the
+  NIF boundary as a call; the two things it calls once per *token* — resolving a
+  scope to a class, and resolving a scope to a theme's inline style — cross once
+  per document as a table, because a NIF call per token to look up a constant
+  costs more than the highlighting did. `classes/0` and `span_attrs/1` return
+  those tables; `scope_to_class/1` and `open_span/2` read them.
+  """
+
+  alias Lumis.Native
+  alias Lumis.Theme
+
+  @default_class "l-text"
+
+  @doc """
+  Escapes `&`, `<`, `>`, `"` and `'`.
+
+      iex> Lumis.Formatter.HTML.escape(~s|a < b && c|)
+      "a &lt; b &amp;&amp; c"
+
+  """
+  @spec escape(String.t()) :: String.t()
+  def escape(text) when is_binary(text), do: Native.html_escape(text)
+
+  @doc """
+  Escapes `{` and `}`, which a templating language such as HEEx would otherwise read.
+
+      iex> Lumis.Formatter.HTML.escape_braces("%{a: 1}")
+      "%&lbrace;a: 1&rbrace;"
+
+  """
+  @spec escape_braces(String.t()) :: String.t()
+  def escape_braces(text) when is_binary(text), do: Native.html_escape_braces(text)
+
+  @doc """
+  Every highlight scope mapped to the CSS class `:html_linked` gives it.
+
+  Read once and keep it: `scope_to_class/1` looks a scope up in this, and calling
+  it per token is the whole reason the table exists.
+  """
+  @spec classes() :: %{String.t() => String.t()}
+  def classes do
+    case :persistent_term.get({__MODULE__, :classes}, nil) do
+      nil ->
+        classes = Native.html_classes()
+        :persistent_term.put({__MODULE__, :classes}, classes)
+        classes
+
+      classes ->
+        classes
+    end
+  end
+
+  @doc """
+  The CSS class for a scope, or `"l-text"` for one Lumis does not know.
+
+      iex> Lumis.Formatter.HTML.scope_to_class("keyword.function")
+      "l-keyword-function"
+
+      iex> Lumis.Formatter.HTML.scope_to_class("not.a.scope")
+      "l-text"
+
+  """
+  @spec scope_to_class(String.t() | nil) :: String.t()
+  def scope_to_class(nil), do: @default_class
+  def scope_to_class(scope) when is_binary(scope), do: Map.get(classes(), scope, @default_class)
+
+  @doc """
+  The `class` attribute for a scope, for output styled by a theme stylesheet.
+
+      iex> Lumis.Formatter.HTML.span_linked_attrs("keyword")
+      ~s|class="l-keyword"|
+
+  """
+  @spec span_linked_attrs(String.t() | nil) :: String.t()
+  def span_linked_attrs(scope), do: ~s|class="#{scope_to_class(scope)}"|
+
+  @doc """
+  A `<span>` carrying a scope's CSS class, with `text` escaped.
+
+      iex> Lumis.Formatter.HTML.span_linked("defmodule", "keyword.function")
+      ~s|<span class="l-keyword-function">defmodule</span>|
+
+  """
+  @spec span_linked(String.t(), String.t() | nil) :: String.t()
+  def span_linked(text, scope) do
+    "<span #{span_linked_attrs(scope)}>#{escape(text)}</span>"
+  end
+
+  @doc """
+  Every scope's `<span>` attributes for one theme and language.
+
+  The inline-style counterpart of `classes/0`, and the same advice applies: build
+  it once per document and read it per token with `open_span/2` or
+  `span_inline_attrs/2`.
+
+  ## Options
+
+    * `:theme` (`t:Lumis.Theme.t/0` or a theme name) — resolves each scope to its
+      style. Without one every scope's attributes are `""`, which is a `<span>`
+      with nothing on it.
+    * `:language` — the language whose specialized scopes to prefer, e.g.
+      `comment.elixir` over `comment`. Defaults to `"plaintext"`.
+    * `:italic` (default `false`) — emit `font-style: italic` for a style that
+      asks for it
+    * `:include_highlights` (default `false`) — add `data-highlight="<scope>"`
+
+  """
+  @spec span_attrs(keyword()) :: %{String.t() => String.t()}
+  def span_attrs(options \\ []) when is_list(options) do
+    Native.html_span_attrs(
+      resolve_theme(Keyword.get(options, :theme)),
+      Keyword.get(options, :language) || "plaintext",
+      Keyword.get(options, :italic, false),
+      Keyword.get(options, :include_highlights, false)
+    )
+  end
+
+  @doc """
+  A scope's `<span>` attributes, read out of a `span_attrs/1` table.
+
+  Returns `""` for a scope the theme styles in no way, which is a `<span>` with
+  no attributes rather than one with an empty `style`.
+  """
+  @spec span_inline_attrs(%{String.t() => String.t()}, String.t() | nil) :: String.t()
+  def span_inline_attrs(_attrs, nil), do: ""
+  def span_inline_attrs(attrs, scope), do: Map.get(attrs, scope, "")
+
+  @doc """
+  An opening `<span>` for a scope, with its attributes from a `span_attrs/1` table.
+
+  A scope the theme does not style opens a bare `<span>`, so every `<span>` still
+  pairs with the `</span>` an `:end` event writes.
+  """
+  @spec open_span(%{String.t() => String.t()}, String.t() | nil) :: String.t()
+  def open_span(attrs, scope) do
+    case span_inline_attrs(attrs, scope) do
+      "" -> "<span>"
+      attrs -> "<span #{attrs}>"
+    end
+  end
+
+  @doc """
+  A `<span>` with a theme's colors written inline, with `text` escaped.
+
+  Convenient for a one-off; in a loop, hoist `span_attrs/1` out and use
+  `open_span/2` so the table is not rebuilt per token.
+  """
+  @spec span_inline(String.t(), %{String.t() => String.t()}, String.t() | nil) :: String.t()
+  def span_inline(text, attrs, scope) do
+    "#{open_span(attrs, scope)}#{escape(text)}</span>"
+  end
+
+  @doc """
+  The opening `<pre>` tag, carrying a theme's own colors when one is given.
+
+  ## Options
+
+    * `:theme` (`t:Lumis.Theme.t/0` or a theme name) — writes the theme's
+      `normal` colors into a `style` attribute, the way `:html_inline` does
+    * `:class` — appended to the `lumis` class every Lumis block carries
+
+  ## Example
+
+      iex> Lumis.Formatter.HTML.open_pre_tag(class: "my-block")
+      ~s|<pre class="lumis my-block">|
+
+  """
+  @spec open_pre_tag(keyword()) :: String.t()
+  def open_pre_tag(options \\ []) when is_list(options) do
+    Native.html_open_pre_tag(
+      Keyword.get(options, :class),
+      resolve_theme(Keyword.get(options, :theme))
+    )
+  end
+
+  @doc """
+  The opening `<code>` tag for a language.
+
+      iex> Lumis.Formatter.HTML.open_code_tag("elixir")
+      ~s|<code class="language-elixir" translate="no" tabindex="0">|
+
+  A formatter reads its language from the `:language` option `render/3` receives,
+  which Lumis has already resolved by detection when the caller named none.
+  """
+  @spec open_code_tag(String.t() | nil) :: String.t()
+  def open_code_tag(language), do: Native.html_open_code_tag(language || "plaintext")
+
+  @doc """
+  Both closing tags, in the order `open_code_tag/1` and `open_pre_tag/1` opened them.
+
+      iex> Lumis.Formatter.HTML.closing_tags()
+      "</code></pre>"
+
+  """
+  @spec closing_tags() :: String.t()
+  def closing_tags, do: Native.html_closing_tags()
+
+  @doc """
+  Wraps one rendered line in the `<div>` the built-in HTML formatters emit.
+
+  Lines are 1-based, and `data-line` is what a "highlight these lines" feature
+  and anchor links both key off.
+
+  ## Options
+
+    * `:class_suffix` — appended to `l-line` verbatim, so pass a leading space,
+      e.g. `" l-highlighted"`
+    * `:style` — a `style` attribute for the line
+
+  ## Example
+
+      iex> Lumis.Formatter.HTML.wrap_line(2, "code")
+      ~s|<div class="l-line" data-line="2">code</div>|
+
+  """
+  @spec wrap_line(pos_integer(), iodata(), keyword()) :: String.t()
+  def wrap_line(line_number, content, options \\ []) when is_list(options) do
+    Native.html_wrap_line(
+      line_number,
+      IO.iodata_to_binary(content),
+      Keyword.get(options, :class_suffix),
+      Keyword.get(options, :style)
+    )
+  end
+
+  defp resolve_theme(nil), do: nil
+  defp resolve_theme(%Theme{} = theme), do: theme
+  defp resolve_theme(name) when is_binary(name), do: Theme.get(name)
+end

--- a/packages/elixir/lumis/lib/lumis/native.ex
+++ b/packages/elixir/lumis/lib/lumis/native.ex
@@ -78,4 +78,18 @@ defmodule Lumis.Native do
   def loaded_languages, do: :erlang.nif_error(:nif_not_loaded)
   def highlight(_source, _options), do: :erlang.nif_error(:nif_not_loaded)
   def highlight_events(_source, _options), do: :erlang.nif_error(:nif_not_loaded)
+
+  def html_escape(_text), do: :erlang.nif_error(:nif_not_loaded)
+  def html_escape_braces(_text), do: :erlang.nif_error(:nif_not_loaded)
+  def html_classes, do: :erlang.nif_error(:nif_not_loaded)
+
+  def html_span_attrs(_theme, _language, _italic, _include_highlights),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def html_open_pre_tag(_pre_class, _theme), do: :erlang.nif_error(:nif_not_loaded)
+  def html_open_code_tag(_language), do: :erlang.nif_error(:nif_not_loaded)
+  def html_closing_tags, do: :erlang.nif_error(:nif_not_loaded)
+
+  def html_wrap_line(_line_number, _content, _class_suffix, _style),
+    do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/packages/elixir/lumis/lib/lumis/nif_structs.ex
+++ b/packages/elixir/lumis/lib/lumis/nif_structs.ex
@@ -1,14 +1,14 @@
-defmodule Lumis.HtmlElement do
+defmodule Lumis.HTMLElement do
   @moduledoc false
   defstruct open_tag: nil, close_tag: nil
 end
 
-defmodule Lumis.HtmlInlineHighlightLines do
+defmodule Lumis.HTMLInlineHighlightLines do
   @moduledoc false
   defstruct lines: [], style: :theme, class: nil
 end
 
-defmodule Lumis.HtmlLinkedHighlightLines do
+defmodule Lumis.HTMLLinkedHighlightLines do
   @moduledoc false
   defstruct lines: [], class: "l-highlighted"
 end

--- a/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
@@ -402,7 +402,7 @@ pub struct ExStyle {
 }
 
 #[derive(Clone, Debug, Default, NifStruct)]
-#[module = "Lumis.HtmlElement"]
+#[module = "Lumis.HTMLElement"]
 pub struct ExHtmlElement {
     pub open_tag: String,
     pub close_tag: String,
@@ -444,7 +444,7 @@ pub enum ExHtmlInlineHighlightLinesStyle {
 }
 
 #[derive(Clone, Debug, Default, NifStruct)]
-#[module = "Lumis.HtmlInlineHighlightLines"]
+#[module = "Lumis.HTMLInlineHighlightLines"]
 pub struct ExHtmlInlineHighlightLines {
     pub lines: Vec<ExLineSpec>,
     pub style: Option<ExHtmlInlineHighlightLinesStyle>,
@@ -452,7 +452,7 @@ pub struct ExHtmlInlineHighlightLines {
 }
 
 #[derive(Clone, Debug, Default, NifStruct)]
-#[module = "Lumis.HtmlLinkedHighlightLines"]
+#[module = "Lumis.HTMLLinkedHighlightLines"]
 pub struct ExHtmlLinkedHighlightLines {
     pub lines: Vec<ExLineSpec>,
     pub class: String,

--- a/packages/elixir/lumis/native/lumis_nif/src/lib.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/lib.rs
@@ -746,6 +746,116 @@ fn build_theme_css(theme: &themes::Theme, options: ExCssOptions) -> String {
     builder.build()
 }
 
+/// `lumis_core::formatter::html`, reachable from Elixir.
+///
+/// A formatter written in Elixir needs the same pieces the built-in HTML
+/// formatters are assembled from. These hand them over rather than let every
+/// formatter grow its own copy, which is how `examples/annotations.exs` shipped
+/// an `escape` missing `'` and a `scope_to_class` that could not express the
+/// `l-text` fallback at all.
+///
+/// The split is by call frequency, not by taste. What a formatter calls once per
+/// document crosses the boundary as a call. The two things it calls once per
+/// token cross once per document as a table instead, because 5000 NIF calls to
+/// look up a constant is not what reusing the Rust core should cost.
+#[rustler::nif]
+fn html_escape(text: &str) -> String {
+    lumis_core::formatter::html::escape(text)
+}
+
+#[rustler::nif]
+fn html_escape_braces(text: &str) -> String {
+    lumis_core::formatter::html::escape_braces(text)
+}
+
+/// Every highlight scope and the class `:html_linked` gives it.
+///
+/// `scope_to_class` is a lookup into two generated 293-row tables, so Elixir
+/// cannot spell it without copying them. The whole table crosses once instead.
+#[rustler::nif]
+fn html_classes() -> HashMap<&'static str, String> {
+    lumis_core::highlights::HIGHLIGHT_NAMES
+        .iter()
+        .map(|scope| (*scope, lumis_core::formatter::html::scope_to_class(scope)))
+        .collect()
+}
+
+/// Every scope's `<span>` attributes for one theme, language and option set.
+///
+/// The per-token counterpart of [`html_classes`]. `span_inline_attrs` resolves a
+/// scope against a theme, and sending the theme across the boundary once per
+/// token to do that would cost more than the highlighting did. There are only
+/// ever 293 answers, so all of them come back at once.
+#[rustler::nif]
+fn html_span_attrs(
+    theme: Option<ExTheme>,
+    language: &str,
+    italic: bool,
+    include_highlights: bool,
+) -> HashMap<&'static str, String> {
+    let theme = theme.map(themes::Theme::from);
+    let language = Language::guess(Some(language), "");
+
+    lumis_core::highlights::HIGHLIGHT_NAMES
+        .iter()
+        .map(|scope| {
+            let attrs = lumis_core::formatter::html::span_inline_attrs(
+                Some(language),
+                scope,
+                theme.as_ref(),
+                italic,
+                include_highlights,
+            );
+            (*scope, attrs)
+        })
+        .collect()
+}
+
+#[rustler::nif]
+fn html_open_pre_tag(pre_class: Option<String>, theme: Option<ExTheme>) -> NifResult<String> {
+    let theme = theme.map(themes::Theme::from);
+    let mut output = Vec::new();
+    lumis_core::formatter::html::open_pre_tag(&mut output, pre_class.as_deref(), theme.as_ref())
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    html_utf8(output)
+}
+
+#[rustler::nif]
+fn html_open_code_tag(language: &str) -> NifResult<String> {
+    let mut output = Vec::new();
+    lumis_core::formatter::html::open_code_tag(&mut output, &Language::guess(Some(language), ""))
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    html_utf8(output)
+}
+
+#[rustler::nif]
+fn html_closing_tags() -> NifResult<String> {
+    let mut output = Vec::new();
+    lumis_core::formatter::html::closing_tags(&mut output)
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    html_utf8(output)
+}
+
+#[rustler::nif]
+fn html_wrap_line(
+    line_number: usize,
+    content: &str,
+    class_suffix: Option<String>,
+    style: Option<String>,
+) -> String {
+    lumis_core::formatter::html::wrap_line(
+        line_number,
+        content,
+        class_suffix.as_deref(),
+        style.as_deref(),
+    )
+}
+
+fn html_utf8(output: Vec<u8>) -> NifResult<String> {
+    String::from_utf8(output)
+        .map_err(|error| Error::Term(Box::new(format!("invalid HTML helper output: {error}"))))
+}
+
 #[cfg(test)]
 mod tests {
     use super::HighlightEvent;

--- a/packages/elixir/lumis/native/lumis_nif/src/lib.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/lib.rs
@@ -455,7 +455,11 @@ pub(crate) fn highlight_events<'a>(
         .map(|event| event.encode(env))
         .collect::<Vec<_>>();
 
-    Ok((ok(), events).encode(env))
+    // The resolved language rides along because detection happened here. A
+    // formatter needs it to label its output, and asking Elixir to guess again
+    // would run detection over the whole source a second time to reach an answer
+    // this call already has.
+    Ok((ok(), language.id_name(), events).encode(env))
 }
 
 /// Reads the tagged tuples `Lumis.annotations_type/1` normalizes to:

--- a/packages/elixir/lumis/test/lumis/formatter/html_test.exs
+++ b/packages/elixir/lumis/test/lumis/formatter/html_test.exs
@@ -1,0 +1,273 @@
+defmodule Lumis.Formatter.HTMLTest do
+  use ExUnit.Case, async: true
+
+  alias Lumis.Formatter.HTML
+
+  # The only public way to see an event stream is to be handed one, so this
+  # captures it the way any formatter would.
+  defmodule CaptureFormatter do
+    @moduledoc false
+    @behaviour Lumis.Formatter
+
+    @impl true
+    def render(_source, events, options) do
+      send(Keyword.fetch!(options, :owner), {:events, events})
+      []
+    end
+  end
+
+  defp events(source, language) do
+    Lumis.highlight!(source, formatter: {CaptureFormatter, language: language, owner: self()})
+
+    receive do
+      {:events, events} -> events
+    after
+      1_000 -> flunk("the formatter was never handed an event stream")
+    end
+  end
+
+  # These helpers exist so an Elixir formatter stops hand-rolling its own, so
+  # every test that could drift compares against what the built-in Rust
+  # formatters actually emit rather than against a literal written here.
+  @sources [
+    {"defmodule App do\n  @doc \"hi & bye, it's fine\"\n  def go, do: :ok\nend\n", "elixir"},
+    {"# Title\n\n```elixir\n:ok\n```\n", "markdown"},
+    {"<p class=\"x\">a & b < c</p>\n", "html"},
+    {"const x = `a ${b} c`\nconst y = '<>'\n", "javascript"},
+    {"just words, no parser\n", "plaintext"},
+    {"", "elixir"}
+  ]
+
+  @themes ["github_light", "dracula"]
+
+  setup_all do
+    :ok = Lumis.Languages.load(~w(elixir markdown markdown_inline html javascript))
+    :ok
+  end
+
+  defp html_linked(source, language) do
+    Lumis.highlight!(source, formatter: {:html_linked, language: language})
+  end
+
+  defp html_inline(source, language, theme, options) do
+    Lumis.highlight!(
+      source,
+      formatter: {:html_inline, [language: language, theme: theme] ++ options}
+    )
+  end
+
+  describe "escape/1" do
+    test "escapes the five entities lumis_core::formatter::html::escape does" do
+      assert HTML.escape(~s|&<>"'|) == "&amp;&lt;&gt;&quot;&#39;"
+    end
+
+    test "escapes an ampersand once" do
+      assert HTML.escape("&lt;") == "&amp;lt;"
+    end
+
+    test "matches the escaping html_linked applies to the same text" do
+      # `'` is the one the hand-rolled copy in examples/annotations.exs missed.
+      for {source, language} <- @sources, source != "" do
+        html = html_linked(source, language)
+
+        for fragment <- ~w(& < > "), String.contains?(source, fragment) do
+          assert String.contains?(html, HTML.escape(fragment)),
+                 "#{language}: html_linked does not contain #{inspect(HTML.escape(fragment))}"
+        end
+      end
+    end
+
+    test "leaves braces alone" do
+      assert HTML.escape("%{a: 1}") == "%{a: 1}"
+    end
+  end
+
+  describe "escape_braces/1" do
+    test "escapes both braces" do
+      assert HTML.escape_braces("%{a: 1}") == "%&lbrace;a: 1&rbrace;"
+    end
+  end
+
+  describe "scope_to_class/1" do
+    test "every class html_linked emits is one scope_to_class produces" do
+      known = MapSet.new(Map.values(HTML.classes()))
+
+      for {source, language} <- @sources do
+        source
+        |> html_linked(language)
+        |> then(&Regex.scan(~r/<span class="([^"]+)"/, &1))
+        |> Enum.each(fn [_, class] ->
+          assert MapSet.member?(known, class),
+                 "#{language}: html_linked emits #{inspect(class)}, which is in no scope's class"
+        end)
+      end
+    end
+
+    test "resolves the scopes an event stream actually carries" do
+      {source, language} = hd(@sources)
+
+      source
+      |> events(language)
+      |> Enum.each(fn
+        {:start, %{scope: scope}} ->
+          assert HTML.scope_to_class(scope) != "l-text",
+                 "#{scope} fell back to l-text"
+
+        _event ->
+          :ok
+      end)
+    end
+
+    test "an unknown scope falls back to l-text, which a hand-rolled copy cannot express" do
+      assert HTML.scope_to_class("not.a.scope") == "l-text"
+      assert HTML.scope_to_class(nil) == "l-text"
+    end
+  end
+
+  describe "tags" do
+    test "open_pre_tag/1 appends a class" do
+      assert HTML.open_pre_tag() == ~s|<pre class="lumis">|
+      assert HTML.open_pre_tag(class: "mine") == ~s|<pre class="lumis mine">|
+    end
+
+    test "open_pre_tag/1 with a theme is what html_inline opens with" do
+      for theme <- @themes, {source, language} <- @sources do
+        assert String.starts_with?(
+                 html_inline(source, language, theme, []),
+                 HTML.open_pre_tag(theme: theme)
+               ),
+               "#{theme}/#{language} opened differently"
+      end
+    end
+
+    test "open_pre_tag/1 without a theme is what html_linked opens with" do
+      for {source, language} <- @sources do
+        assert String.starts_with?(html_linked(source, language), HTML.open_pre_tag())
+      end
+    end
+
+    test "open_code_tag/1 is what the built-in formatters open with" do
+      for {source, language} <- @sources do
+        assert String.contains?(html_linked(source, language), HTML.open_code_tag(language))
+      end
+    end
+
+    test "closing_tags/0 is what the built-in formatters close with" do
+      assert HTML.closing_tags() == "</code></pre>"
+
+      for {source, language} <- @sources do
+        assert String.ends_with?(html_linked(source, language), HTML.closing_tags())
+      end
+    end
+  end
+
+  describe "wrap_line/3" do
+    test "numbers lines from one" do
+      assert HTML.wrap_line(2, "code") == ~s|<div class="l-line" data-line="2">code</div>|
+    end
+
+    test "appends a class suffix and a style" do
+      assert HTML.wrap_line(1, "x", class_suffix: " l-highlighted", style: "color: red;") ==
+               ~s|<div class="l-line l-highlighted" style="color: red;" data-line="1">x</div>|
+    end
+
+    test "produces the line wrappers html_linked emits" do
+      for {source, language} <- @sources do
+        html = html_linked(source, language)
+
+        html
+        |> then(&Regex.scan(~r|<div class="l-line" data-line="(\d+)">|, &1))
+        |> Enum.each(fn [opening, number] ->
+          assert String.starts_with?(HTML.wrap_line(String.to_integer(number), ""), opening),
+                 "#{language}: wrap_line does not produce #{inspect(opening)}"
+        end)
+      end
+    end
+  end
+
+  describe "span_attrs/1 and open_span/2" do
+    test "every span html_inline opens is one open_span produces" do
+      for theme <- @themes,
+          {source, language} <- @sources,
+          italic <- [false, true],
+          include_highlights <- [false, true] do
+        html =
+          html_inline(source, language, theme,
+            italic: italic,
+            include_highlights: include_highlights
+          )
+
+        attrs =
+          HTML.span_attrs(
+            theme: theme,
+            language: language,
+            italic: italic,
+            include_highlights: include_highlights
+          )
+
+        html
+        |> then(&Regex.scan(~r|(<span[^>]*>)|, &1))
+        |> Enum.map(fn [_, tag] -> tag end)
+        |> Enum.uniq()
+        |> Enum.each(fn tag ->
+          scope = scope_of(tag, attrs)
+
+          assert scope, "#{theme}/#{language}: no scope produces #{inspect(tag)}"
+        end)
+      end
+    end
+
+    test "a scope the theme does not style opens a bare span" do
+      attrs = HTML.span_attrs(theme: "github_light", language: "elixir")
+
+      assert HTML.open_span(attrs, nil) == "<span>"
+      assert HTML.open_span(attrs, "not.a.scope") == "<span>"
+    end
+
+    test "without a theme every scope is unstyled" do
+      attrs = HTML.span_attrs(language: "elixir")
+
+      assert HTML.open_span(attrs, "keyword.function") == "<span>"
+    end
+
+    test "include_highlights adds the scope html_inline puts in data-highlight" do
+      attrs = HTML.span_attrs(theme: "github_light", language: "elixir", include_highlights: true)
+
+      assert HTML.open_span(attrs, "keyword.function") =~ ~s|data-highlight="keyword.function"|
+    end
+
+    test "span_inline/3 escapes the text" do
+      attrs = HTML.span_attrs(language: "elixir")
+
+      assert HTML.span_inline("a & b", attrs, "keyword") == "<span>a &amp; b</span>"
+    end
+  end
+
+  describe "span_linked/2" do
+    test "is the span html_linked emits for the same scope" do
+      for {source, language} <- @sources, source != "" do
+        html = html_linked(source, language)
+
+        source
+        |> events(language)
+        |> Enum.flat_map(fn
+          {:start, %{scope: scope}} -> [scope]
+          _event -> []
+        end)
+        |> Enum.uniq()
+        |> Enum.each(fn scope ->
+          assert String.contains?(html, "<span #{HTML.span_linked_attrs(scope)}>"),
+                 "#{language}: html_linked never opens <span #{HTML.span_linked_attrs(scope)}>"
+        end)
+      end
+    end
+  end
+
+  # A `<span ...>` from html_inline is reproduced by `open_span/2` for exactly
+  # one scope; find it, or report that none matches.
+  defp scope_of(tag, attrs) do
+    Enum.find_value(Map.keys(attrs), fn scope ->
+      if HTML.open_span(attrs, scope) == tag, do: scope
+    end) || if tag == "<span>", do: :unstyled
+  end
+end

--- a/packages/elixir/lumis/test/lumis/formatter_test.exs
+++ b/packages/elixir/lumis/test/lumis/formatter_test.exs
@@ -1,0 +1,54 @@
+defmodule Lumis.FormatterTest do
+  use ExUnit.Case, async: true
+
+  defmodule LanguageFormatter do
+    @moduledoc false
+    @behaviour Lumis.Formatter
+
+    @impl true
+    def render(_source, _events, options) do
+      Keyword.fetch!(options, :language)
+    end
+  end
+
+  @bash "#!/usr/bin/env bash\nID=1\n"
+
+  setup_all do
+    :ok = Lumis.Languages.load(~w(elixir bash))
+    :ok
+  end
+
+  defp language_of(source, options \\ []) do
+    Lumis.highlight!(source, formatter: {LanguageFormatter, options})
+  end
+
+  describe "the :language a formatter receives" do
+    test "is the language highlighting detected, not the nothing the caller named" do
+      # Rust's `Formatter::language()` and JavaScript's `this.language` both
+      # carry the resolved language. Elixir used to hand over the caller's
+      # `nil`, so a formatter could not label its own output without running
+      # detection a second time.
+      assert language_of(@bash) == "bash"
+    end
+
+    test "agrees with what the built-in formatters label the same source" do
+      built_in = Lumis.highlight!(@bash, formatter: :html_linked)
+
+      assert String.contains?(built_in, "class=\"language-#{language_of(@bash)}\"")
+    end
+
+    test "agrees with Lumis.Languages.guess/2" do
+      for source <- [@bash, "defmodule App do\nend\n", "nothing identifies this\n"] do
+        assert language_of(source) == Lumis.Languages.guess(nil, source)
+      end
+    end
+
+    test "is the language the caller named when they named one" do
+      assert language_of(@bash, language: "elixir") == "elixir"
+    end
+
+    test "is plaintext when nothing matches" do
+      assert language_of("nothing identifies this\n") == "plaintext"
+    end
+  end
+end

--- a/packages/elixir/lumis/test/lumis_test.exs
+++ b/packages/elixir/lumis/test/lumis_test.exs
@@ -1463,7 +1463,7 @@ defmodule Lumis.LumisTest do
                  {:html_inline,
                   %{
                     header: nil,
-                    highlight_lines: %Lumis.HtmlInlineHighlightLines{},
+                    highlight_lines: %Lumis.HTMLInlineHighlightLines{},
                     include_highlights: false,
                     italic: false,
                     pre_class: nil,
@@ -1480,7 +1480,7 @@ defmodule Lumis.LumisTest do
                formatter:
                  {:html_inline,
                   %{
-                    header: %Lumis.HtmlElement{open_tag: "<div>", close_tag: "</div>"},
+                    header: %Lumis.HTMLElement{open_tag: "<div>", close_tag: "</div>"},
                     highlight_lines: nil,
                     include_highlights: false,
                     italic: false,

--- a/packages/elixir/lumis/usage-rules.md
+++ b/packages/elixir/lumis/usage-rules.md
@@ -467,6 +467,57 @@ Lumis.highlight!(code,
 
 Both `:open_tag` and `:close_tag` are required when using `:header`.
 
+### Custom Formatters
+
+When no built-in formatter emits what you need, implement `Lumis.Formatter` and
+pass the module. Lumis highlights the source and hands `render/3` the event
+stream, with the resolved language in `options`.
+
+```elixir
+defmodule MyFormatter do
+  @behaviour Lumis.Formatter
+
+  alias Lumis.Formatter.HTML
+
+  @impl true
+  def render(source, events, options) do
+    language = Keyword.fetch!(options, :language)
+    theme = Keyword.get(options, :theme)
+    attrs = HTML.span_attrs(theme: theme, language: language)
+
+    body =
+      Enum.map(events, fn
+        {:start, %{scope: scope}} -> HTML.open_span(attrs, scope)
+        :end -> "</span>"
+        {:source, %{start: start, end: stop}} ->
+          HTML.escape(binary_part(source, start, stop - start))
+
+        # Always keep this clause. Lumis adds event kinds as it grows, and
+        # without it a newer Lumis raises FunctionClauseError instead of
+        # rendering.
+        _event -> []
+      end)
+
+    [HTML.open_pre_tag(theme: theme), HTML.open_code_tag(language), body, HTML.closing_tags()]
+  end
+end
+
+Lumis.highlight!(code, formatter: {MyFormatter, language: "elixir", theme: "github_light"})
+```
+
+`render/3` returns iodata; Lumis flattens it once at the end.
+
+Do not hand-roll HTML escaping or scope-to-class mapping. `Lumis.Formatter.HTML`
+calls the same Rust the built-in formatters call:
+
+- `escape/1`, `escape_braces/1`
+- `scope_to_class/1`, `span_linked_attrs/1`, `span_linked/2`
+- `span_attrs/1`, `open_span/2`, `span_inline_attrs/2`, `span_inline/3`
+- `open_pre_tag/1`, `open_code_tag/1`, `closing_tags/0`, `wrap_line/3`
+
+`span_attrs/1` and `classes/0` return whole tables because resolving a scope is
+a per-token operation. Build the table once outside the loop and read it inside.
+
 ## HTML Output Structure
 
 Lumis generates semantic HTML with line wrappers:
@@ -705,6 +756,9 @@ highlight_lines: %{lines: [1, 2]}
 
 # Highlight and raise on error
 html = Lumis.highlight!(source, opts)
+
+# Render the event stream yourself
+html = Lumis.highlight!(source, formatter: {MyFormatter, language: "elixir"})
 
 # Get all available languages
 [%{id: _} | _] = Lumis.available_languages()

--- a/packages/javascript/lumis/examples/annotations.ts
+++ b/packages/javascript/lumis/examples/annotations.ts
@@ -53,7 +53,7 @@ const formatter: Formatter<Mark> = {
       } else if (event.type === "annotationEnd") {
         out.push(`</${open.pop()}>`);
       } else {
-        out.push(escape(decoder.decode(bytes.subarray(event.startByte, event.endByte))));
+        out.push(escape(decoder.decode(bytes.subarray(event.start, event.end))));
       }
     }
 

--- a/packages/javascript/lumis/src/annotations.ts
+++ b/packages/javascript/lumis/src/annotations.ts
@@ -294,7 +294,7 @@ function emitPoints<T>(
  * syntax layers around each piece so the emitted stream stays nested.
  */
 function composeSourceEvent<T>(
-  event: { startByte: number; endByte: number },
+  event: { start: number; end: number },
   state: ComposeState<T>,
   boundaries: BoundaryTable,
   activeAnnotations: Set<number>,
@@ -306,13 +306,13 @@ function composeSourceEvent<T>(
     boundaries,
     activeAnnotations,
     state.boundaryIndex,
-    event.startByte,
+    event.start,
   );
 
-  let cursor = event.startByte;
-  while (cursor < event.endByte) {
+  let cursor = event.start;
+  while (cursor < event.end) {
     const boundary = boundaries.offsets[state.boundaryIndex];
-    const next = boundary !== undefined && boundary < event.endByte ? boundary : event.endByte;
+    const next = boundary !== undefined && boundary < event.end ? boundary : event.end;
 
     state.activeLayers = transitionLayers(
       output,
@@ -322,7 +322,7 @@ function composeSourceEvent<T>(
     emitPoints(output, boundaries, annotations, state.pendingPoints, cursor);
 
     if (cursor < next) {
-      output.push({ type: "source", startByte: cursor, endByte: next });
+      output.push({ type: "source", start: cursor, end: next });
     }
     cursor = next;
 

--- a/packages/javascript/lumis/src/core/highlighter.ts
+++ b/packages/javascript/lumis/src/core/highlighter.ts
@@ -225,7 +225,7 @@ function runHighlightIter(
 // The innermost open span decides a token's scope and language; a token outside
 // any span carries the document's language and no scope.
 function emitToken(
-  event: { startByte: number; endByte: number },
+  event: { start: number; end: number },
   scopeStack: Array<{ scope: string; language: string }>,
   bytes: Uint8Array,
   theme: Theme | undefined,
@@ -237,9 +237,9 @@ function emitToken(
   const tokenLanguage = active?.language ?? documentLanguage;
 
   onToken(
-    decodeSlice(bytes, event.startByte, event.endByte),
+    decodeSlice(bytes, event.start, event.end),
     tokenLanguage,
-    { start: event.startByte, end: event.endByte },
+    { start: event.start, end: event.end },
     scope,
     scope.length > 0 ? getScopedThemeStyle(theme, scope, tokenLanguage) : undefined,
   );

--- a/packages/javascript/lumis/src/core/languages.ts
+++ b/packages/javascript/lumis/src/core/languages.ts
@@ -1436,7 +1436,7 @@ export function createLanguagesModule(runtime: RuntimeEnvironment): LanguagesMod
       options: { rainbowBrackets?: boolean } = {},
     ): SyntaxHighlightEvent[] {
       if (language.definition.id === PLAINTEXT_LANG_ID) {
-        return [{ type: "source", startByte: 0, endByte: encoder.encode(source).byteLength }];
+        return [{ type: "source", start: 0, end: encoder.encode(source).byteLength }];
       }
       if (options.rainbowBrackets && !language.brackets) {
         const compile = this.bracketCompilers.get(language);

--- a/packages/javascript/lumis/src/core/native-event-codec.ts
+++ b/packages/javascript/lumis/src/core/native-event-codec.ts
@@ -36,7 +36,7 @@ export function decodeNativeEvents(data: Uint8Array): SyntaxHighlightEvent[] {
         const startByte = view.getUint32(offset, true);
         const endByte = view.getUint32(offset + 4, true);
         offset += SOURCE_EVENT_BYTES;
-        events.push({ type: "source", startByte, endByte });
+        events.push({ type: "source", start: startByte, end: endByte });
         break;
       }
       case START_EVENT: {

--- a/packages/javascript/lumis/src/core/native-languages.ts
+++ b/packages/javascript/lumis/src/core/native-languages.ts
@@ -442,7 +442,7 @@ export function createNativeLanguagesModule(
     ): SyntaxHighlightEvent[] {
       rejectReentrantHighlight();
       if (language.definition.id === PLAINTEXT_LANG_ID) {
-        return [{ type: "source", startByte: 0, endByte: encoder.encode(source).byteLength }];
+        return [{ type: "source", start: 0, end: encoder.encode(source).byteLength }];
       }
       const hasResolvers = hasResolverOverride(this.resolverState);
       const highlighted = this.native.highlightEvents(

--- a/packages/javascript/lumis/src/events.ts
+++ b/packages/javascript/lumis/src/events.ts
@@ -71,8 +71,8 @@ export interface HighlightStartEvent {
 
 export interface HighlightSourceEvent {
   type: "source";
-  startByte: number;
-  endByte: number;
+  start: number;
+  end: number;
 }
 
 export interface HighlightEndEvent {
@@ -931,7 +931,7 @@ function applyRainbowBrackets(
       continue;
     }
 
-    while (rangeIndex < ranges.length && ranges[rangeIndex]!.endByte <= event.startByte) {
+    while (rangeIndex < ranges.length && ranges[rangeIndex]!.endByte <= event.start) {
       rangeIndex += 1;
     }
 
@@ -945,30 +945,30 @@ function applyRainbowBrackets(
 // range it wholly contains. A range that straddles the event is left to the
 // event that does contain it.
 function splitSourceEvent(
-  event: { type: "source"; startByte: number; endByte: number },
+  event: { type: "source"; start: number; end: number },
   ranges: Array<{ startByte: number; endByte: number; scope: string }>,
   rangeIndex: number,
   languageId: string,
 ): HighlightEvent[] {
   const output: HighlightEvent[] = [];
-  let cursor = event.startByte;
+  let cursor = event.start;
 
   for (let index = rangeIndex; index < ranges.length; index += 1) {
     const range = ranges[index]!;
-    if (range.startByte >= event.endByte) break;
-    if (range.startByte < event.startByte || range.endByte > event.endByte) continue;
+    if (range.startByte >= event.end) break;
+    if (range.startByte < event.start || range.endByte > event.end) continue;
 
     if (cursor < range.startByte) {
-      output.push({ type: "source", startByte: cursor, endByte: range.startByte });
+      output.push({ type: "source", start: cursor, end: range.startByte });
     }
     output.push({ type: "start", scope: range.scope, language: languageId });
-    output.push({ type: "source", startByte: range.startByte, endByte: range.endByte });
+    output.push({ type: "source", start: range.startByte, end: range.endByte });
     output.push({ type: "end" });
     cursor = range.endByte;
   }
 
-  if (cursor < event.endByte) {
-    output.push({ type: "source", startByte: cursor, endByte: event.endByte });
+  if (cursor < event.end) {
+    output.push({ type: "source", start: cursor, end: event.end });
   }
 
   return output;
@@ -1273,7 +1273,7 @@ function buildNestedEvents(inputLayers: HighlightLayer[], maps: SourceMaps): Hig
 
   function emitSource(endByte: number): void {
     if (endByte > cursor) {
-      events.push({ type: "source", startByte: cursor, endByte });
+      events.push({ type: "source", start: cursor, end: endByte });
       cursor = endByte;
     }
   }

--- a/packages/javascript/lumis/src/formatter/bbcode.ts
+++ b/packages/javascript/lumis/src/formatter/bbcode.ts
@@ -34,7 +34,7 @@ export function formatBBCode(source: string, events: readonly HighlightEvent[]):
       continue;
     }
 
-    const text = decodeSourceSlice(sourceBytes, event.startByte, event.endByte);
+    const text = decodeSourceSlice(sourceBytes, event.start, event.end);
     parts.push(escapeBbcodeText(text));
   }
 

--- a/packages/javascript/lumis/src/formatter/html.ts
+++ b/packages/javascript/lumis/src/formatter/html.ts
@@ -1025,7 +1025,7 @@ export function formatHighlightIterLines(
     } else if (event.type === "source") {
       // The document's language is the outermost span's, once one is open.
       language = resolveDocumentLanguage(language, stack);
-      const text = decodeSourceSlice(sourceBytes, event.startByte, event.endByte);
+      const text = decodeSourceSlice(sourceBytes, event.start, event.end);
       renderSourceEvent(lines, text, stack, formatText, options.openSpan, closeSpan, theme);
     }
   }
@@ -1110,7 +1110,7 @@ export function renderEvents(
       continue;
     }
 
-    const text = decodeSourceSlice(sourceBytes, event.startByte, event.endByte);
+    const text = decodeSourceSlice(sourceBytes, event.start, event.end);
     for (let i = 0; i < text.length; i += 1) {
       const char = text[i]!;
       push(escapeChar(char));

--- a/packages/javascript/lumis/src/formatter/terminal.ts
+++ b/packages/javascript/lumis/src/formatter/terminal.ts
@@ -116,7 +116,7 @@ export function formatTerminal(
       continue;
     }
 
-    const text = decodeSourceSlice(sourceBytes, event.startByte, event.endByte);
+    const text = decodeSourceSlice(sourceBytes, event.start, event.end);
     const style = activeStyle(scopeStack, formatter.theme);
 
     if (fallbackBg === undefined) {

--- a/packages/javascript/lumis/src/types.ts
+++ b/packages/javascript/lumis/src/types.ts
@@ -401,7 +401,7 @@ export interface HighlightOptions<T = unknown> {
  */
 export type SyntaxHighlightEvent =
   | { type: "start"; scope: string; language: string }
-  | { type: "source"; startByte: number; endByte: number }
+  | { type: "source"; start: number; end: number }
   | { type: "end" };
 
 /** A unified syntax and caller-provided annotation event. */
@@ -459,7 +459,7 @@ export type HighlightIterFn = (
  *
  *     return events
  *       .filter(event => event.type === 'source')
- *       .map(event => decoder.decode(bytes.subarray(event.startByte, event.endByte)))
+ *       .map(event => decoder.decode(bytes.subarray(event.start, event.end)))
  *       .join('')
  *   },
  * }

--- a/packages/javascript/lumis/test/annotation-composition.test.ts
+++ b/packages/javascript/lumis/test/annotation-composition.test.ts
@@ -40,7 +40,7 @@ function render(testCase: Case): string {
           case "start":
             return `S:${event.scope}`;
           case "source":
-            return `T:${event.startByte}-${event.endByte}`;
+            return `T:${event.start}-${event.end}`;
           case "end":
             return "E";
           case "annotationEnd":

--- a/packages/javascript/lumis/test/annotations.test.ts
+++ b/packages/javascript/lumis/test/annotations.test.ts
@@ -40,7 +40,7 @@ describe("annotations", () => {
           }
           if (event.type === "annotationEnd") output.push("</annotation>");
           if (event.type === "source") {
-            output.push(decoder.decode(bytes.subarray(event.startByte, event.endByte)));
+            output.push(decoder.decode(bytes.subarray(event.start, event.end)));
           }
         }
 
@@ -107,7 +107,7 @@ describe("annotations", () => {
               resolvedRange = event.annotation.range;
             }
             if (event.type === "source") {
-              return decoder.decode(sourceBytes.subarray(event.startByte, event.endByte));
+              return decoder.decode(sourceBytes.subarray(event.start, event.end));
             }
             return "";
           })
@@ -169,7 +169,7 @@ describe("annotations", () => {
           if (event.type === "annotationStart") parts.push(`<mark:${event.annotation.data.id}>`);
           else if (event.type === "annotationEnd") parts.push("</mark>");
           else if (event.type === "source") {
-            parts.push(decoder.decode(bytes.subarray(event.startByte, event.endByte)));
+            parts.push(decoder.decode(bytes.subarray(event.start, event.end)));
           }
         }
         return parts.join("");

--- a/packages/javascript/lumis/test/browser/smoke.ts
+++ b/packages/javascript/lumis/test/browser/smoke.ts
@@ -315,9 +315,7 @@ async function run(): Promise<void> {
           depth -= 1;
           balancedEvents &&= depth >= 0;
         } else {
-          reconstructedSource += decoder.decode(
-            sourceBytes.subarray(event.startByte, event.endByte),
-          );
+          reconstructedSource += decoder.decode(sourceBytes.subarray(event.start, event.end));
         }
       }
       balancedEvents &&= depth === 0;

--- a/packages/javascript/lumis/test/formatter-parity.test.ts
+++ b/packages/javascript/lumis/test/formatter-parity.test.ts
@@ -23,7 +23,7 @@ const theme: Theme = {
 };
 
 function sourceEvents(source: string): HighlightEvent[] {
-  return [{ type: "source", startByte: 0, endByte: Buffer.byteLength(source) }];
+  return [{ type: "source", start: 0, end: Buffer.byteLength(source) }];
 }
 
 function terminalFormatter(options: Partial<TerminalFormatter>): TerminalFormatter {

--- a/packages/javascript/lumis/test/formatter-shared.test.ts
+++ b/packages/javascript/lumis/test/formatter-shared.test.ts
@@ -164,11 +164,11 @@ describe("formatter shared helpers", () => {
       "a\nb",
       [
         { type: "start", scope: "string", language: "json" },
-        { type: "source", startByte: 0, endByte: 1 },
+        { type: "source", start: 0, end: 1 },
         { type: "end" },
-        { type: "source", startByte: 1, endByte: 2 },
+        { type: "source", start: 1, end: 2 },
         { type: "start", scope: "number", language: "json" },
-        { type: "source", startByte: 2, endByte: 3 },
+        { type: "source", start: 2, end: 3 },
         { type: "end" },
       ],
       jsonLang,
@@ -190,7 +190,7 @@ describe("formatter shared helpers", () => {
       "ab\ncd",
       [
         { type: "start", scope: "string", language: "json" },
-        { type: "source", startByte: 0, endByte: 5 },
+        { type: "source", start: 0, end: 5 },
         { type: "end" },
       ],
       jsonLang,
@@ -211,7 +211,7 @@ describe("formatter shared helpers", () => {
       "a\nb",
       [
         { type: "start", scope: "string", language: "json" },
-        { type: "source", startByte: 0, endByte: 3 },
+        { type: "source", start: 0, end: 3 },
         { type: "end" },
       ],
       jsonLang,
@@ -233,7 +233,7 @@ describe("formatter shared helpers", () => {
       "a\nb",
       [
         { type: "start", scope: "string", language: "json" },
-        { type: "source", startByte: 0, endByte: 3 },
+        { type: "source", start: 0, end: 3 },
         { type: "end" },
       ],
       (scope) => `class="${scope}"`,
@@ -247,9 +247,9 @@ describe("formatter shared helpers", () => {
       "ab",
       [
         { type: "start", scope: "string", language: "json" },
-        { type: "source", startByte: 0, endByte: 1 },
+        { type: "source", start: 0, end: 1 },
         { type: "start", scope: "unstyled", language: "json" },
-        { type: "source", startByte: 1, endByte: 2 },
+        { type: "source", start: 1, end: 2 },
         { type: "end" },
         { type: "end" },
       ],
@@ -264,7 +264,7 @@ describe("formatter shared helpers", () => {
       "a\nb",
       [
         { type: "start", scope: "unstyled", language: "json" },
-        { type: "source", startByte: 0, endByte: 3 },
+        { type: "source", start: 0, end: 3 },
         { type: "end" },
       ],
       () => "",
@@ -278,7 +278,7 @@ describe("formatter shared helpers", () => {
       "ab",
       [
         { type: "start", scope: "unstyled", language: "json" },
-        { type: "source", startByte: 0, endByte: 2 },
+        { type: "source", start: 0, end: 2 },
         { type: "end" },
       ],
       () => {},
@@ -292,7 +292,7 @@ describe("formatter shared helpers", () => {
       "a\n<b>",
       [
         { type: "start", scope: "string", language: "json" },
-        { type: "source", startByte: 0, endByte: 5 },
+        { type: "source", start: 0, end: 5 },
         { type: "end" },
       ],
       (scope, _language, out) => {

--- a/packages/javascript/lumis/test/native-event-codec.test.ts
+++ b/packages/javascript/lumis/test/native-event-codec.test.ts
@@ -27,7 +27,7 @@ describe("native event codec", () => {
 
     expect(decodeNativeEvents(encoded)).toEqual([
       { type: "start", scope: HIGHLIGHT_NAMES[0], language: "js" },
-      { type: "source", startByte: 1, endByte: 5 },
+      { type: "source", start: 1, end: 5 },
       { type: "end" },
     ]);
   });
@@ -36,7 +36,7 @@ describe("native event codec", () => {
     const wrapped = new Uint8Array([255, 0, 1, 0, 0, 0, 5, 0, 0, 0, 255]);
 
     expect(decodeNativeEvents(wrapped.subarray(1, -1))).toEqual([
-      { type: "source", startByte: 1, endByte: 5 },
+      { type: "source", start: 1, end: 5 },
     ]);
   });
 


### PR DESCRIPTION
Closes #1359, and the last open point of #1334.

Three commits, because the changelog is generated per package from the subjects:

| | |
| --- | --- |
| `feat(elixir): HTML formatter helpers` | #1359 |
| `fix(elixir): hand a custom formatter the language detection resolved` | |
| `feat(javascript)!: name source event offsets start and end` | **breaking, JS only** |
| `refactor(elixir): spell the HTML acronym in full` | |

---

## 1. `Lumis.Formatter.HTML` — #1359

#1100 gave Elixir a `Lumis.Formatter` behaviour over an event stream, covering points 1 and 2 of #1334. It left point 3 untouched: Rust and JavaScript both ship HTML helpers a custom formatter calls, and Elixir shipped none.

That had already drifted. `examples/annotations.exs` hand-rolled both helpers it needed, one wrong on arrival — an `escape` covering four characters where `lumis_core::formatter::html::escape` covers five, missing `'`. Patched in #1100, but nothing stopped it recurring, because there was no original in Elixir to pin a copy to. The example now calls the helpers and both copies are gone.

Per #1359 and AGENTS.md the module **exposes** the Rust rather than porting it, so there is no second implementation to drift. `crates/` is untouched by this commit — every helper already existed in `lumis_core::formatter::html`.

```
escape/1  escape_braces/1
scope_to_class/1  span_linked_attrs/1  span_linked/2
span_attrs/1  open_span/2  span_inline_attrs/2  span_inline/3
open_pre_tag/1  open_code_tag/1  closing_tags/0  wrap_line/3
```

The NIF split is by call frequency: what a formatter calls once per document crosses as a call; the two things it calls once per *token* cross once per document as a **table**, because 5000 NIF calls to look up a constant is not what reusing the Rust core should cost.

**On the name** — `Lumis.Formatter.HTML`, not the `Lumis.HTML` #1359 floated, because that is where the other runtimes put it:

| | Canonical path | Sibling |
| --- | --- | --- |
| Rust | `lumis::formatters::html` | `lumis::formatters::ansi` |
| JavaScript | `@lumis-sh/lumis/formatters/html` | `@lumis-sh/lumis/formatters/ansi` |

`lumis::html` is only a re-export alias and JavaScript has no top-level `/html` at all. The sibling decides it: `Lumis.Formatter.ANSI` sits where the others put theirs, whereas `Lumis.ANSI` would land in the top namespace.

## 2. A custom formatter now gets the language detection resolved

```elixir
Lumis.highlight!("#!/usr/bin/env bash\nID=1\n", formatter: Probe)
#=> language option = nil          # before
#=> language option = "bash"       # after
```

`:html_linked` on the same source emitted `class="language-bash"` the whole time. Rust's `Formatter::language()` and JavaScript's `fmt.language = detectedRef` both hand over the resolved language; Elixir passed the caller's `nil` straight through, so a formatter could not label its own output without calling `Lumis.Languages.guess/2` and running detection a second time.

`highlight_events` now returns the language beside the events. `Keyword.put/3` rather than `put_new/3` is deliberate: the caller's `:language` is a *hint*, and `Language::guess` normalizes it, so `{MyFormatter, language: "app.ex"}` now reports `elixir` — verified, and matching what the built-in formatter labels the same source.

## 3. `startByte`/`endByte` → `start`/`end` in JavaScript (breaking)

```
Rust    HighlightEvent::Source { start, end }
Elixir  {:source, %{start: _, end: _}}
JS      { type: "source", startByte, endByte }   ← moved
```

JavaScript was also inconsistent with itself: `HighlightRange`, which `highlightIter` hands the same offsets through, has always been `{start, end}`. `fixtures/annotation-composition.json` moves with it, and the Rust fixture parser drops two `#[serde(rename)]` attributes that existed only to read JavaScript's spelling out of a shared fixture whose annotation ranges already used `start`/`end`.

Only property names change. The offsets are still UTF-8 bytes and the native wire format is untouched. Internal range types that are *not* this event — `HighlightSpan`, the bracket ranges in `events.ts` — are deliberately left alone.

## 4. `Html` → `HTML` in three Elixir module names

`Lumis.HtmlElement`, `Lumis.HtmlInlineHighlightLines` and `Lumis.HtmlLinkedHighlightLines` predated `Lumis.Native.ArtifactURL`, which already spells its acronym in full. Elixir capitalizes acronyms — `Phoenix.HTML`, `Plug.CSRFProtection` — and this PR adds `Lumis.Formatter.HTML`, so the three stragglers move too.

All three are `@moduledoc false` and are built by `Lumis.highlight/2` from the caller's plain maps, so nothing published names them. The `#[module = "..."]` attributes in the NIF move with them, since Rustler matches a struct by its Elixir module name. The Rust types keep `ExHtmlElement` / `HtmlElement`: Rust spells acronyms `Html`, and `lumis_core` is a Rust API first.

## Tests

Helpers are compared against what the built-in Rust formatters emit, not against literals: every class `:html_linked` emits is one `scope_to_class/1` produces; every `<span ...>` `:html_inline` opens, across two themes, six sources and all four `italic`/`include_highlights` combinations, is one `open_span/2` produces; the `<pre>`, `<code>`, `</code></pre>` and `l-line` wrappers are pinned the same way.

Both new guards were checked by injecting the defect they exist to catch — the naive `"l-" <> String.replace(scope, ".", "-")` reddens the fallback test, and reverting the language fix to `put_new/3` reddens 4 of the 5 language tests.

**Precise about the `l-text` fallback**, because #1359 is not: the naive transform agrees with `scope_to_class` on **all 293** real scopes. The divergence was only ever reachable through a scope not in `HIGHLIGHT_NAMES`, where Rust answers `l-text`.

## Verification

- `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt` — clean
- `mix test` — 211 passed (184 before); `mix test --include conformance` — 150, unchanged
- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` — clean
- JS wasm suite 651 passed, native suite 636 passed, conformance 150 passed
- `mise run fmt-js --check`, `mise run lint-js`, `tsc --noEmit` — clean
- `mix run examples/annotations.exs` — byte-identical output to before
- `docusaurus build` — succeeds; both doc examples were run, not just written

## Known, not fixed here

Attribute values reaching `open_pre_tag` and `wrap_line` are interpolated raw by the Rust core, while JavaScript escapes them. It predates this PR — the existing `{:html_inline, pre_class: …}` path behaves the same — and the fix belongs in `lumis_core::formatter::html` so Rust, the CLI and Elixir all get it at once. Split out as #1378.

## Not in scope

A flat-token API. #1334 asked for one, but #1359 records that #1100 settled points 1 and 2, and nested events are what Elixir gets.