### PR TITLE
fix(html): escape attribute values in the Rust formatters

### DIFF
--- a/crates/lumis-core/src/formatter/html.rs
+++ b/crates/lumis-core/src/formatter/html.rs
@@ -18,7 +18,7 @@ pub fn span_inline_attrs(
     let mut attrs = String::new();
 
     if include_highlights {
-        let _ = write!(attrs, "data-highlight=\"{scope}\"");
+        let _ = write!(attrs, "data-highlight=\"{}\"", escape_attr(scope));
     }
 
     if let Some(theme) = theme {
@@ -43,7 +43,7 @@ pub fn span_inline_attrs(
 
             let css = style.css(italic, " ");
             if !css.is_empty() {
-                let _ = write!(attrs, "style=\"{css}\"");
+                let _ = write!(attrs, "style=\"{}\"", escape_attr(&css));
             }
         }
     }
@@ -373,20 +373,21 @@ fn render_style_attrs(
 ) -> String {
     let mut attrs = String::new();
     if include_highlights {
-        let _ = write!(attrs, "data-highlight=\"{scope}\" ");
+        let _ = write!(attrs, "data-highlight=\"{}\" ", escape_attr(scope));
     }
 
-    attrs.push_str("style=\"");
+    let mut style = String::new();
     if !inline_styles.is_empty() {
-        attrs.push_str(&inline_styles.join(" "));
+        style.push_str(&inline_styles.join(" "));
     }
     if !css_vars.is_empty() {
         if !inline_styles.is_empty() {
-            attrs.push(' ');
+            style.push(' ');
         }
-        attrs.push_str(&css_vars.join(" "));
+        style.push_str(&css_vars.join(" "));
     }
-    attrs.push('"');
+
+    let _ = write!(attrs, "style=\"{}\"", escape_attr(&style));
 
     attrs
 }
@@ -446,6 +447,22 @@ pub fn escape(text: &str) -> String {
     buf
 }
 
+/// Escape a value for use inside a double-quoted HTML attribute.
+///
+/// Attribute values reach the formatters from two places outside the binary: a
+/// caller-supplied class or style (`pre_class`, `highlight_lines`), and a theme
+/// loaded with [`crate::themes::from_json`]. Neither is a generated constant, so
+/// both are escaped here rather than interpolated raw.
+///
+/// The escape set is the same as [`escape`], which is what `escapeAttr` in
+/// `packages/javascript/lumis/src/formatter/html.ts` covers, so the two runtimes
+/// answer the same for the same input. Escaping is safe for CSS in an attribute
+/// because the HTML parser decodes the entity before the CSS parser sees it, so
+/// `font-family: 'Fira Code'` survives the round trip.
+pub fn escape_attr(value: &str) -> String {
+    escape(value)
+}
+
 /// Escape braces for framework compatibility.
 pub fn escape_braces(text: &str) -> String {
     text.replace('{', "&lbrace;").replace('}', "&rbrace;")
@@ -459,14 +476,17 @@ pub fn wrap_line(
     style: Option<&str>,
 ) -> String {
     let class_attr = match class_suffix {
-        Some(suffix) => format!("l-line{suffix}"),
+        Some(suffix) => escape_attr(&format!("l-line{suffix}")),
         None => "l-line".to_string(),
     };
 
     match style {
-        Some(s) => format!(
-            "<div class=\"{class_attr}\" style=\"{s}\" data-line=\"{line_number}\">{content}</div>"
-        ),
+        Some(s) => {
+            let style_attr = escape_attr(s);
+            format!(
+                "<div class=\"{class_attr}\" style=\"{style_attr}\" data-line=\"{line_number}\">{content}</div>"
+            )
+        }
         None => format!("<div class=\"{class_attr}\" data-line=\"{line_number}\">{content}</div>"),
     }
 }
@@ -486,10 +506,9 @@ pub fn open_pre_tag(
     pre_class: Option<&str>,
     theme: Option<&Theme>,
 ) -> io::Result<()> {
-    let class = if let Some(pre_class) = pre_class {
-        format!("lumis {pre_class}")
-    } else {
-        "lumis".to_string()
+    let class = match pre_class {
+        Some(pre_class) => escape_attr(&format!("lumis {pre_class}")),
+        None => "lumis".to_string(),
     };
 
     write!(
@@ -498,7 +517,7 @@ pub fn open_pre_tag(
         class,
         theme
             .and_then(|theme| theme.pre_style(" "))
-            .map(|pre_style| format!(" style=\"{pre_style}\""))
+            .map(|pre_style| format!(" style=\"{}\"", escape_attr(&pre_style)))
             .unwrap_or_default(),
     )
 }
@@ -511,12 +530,12 @@ pub fn open_multi_themes_pre_tag(
     default_theme: Option<&str>,
     css_variable_prefix: &str,
 ) -> io::Result<()> {
-    let classes = multi_themes_pre_classes(pre_class, themes);
+    let classes = escape_attr(&multi_themes_pre_classes(pre_class, themes));
     let style = multi_themes_pre_style(themes, default_theme, css_variable_prefix);
 
     write!(output, "<pre class=\"{classes}\"")?;
     if !style.is_empty() {
-        write!(output, " style=\"{style}\"")?;
+        write!(output, " style=\"{}\"", escape_attr(&style))?;
     }
     write!(output, ">")
 }
@@ -908,6 +927,127 @@ mod tests {
     #[test]
     fn test_escape_braces_only() {
         assert_eq!(escape_braces("fn() {}"), "fn() &lbrace;&rbrace;");
+    }
+
+    /// A theme is data, so a colour can carry a quote out of a JSON file and
+    /// close the attribute it is written into.
+    fn quote_bearing_theme() -> Theme {
+        crate::themes::from_json(
+            r##"{
+              "name": "quote-bearing",
+              "appearance": "dark",
+              "revision": "test",
+              "highlights": {
+                "normal": { "fg": "red\" onmouseover=\"alert(1)", "bg": "#000000" },
+                "keyword": { "fg": "red\" onmouseover=\"alert(1)" }
+              }
+            }"##,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_escape_attr_matches_escape() {
+        assert_eq!(escape_attr("&<>\"'"), "&amp;&lt;&gt;&quot;&#39;");
+    }
+
+    #[test]
+    fn test_escape_attr_keeps_quoted_css_readable() {
+        assert_eq!(
+            escape_attr("font-family: 'Fira Code';"),
+            "font-family: &#39;Fira Code&#39;;"
+        );
+    }
+
+    #[test]
+    fn test_open_pre_tag_escapes_caller_class() {
+        let mut output = Vec::new();
+        open_pre_tag(&mut output, Some(r#"x"><script>"#), None).unwrap();
+
+        assert_str_eq!(
+            String::from_utf8(output).unwrap(),
+            r#"<pre class="lumis x&quot;&gt;&lt;script&gt;">"#
+        );
+    }
+
+    #[test]
+    fn test_open_pre_tag_escapes_theme_colors() {
+        let mut output = Vec::new();
+        open_pre_tag(&mut output, None, Some(&quote_bearing_theme())).unwrap();
+
+        assert_str_eq!(
+            String::from_utf8(output).unwrap(),
+            r#"<pre class="lumis" style="color: red&quot; onmouseover=&quot;alert(1); background-color: #000000;">"#
+        );
+    }
+
+    #[test]
+    fn test_open_multi_themes_pre_tag_escapes_caller_class() {
+        let mut themes = std::collections::HashMap::new();
+        themes.insert("dark".to_string(), quote_bearing_theme());
+
+        let mut output = Vec::new();
+        open_multi_themes_pre_tag(
+            &mut output,
+            Some(r#"x"><script>"#),
+            &themes,
+            Some("dark"),
+            "--lumis",
+        )
+        .unwrap();
+
+        let html = String::from_utf8(output).unwrap();
+
+        assert!(
+            html.starts_with(r#"<pre class="lumis lumis-themes x&quot;&gt;&lt;script&gt; dark""#),
+            "unescaped class in {html}"
+        );
+        assert!(!html.contains("<script>"), "unescaped markup in {html}");
+    }
+
+    #[test]
+    fn test_wrap_line_escapes_caller_class_and_style() {
+        let result = wrap_line(
+            1,
+            "content",
+            Some(r#" x"><script>"#),
+            Some(r#"color: red" onmouseover="alert(1)"#),
+        );
+
+        assert_str_eq!(
+            result,
+            r#"<div class="l-line x&quot;&gt;&lt;script&gt;" style="color: red&quot; onmouseover=&quot;alert(1)" data-line="1">content</div>"#
+        );
+    }
+
+    #[test]
+    fn test_span_inline_escapes_theme_colors() {
+        assert_str_eq!(
+            span_inline(
+                "fn",
+                None,
+                "keyword",
+                Some(&quote_bearing_theme()),
+                false,
+                false
+            ),
+            r#"<span style="color: red&quot; onmouseover=&quot;alert(1);">fn</span>"#
+        );
+    }
+
+    #[test]
+    fn test_span_multi_themes_escapes_theme_colors() {
+        let mut themes = std::collections::HashMap::new();
+        themes.insert("dark".to_string(), quote_bearing_theme());
+
+        let result = span_multi_themes(
+            "fn", "keyword", None, &themes, None, "--lumis", false, false,
+        );
+
+        assert_str_eq!(
+            result,
+            r#"<span style="--lumis-dark:red&quot; onmouseover=&quot;alert(1); --lumis-dark-font-style:normal; --lumis-dark-font-weight:normal; --lumis-dark-text-decoration:none;">fn</span>"#
+        );
     }
 
     #[test]

--- a/crates/lumis-core/tests/html_attr_escaping.rs
+++ b/crates/lumis-core/tests/html_attr_escaping.rs
@@ -7,11 +7,13 @@
 //! a bug in the port rather than something to record.
 
 use lumis_core::formatter::html;
+use lumis_core::languages::Language;
 use lumis_core::themes::Theme;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
+use std::str::FromStr as _;
 
 #[derive(Debug, Deserialize)]
 struct Manifest {
@@ -29,6 +31,11 @@ struct Case {
     text: String,
     #[serde(default)]
     scope: String,
+    /// The same string the port passes, so both resolve the same specialized
+    /// scope. Rust's argument is optional and the port's is not, so leaving it
+    /// to each side would have them look up different scopes.
+    #[serde(default = "plaintext")]
+    language: String,
     #[serde(default)]
     theme: Option<String>,
     #[serde(default)]
@@ -54,6 +61,10 @@ enum Helper {
     Line,
 }
 
+fn plaintext() -> String {
+    "plaintext".to_string()
+}
+
 fn manifest() -> Manifest {
     let path =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/html-attr-escaping.json");
@@ -67,6 +78,11 @@ fn theme(manifest: &Manifest, key: &str) -> Theme {
         .get(key)
         .unwrap_or_else(|| panic!("`{key}` is not a fixture theme"));
     lumis_core::themes::from_json(&source.to_string()).expect("fixture themes are well-formed")
+}
+
+fn language(case: &Case) -> Language {
+    Language::from_str(&case.language)
+        .unwrap_or_else(|_| panic!("`{}` is not a language", case.language))
 }
 
 fn render(manifest: &Manifest, case: &Case) -> String {
@@ -83,7 +99,7 @@ fn render(manifest: &Manifest, case: &Case) -> String {
         }
         Helper::SpanInline => html::span_inline(
             &case.text,
-            None,
+            Some(language(case)),
             &case.scope,
             case.theme.as_ref().map(|key| theme(manifest, key)).as_ref(),
             false,
@@ -99,7 +115,7 @@ fn render(manifest: &Manifest, case: &Case) -> String {
             html::span_multi_themes(
                 &case.text,
                 &case.scope,
-                None,
+                Some(language(case)),
                 &themes,
                 case.default_theme.as_deref(),
                 "--lumis",
@@ -137,6 +153,7 @@ fn covers_both_vectors_that_reach_an_attribute() {
         "multi-themes/theme-colour-closes-the-attribute",
         "line/caller-class-closes-the-attribute",
         "line/caller-style-closes-the-attribute",
+        "span/language-specialized-theme-colour",
     ] {
         assert!(
             names.contains(&required),

--- a/crates/lumis-core/tests/html_attr_escaping.rs
+++ b/crates/lumis-core/tests/html_attr_escaping.rs
@@ -1,0 +1,165 @@
+//! Rust's half of the HTML attribute escaping parity check.
+//!
+//! `fixtures/html-attr-escaping.json` holds one expected tag per case. This
+//! asserts Rust produces it;
+//! `packages/javascript/lumis/test/html-attr-escaping.test.ts` asserts the
+//! TypeScript port produces the same. Rust is the reference, so a difference is
+//! a bug in the port rather than something to record.
+
+use lumis_core::formatter::html;
+use lumis_core::themes::Theme;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    themes: HashMap<String, serde_json::Value>,
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Case {
+    name: String,
+    helper: Helper,
+    expected: String,
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    scope: String,
+    #[serde(default)]
+    theme: Option<String>,
+    #[serde(default)]
+    include_highlights: bool,
+    #[serde(default)]
+    themes: HashMap<String, String>,
+    #[serde(default)]
+    default_theme: Option<String>,
+    #[serde(default)]
+    pre_class: Option<String>,
+    #[serde(default)]
+    line_class: Option<String>,
+    #[serde(default)]
+    line_style: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum Helper {
+    PreTag,
+    SpanInline,
+    SpanMultiThemes,
+    Line,
+}
+
+fn manifest() -> Manifest {
+    let path =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/html-attr-escaping.json");
+    serde_json::from_str(&fs::read_to_string(&path).expect("read html-attr-escaping.json"))
+        .expect("parse html-attr-escaping.json")
+}
+
+fn theme(manifest: &Manifest, key: &str) -> Theme {
+    let source = manifest
+        .themes
+        .get(key)
+        .unwrap_or_else(|| panic!("`{key}` is not a fixture theme"));
+    lumis_core::themes::from_json(&source.to_string()).expect("fixture themes are well-formed")
+}
+
+fn render(manifest: &Manifest, case: &Case) -> String {
+    match case.helper {
+        Helper::PreTag => {
+            let mut output = Vec::new();
+            html::open_pre_tag(
+                &mut output,
+                case.pre_class.as_deref(),
+                case.theme.as_ref().map(|key| theme(manifest, key)).as_ref(),
+            )
+            .expect("write to a Vec cannot fail");
+            String::from_utf8(output).expect("valid UTF-8")
+        }
+        Helper::SpanInline => html::span_inline(
+            &case.text,
+            None,
+            &case.scope,
+            case.theme.as_ref().map(|key| theme(manifest, key)).as_ref(),
+            false,
+            case.include_highlights,
+        ),
+        Helper::SpanMultiThemes => {
+            let themes: HashMap<String, Theme> = case
+                .themes
+                .iter()
+                .map(|(name, key)| (name.clone(), theme(manifest, key)))
+                .collect();
+
+            html::span_multi_themes(
+                &case.text,
+                &case.scope,
+                None,
+                &themes,
+                case.default_theme.as_deref(),
+                "--lumis",
+                false,
+                case.include_highlights,
+            )
+        }
+        // The tag only: Rust takes the trailing newline in `content` and the
+        // TypeScript port appends it, so the two agree up to the `>`.
+        Helper::Line => html::wrap_line(
+            1,
+            "",
+            case.line_class
+                .as_ref()
+                .map(|class| format!(" {class}"))
+                .as_deref(),
+            case.line_style.as_deref(),
+        ),
+    }
+}
+
+#[test]
+fn covers_both_vectors_that_reach_an_attribute() {
+    let manifest = manifest();
+    let names: Vec<&str> = manifest
+        .cases
+        .iter()
+        .map(|case| case.name.as_str())
+        .collect();
+
+    for required in [
+        "pre/caller-class-closes-the-attribute",
+        "pre/theme-colour-closes-the-attribute",
+        "span/theme-colour-closes-the-attribute",
+        "multi-themes/theme-colour-closes-the-attribute",
+        "line/caller-class-closes-the-attribute",
+        "line/caller-style-closes-the-attribute",
+    ] {
+        assert!(
+            names.contains(&required),
+            "the corpus lost its `{required}` case"
+        );
+    }
+}
+
+#[test]
+fn escapes_every_attribute_value() {
+    let manifest = manifest();
+
+    for case in &manifest.cases {
+        let rendered = render(&manifest, case);
+
+        match case.helper {
+            Helper::Line => assert!(
+                rendered.starts_with(&case.expected),
+                "{}: expected the tag {:?}, got {rendered:?}",
+                case.name,
+                case.expected
+            ),
+            _ => assert_eq!(rendered, case.expected, "{}", case.name),
+        }
+    }
+}

--- a/crates/lumis/src/formatter/html.rs
+++ b/crates/lumis/src/formatter/html.rs
@@ -297,6 +297,24 @@ pub fn escape(text: &str) -> String {
     lumis_core::formatter::html::escape(text)
 }
 
+/// Escape a value for use inside a double-quoted HTML attribute.
+///
+/// The helpers in this module already escape every attribute they build, so this
+/// is for custom formatters that assemble their own tags. The escape set matches
+/// [`escape`].
+///
+/// # Example
+///
+/// ```rust
+/// use lumis::html;
+///
+/// assert_eq!(html::escape_attr(r#"x"><script>"#), "x&quot;&gt;&lt;script&gt;");
+/// assert_eq!(html::escape_attr("font-family: 'Fira Code'"), "font-family: &#39;Fira Code&#39;");
+/// ```
+pub fn escape_attr(value: &str) -> String {
+    lumis_core::formatter::html::escape_attr(value)
+}
+
 /// Escape braces for framework compatibility.
 ///
 /// Replaces `{` with `&lbrace;` and `}` with `&rbrace;`. This is useful

--- a/fixtures/html-attr-escaping.json
+++ b/fixtures/html-attr-escaping.json
@@ -1,0 +1,160 @@
+{
+  "$comment": [
+    "HTML attribute escaping, pinned between Rust and the TypeScript port.",
+    "",
+    "`crates/lumis-core/src/formatter/html.rs` and",
+    "`packages/javascript/lumis/src/formatter/html.ts` build the same tags. Rust",
+    "used to interpolate attribute values raw while JavaScript routed every one",
+    "through `escapeAttr`, so the same class or theme colour produced two",
+    "different documents (#1378). Rust is the reference; `expected` is one string",
+    "both runtimes must produce.",
+    "",
+    "Two values reach these helpers from outside the binary, and both are covered",
+    "here: a caller-supplied class or style (`pre_class`, `highlight_lines`), and",
+    "a theme, which is data loaded from JSON at run time.",
+    "",
+    "`helper` selects which tag a case builds:",
+    "  preTag           `<pre>` from `preClass` and `theme`",
+    "  spanInline       `<span>` from `text`, `scope`, `theme`, `includeHighlights`",
+    "  spanMultiThemes  `<span>` from `text`, `scope`, `themes`, `defaultTheme`",
+    "  line             the opening `<div>` of a line from `lineClass` and `lineStyle`",
+    "",
+    "`line` is the one case checked as a prefix rather than in full: Rust's",
+    "`wrap_line` takes the trailing newline in `content` and the TypeScript",
+    "`wrapLine` appends it, so the two agree on the tag but not on what follows it.",
+    "",
+    "`theme` and the values of `themes` name an entry in `themes` below rather",
+    "than repeating it, so a colour is written once."
+  ],
+  "themes": {
+    "evil": {
+      "name": "evil",
+      "appearance": "dark",
+      "revision": "fixture",
+      "highlights": {
+        "normal": { "fg": "red\" onmouseover=\"alert(1)", "bg": "#101010" },
+        "keyword": { "fg": "red\" onmouseover=\"alert(1)" }
+      }
+    },
+    "quoted-font": {
+      "name": "quoted-font",
+      "appearance": "light",
+      "revision": "fixture",
+      "highlights": {
+        "normal": { "fg": "#1f2328", "bg": "#ffffff" },
+        "keyword": { "fg": "#0550ae" }
+      }
+    }
+  },
+  "cases": [
+    {
+      "name": "pre/plain",
+      "helper": "preTag",
+      "expected": "<pre class=\"lumis\">"
+    },
+    {
+      "name": "pre/ordinary-theme-is-unchanged",
+      "helper": "preTag",
+      "preClass": "my-code",
+      "theme": "quoted-font",
+      "expected": "<pre class=\"lumis my-code\" style=\"color: #1f2328; background-color: #ffffff;\">"
+    },
+    {
+      "name": "pre/caller-class-closes-the-attribute",
+      "helper": "preTag",
+      "preClass": "x\"><script>",
+      "expected": "<pre class=\"lumis x&quot;&gt;&lt;script&gt;\">"
+    },
+    {
+      "name": "pre/caller-class-with-apostrophe",
+      "helper": "preTag",
+      "preClass": "it's-fine",
+      "expected": "<pre class=\"lumis it&#39;s-fine\">"
+    },
+    {
+      "name": "pre/theme-colour-closes-the-attribute",
+      "helper": "preTag",
+      "theme": "evil",
+      "expected": "<pre class=\"lumis\" style=\"color: red&quot; onmouseover=&quot;alert(1); background-color: #101010;\">"
+    },
+    {
+      "name": "span/no-theme-escapes-only-the-text",
+      "helper": "spanInline",
+      "text": "<b>&\"",
+      "scope": "keyword",
+      "expected": "<span>&lt;b&gt;&amp;&quot;</span>"
+    },
+    {
+      "name": "span/ordinary-theme-is-unchanged",
+      "helper": "spanInline",
+      "text": "fn",
+      "scope": "keyword",
+      "theme": "quoted-font",
+      "expected": "<span style=\"color: #0550ae;\">fn</span>"
+    },
+    {
+      "name": "span/theme-colour-closes-the-attribute",
+      "helper": "spanInline",
+      "text": "fn",
+      "scope": "keyword",
+      "theme": "evil",
+      "expected": "<span style=\"color: red&quot; onmouseover=&quot;alert(1);\">fn</span>"
+    },
+    {
+      "name": "span/theme-colour-with-data-highlight",
+      "helper": "spanInline",
+      "text": "fn",
+      "scope": "keyword",
+      "theme": "evil",
+      "includeHighlights": true,
+      "expected": "<span data-highlight=\"keyword\" style=\"color: red&quot; onmouseover=&quot;alert(1);\">fn</span>"
+    },
+    {
+      "name": "multi-themes/theme-colour-closes-the-attribute",
+      "helper": "spanMultiThemes",
+      "text": "fn",
+      "scope": "keyword",
+      "themes": { "evil": "evil" },
+      "expected": "<span style=\"--lumis-evil:red&quot; onmouseover=&quot;alert(1); --lumis-evil-font-style:normal; --lumis-evil-font-weight:normal; --lumis-evil-text-decoration:none;\">fn</span>"
+    },
+    {
+      "name": "multi-themes/named-default-theme-colour",
+      "helper": "spanMultiThemes",
+      "text": "fn",
+      "scope": "keyword",
+      "themes": { "evil": "evil" },
+      "defaultTheme": "evil",
+      "expected": "<span style=\"color:red&quot; onmouseover=&quot;alert(1); --lumis-evil-font-style:normal; --lumis-evil-font-weight:normal; --lumis-evil-text-decoration:none;\">fn</span>"
+    },
+    {
+      "name": "line/plain",
+      "helper": "line",
+      "expected": "<div class=\"l-line\" data-line=\"1\">"
+    },
+    {
+      "name": "line/ordinary-class-and-style-are-unchanged",
+      "helper": "line",
+      "lineClass": "highlighted",
+      "lineStyle": "background-color: #fffbdd;",
+      "expected": "<div class=\"l-line highlighted\" style=\"background-color: #fffbdd;\" data-line=\"1\">"
+    },
+    {
+      "name": "line/caller-class-closes-the-attribute",
+      "helper": "line",
+      "lineClass": "x\"><script>",
+      "expected": "<div class=\"l-line x&quot;&gt;&lt;script&gt;\" data-line=\"1\">"
+    },
+    {
+      "name": "line/caller-style-closes-the-attribute",
+      "helper": "line",
+      "lineStyle": "color: red\" onmouseover=\"alert(1)",
+      "expected": "<div class=\"l-line\" style=\"color: red&quot; onmouseover=&quot;alert(1)\" data-line=\"1\">"
+    },
+    {
+      "name": "line/quoted-font-family-survives",
+      "helper": "line",
+      "lineStyle": "font-family: 'Fira Code';",
+      "expected": "<div class=\"l-line\" style=\"font-family: &#39;Fira Code&#39;;\" data-line=\"1\">"
+    }
+  ]
+}

--- a/fixtures/html-attr-escaping.json
+++ b/fixtures/html-attr-escaping.json
@@ -59,7 +59,7 @@
       "highlights": {
         "normal": { "fg": "#c0c0c0", "bg": "#101010" },
         "keyword": { "fg": "red\" data-scope=\"generic" },
-        "keyword.rust": { "fg": "red\" data-scope=\"rust" }
+        "keyword.diff": { "fg": "red\" data-scope=\"diff" }
       }
     }
   },
@@ -131,9 +131,9 @@
       "helper": "spanInline",
       "text": "fn",
       "scope": "keyword",
-      "language": "rust",
+      "language": "diff",
       "theme": "specialized",
-      "expected": "<span style=\"color: red&quot; data-scope=&quot;rust;\">fn</span>"
+      "expected": "<span style=\"color: red&quot; data-scope=&quot;diff;\">fn</span>"
     },
     {
       "name": "span/language-falls-back-to-the-generic-scope",

--- a/fixtures/html-attr-escaping.json
+++ b/fixtures/html-attr-escaping.json
@@ -24,7 +24,14 @@
     "`wrapLine` appends it, so the two agree on the tag but not on what follows it.",
     "",
     "`theme` and the values of `themes` name an entry in `themes` below rather",
-    "than repeating it, so a colour is written once."
+    "than repeating it, so a colour is written once.",
+    "",
+    "`language` defaults to `plaintext` and is the same string on both sides, so",
+    "the specialized scope both runtimes look up first is the same one. Rust's",
+    "`language` argument is an `Option<Language>` and the port's is required, so",
+    "leaving it off here would have Rust resolve `keyword` while the port resolved",
+    "`keyword.plaintext`, and only a theme carrying the specialized scope would",
+    "show it."
   ],
   "themes": {
     "evil": {
@@ -43,6 +50,16 @@
       "highlights": {
         "normal": { "fg": "#1f2328", "bg": "#ffffff" },
         "keyword": { "fg": "#0550ae" }
+      }
+    },
+    "specialized": {
+      "name": "specialized",
+      "appearance": "dark",
+      "revision": "fixture",
+      "highlights": {
+        "normal": { "fg": "#c0c0c0", "bg": "#101010" },
+        "keyword": { "fg": "red\" data-scope=\"generic" },
+        "keyword.rust": { "fg": "red\" data-scope=\"rust" }
       }
     }
   },
@@ -108,6 +125,24 @@
       "theme": "evil",
       "includeHighlights": true,
       "expected": "<span data-highlight=\"keyword\" style=\"color: red&quot; onmouseover=&quot;alert(1);\">fn</span>"
+    },
+    {
+      "name": "span/language-specialized-theme-colour",
+      "helper": "spanInline",
+      "text": "fn",
+      "scope": "keyword",
+      "language": "rust",
+      "theme": "specialized",
+      "expected": "<span style=\"color: red&quot; data-scope=&quot;rust;\">fn</span>"
+    },
+    {
+      "name": "span/language-falls-back-to-the-generic-scope",
+      "helper": "spanInline",
+      "text": "fn",
+      "scope": "keyword",
+      "language": "plaintext",
+      "theme": "specialized",
+      "expected": "<span style=\"color: red&quot; data-scope=&quot;generic;\">fn</span>"
     },
     {
       "name": "multi-themes/theme-colour-closes-the-attribute",

--- a/packages/javascript/lumis/test/html-attr-escaping.test.ts
+++ b/packages/javascript/lumis/test/html-attr-escaping.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The TypeScript half of the HTML attribute escaping parity check.
+ *
+ * `fixtures/html-attr-escaping.json` holds one expected tag per case.
+ * `crates/lumis-core/tests/html_attr_escaping.rs` asserts Rust produces it;
+ * this asserts the port does too. Rust is the reference, so a difference here
+ * is a bug in this port.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { openPreTag, spanInline, spanMultiThemes, wrapLine } from "../src/formatter/html.js";
+import type { Theme } from "../src/types.js";
+
+type Helper = "preTag" | "spanInline" | "spanMultiThemes" | "line";
+
+interface Case {
+  name: string;
+  helper: Helper;
+  expected: string;
+  text?: string;
+  scope?: string;
+  theme?: string;
+  includeHighlights?: boolean;
+  themes?: Record<string, string>;
+  defaultTheme?: string;
+  preClass?: string;
+  lineClass?: string;
+  lineStyle?: string;
+}
+
+const manifest: { themes: Record<string, Theme>; cases: Case[] } = JSON.parse(
+  readFileSync(new URL("../../../../fixtures/html-attr-escaping.json", import.meta.url), "utf8"),
+);
+
+function theme(key: string): Theme {
+  const found = manifest.themes[key];
+  if (!found) throw new Error(`\`${key}\` is not a fixture theme`);
+  return found;
+}
+
+function themesOf(testCase: Case): Record<string, Theme> {
+  return Object.fromEntries(
+    Object.entries(testCase.themes ?? {}).map(([name, key]) => [name, theme(key)]),
+  );
+}
+
+function themeOf(testCase: Case): Theme | undefined {
+  return testCase.theme ? theme(testCase.theme) : undefined;
+}
+
+const RENDERERS: Record<Helper, (testCase: Case) => string> = {
+  preTag: (testCase) => openPreTag({ preClass: testCase.preClass, theme: themeOf(testCase) }),
+
+  spanInline: (testCase) =>
+    spanInline(testCase.text ?? "", {
+      language: "plaintext",
+      scope: testCase.scope ?? "",
+      theme: themeOf(testCase),
+      italic: false,
+      includeHighlights: testCase.includeHighlights ?? false,
+    }),
+
+  spanMultiThemes: (testCase) =>
+    spanMultiThemes(testCase.text ?? "", {
+      language: "plaintext",
+      scope: testCase.scope ?? "",
+      themes: themesOf(testCase),
+      defaultTheme: testCase.defaultTheme,
+      cssVariablePrefix: "--lumis",
+      italic: false,
+      includeHighlights: testCase.includeHighlights ?? false,
+    }),
+
+  // The tag only: Rust takes the trailing newline in `content` and this port
+  // appends it, so the two agree up to the `>`.
+  line: (testCase) => wrapLine(1, "", { className: testCase.lineClass, style: testCase.lineStyle }),
+};
+
+function render(testCase: Case): string {
+  return RENDERERS[testCase.helper](testCase);
+}
+
+describe("html attribute escaping parity", () => {
+  it("covers both vectors that reach an attribute", () => {
+    const names = manifest.cases.map((testCase) => testCase.name);
+
+    for (const required of [
+      "pre/caller-class-closes-the-attribute",
+      "pre/theme-colour-closes-the-attribute",
+      "span/theme-colour-closes-the-attribute",
+      "multi-themes/theme-colour-closes-the-attribute",
+      "line/caller-class-closes-the-attribute",
+      "line/caller-style-closes-the-attribute",
+    ]) {
+      expect(names, `the corpus lost its \`${required}\` case`).toContain(required);
+    }
+  });
+
+  it("produces the same tags as Rust", () => {
+    for (const testCase of manifest.cases) {
+      const rendered = render(testCase);
+
+      if (testCase.helper === "line") {
+        expect(rendered.startsWith(testCase.expected), `${testCase.name}: got ${rendered}`).toBe(
+          true,
+        );
+      } else {
+        expect(rendered, `${testCase.name}: diverged from Rust`).toBe(testCase.expected);
+      }
+    }
+  });
+});

--- a/packages/javascript/lumis/test/html-attr-escaping.test.ts
+++ b/packages/javascript/lumis/test/html-attr-escaping.test.ts
@@ -20,6 +20,12 @@ interface Case {
   expected: string;
   text?: string;
   scope?: string;
+  /**
+   * The same string Rust passes, so both resolve the same specialized scope.
+   * Rust's argument is optional and this port's is not, so leaving it to each
+   * side would have them look up different scopes.
+   */
+  language?: string;
   theme?: string;
   includeHighlights?: boolean;
   themes?: Record<string, string>;
@@ -54,7 +60,7 @@ const RENDERERS: Record<Helper, (testCase: Case) => string> = {
 
   spanInline: (testCase) =>
     spanInline(testCase.text ?? "", {
-      language: "plaintext",
+      language: testCase.language ?? "plaintext",
       scope: testCase.scope ?? "",
       theme: themeOf(testCase),
       italic: false,
@@ -63,7 +69,7 @@ const RENDERERS: Record<Helper, (testCase: Case) => string> = {
 
   spanMultiThemes: (testCase) =>
     spanMultiThemes(testCase.text ?? "", {
-      language: "plaintext",
+      language: testCase.language ?? "plaintext",
       scope: testCase.scope ?? "",
       themes: themesOf(testCase),
       defaultTheme: testCase.defaultTheme,
@@ -92,6 +98,7 @@ describe("html attribute escaping parity", () => {
       "multi-themes/theme-colour-closes-the-attribute",
       "line/caller-class-closes-the-attribute",
       "line/caller-style-closes-the-attribute",
+      "span/language-specialized-theme-colour",
     ]) {
       expect(names, `the corpus lost its \`${required}\` case`).toContain(required);
     }


### PR DESCRIPTION
Closes #1378.

`lumis_core::formatter::html` wrote attribute values straight into quoted attributes while JavaScript routed every one through `escapeAttr`. Same input, two answers:

```
JS           <pre class="lumis x&quot;&gt;&lt;script&gt;">
Rust/Elixir  <pre class="lumis x"><script>">
```

## What changed

`escape_attr` in `lumis_core::formatter::html`, delegating to the existing `escape`, which already covers the five characters `escapeAttr` covers. Every attribute the module builds now goes through it, so Rust, the CLI and Elixir get it from one change:

| Site | Value comes from |
| --- | --- |
| `open_pre_tag` | `pre_class` — caller; theme `normal` colours — theme |
| `open_multi_themes_pre_tag` | `pre_class` and theme names — caller; theme colours — theme |
| `wrap_line` | `class_suffix`, `style` — caller |
| `span_inline_attrs` | `Style::css` output — theme |
| `span_multi_themes_attrs` | `Style::css` output — theme |

`open_code_tag` and `span_linked_attrs` keep interpolating raw. They build from `Language::id_name()` and `HIGHLIGHT_NAMES`, which are generated constants, and `Language` is an enum, so nothing outside the binary reaches them. `:header` / `HtmlElement` is caller-authored markup by design and is untouched.

`escape_attr` is also re-exported from `lumis::html` for custom formatters that assemble their own tags.

## Tests

`fixtures/html-attr-escaping.json` holds 16 cases with one expected tag each, pinned by a half in each runtime — `crates/lumis-core/tests/html_attr_escaping.rs` and `packages/javascript/lumis/test/html-attr-escaping.test.ts` — following the `fixtures/annotation-composition.json` pattern. That is the part with no coverage today: it is what stops the two drifting apart again. Both vectors are covered, plus ordinary classes and themes so a regression to raw interpolation is not the only thing that fails.

Unit tests in `crates/lumis-core/src/formatter/html.rs` cover each site directly, including a theme loaded from JSON with `red" onmouseover="alert(1)` as a colour.

## Blast radius

Zero for anything committed, as the issue predicted: `mise run test-conformance-rust` passes byte for byte (180 cases), and no fixture uses a special character in a class or style. Escaping is safe for CSS in an attribute — the HTML parser decodes `&#39;` before the CSS parser sees it, so `font-family: 'Fira Code'` keeps working; there is a fixture case for it.

`cargo test -p lumis-core -p lumis -p lumis-cli`, `cargo clippy --all-targets`, `mise run lint-complexity-rust` and `mise run lint-js` are clean.