### PR TITLE
feat(elixir): ANSI formatter helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,34 @@ the line apart. Better still, check whether the `cd` is needed at all: `node
 packages/javascript/lumis/test.mjs` runs from the repo root, because Node
 resolves imports from the file rather than the working directory.
 
+### Public docs describe the runtime, not what is under it
+
+Rust being the reference implementation is a rule for contributors, not a fact
+users need. Someone reading `Lumis.Formatter.ANSI` cannot act on "this calls into
+Rust", cannot see the crate, and would not do anything differently if the answer
+were Zig. Every sentence of it is bloat in a place with a low budget for it.
+
+- **A public doc says what the function does and what to do with it.** Not what
+  it delegates to, not which crate owns the logic, not that a table crosses a
+  boundary once instead of per token. `styles/1` returns the whole table because
+  a reader is told to build it once and read it per token, which is a fact about
+  their loop; whether that is Rust, a `:persistent_term` or a literal is not.
+- **Name the behaviour, not the implementation, when explaining a difference.**
+  "`Map.get(theme.highlights, scope)` misses the fallbacks `:terminal` applies"
+  is actionable. "Scope resolution belongs in Rust" is trivia that happens to
+  sit where the actionable sentence should have been.
+- **The Rust origin belongs where a contributor reads it**: this file, the
+  binding crate's own doc comments, a commit message. `html_span_attrs` in
+  `lumis_nif` explains the call-frequency split at length, correctly — that is a
+  contributor's file.
+- **Cross-runtime pointers are not this.** "The counterpart of `Language::guess`
+  in Rust and `guessLanguage()` in JavaScript" helps someone moving between the
+  packages Lumis publishes, and stays.
+
+This applies to every published surface: package docs, READMEs, `usage-rules.md`,
+and `docs/content/`. It came out of an ANSI helper module whose moduledoc opened
+by explaining that its functions call Rust, before saying what any of them did.
+
 ### READMEs stay small, detail lives in the docs site
 
 READMEs are entry points, not manuals. Keep them small, direct, and targeted: the minimal usage to get started, then a link to the relevant page under `docs/content/`.

--- a/crates/lumis-core/src/formatter/ansi.rs
+++ b/crates/lumis-core/src/formatter/ansi.rs
@@ -16,9 +16,9 @@ pub fn hex_to_rgb(hex: &str) -> Option<(u8, u8, u8)> {
         return None;
     }
 
-    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    let r = u8::from_str_radix(hex.get(0..2)?, 16).ok()?;
+    let g = u8::from_str_radix(hex.get(2..4)?, 16).ok()?;
+    let b = u8::from_str_radix(hex.get(4..6)?, 16).ok()?;
 
     Some((r, g, b))
 }
@@ -124,6 +124,7 @@ mod tests {
     fn test_hex_to_rgb_invalid() {
         assert_eq!(hex_to_rgb("invalid"), None);
         assert_eq!(hex_to_rgb("#fff"), None);
+        assert_eq!(hex_to_rgb("aéaaa"), None);
         assert_eq!(hex_to_rgb(""), None);
     }
 

--- a/crates/lumis/src/formatter/ansi.rs
+++ b/crates/lumis/src/formatter/ansi.rs
@@ -26,13 +26,13 @@
 
 use crate::highlight::{highlight_iter, HighlightError, Style};
 use crate::languages::Language;
-use crate::themes::{Theme, UnderlineStyle};
+use crate::themes::Theme;
 use std::ops::Range;
 
 /// ANSI reset sequence to clear all formatting.
 ///
 /// Use this to reset terminal colors and styles back to default.
-pub const ANSI_RESET: &str = "\u{1b}[0m";
+pub const ANSI_RESET: &str = lumis_core::formatter::ansi::ANSI_RESET;
 
 /// Convert a hex color string to RGB tuple.
 ///
@@ -54,17 +54,7 @@ pub const ANSI_RESET: &str = "\u{1b}[0m";
 /// assert_eq!(hex_to_rgb("invalid"), None);
 /// ```
 pub fn hex_to_rgb(hex: &str) -> Option<(u8, u8, u8)> {
-    let hex = hex.trim_start_matches('#');
-
-    if hex.len() != 6 {
-        return None;
-    }
-
-    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
-    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
-    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
-
-    Some((r, g, b))
+    lumis_core::formatter::ansi::hex_to_rgb(hex)
 }
 
 /// Generate ANSI color escape sequence from RGB values.
@@ -90,11 +80,7 @@ pub fn hex_to_rgb(hex: &str) -> Option<(u8, u8, u8)> {
 /// assert_eq!(bg, "\u{1b}[48;2;40;42;54m");
 /// ```
 pub fn rgb_to_ansi(r: u8, g: u8, b: u8, is_background: bool) -> String {
-    if is_background {
-        format!("\u{1b}[48;2;{r};{g};{b}m")
-    } else {
-        format!("\u{1b}[38;2;{r};{g};{b}m")
-    }
+    lumis_core::formatter::ansi::rgb_to_ansi(r, g, b, is_background)
 }
 
 /// Convert a Style to ANSI escape sequences.
@@ -126,42 +112,7 @@ pub fn rgb_to_ansi(r: u8, g: u8, b: u8, is_background: bool) -> String {
 /// let ansi = style_to_ansi(&style);
 /// ```
 pub fn style_to_ansi(style: &Style) -> String {
-    let mut result = String::new();
-
-    if let Some(fg) = &style.fg {
-        if let Some((r, g, b)) = hex_to_rgb(fg) {
-            result.push_str(&rgb_to_ansi(r, g, b, false));
-        }
-    }
-
-    if let Some(bg) = &style.bg {
-        if let Some((r, g, b)) = hex_to_rgb(bg) {
-            result.push_str(&rgb_to_ansi(r, g, b, true));
-        }
-    }
-
-    if style.bold {
-        result.push_str("\u{1b}[1m");
-    }
-
-    if style.italic {
-        result.push_str("\u{1b}[3m");
-    }
-
-    match style.text_decoration.underline {
-        UnderlineStyle::None => {}
-        UnderlineStyle::Solid => result.push_str("\u{1b}[4m"),
-        UnderlineStyle::Wavy => result.push_str("\u{1b}[4:3m"),
-        UnderlineStyle::Double => result.push_str("\u{1b}[4:2m"),
-        UnderlineStyle::Dotted => result.push_str("\u{1b}[4:4m"),
-        UnderlineStyle::Dashed => result.push_str("\u{1b}[4:5m"),
-    }
-
-    if style.text_decoration.strikethrough {
-        result.push_str("\u{1b}[9m");
-    }
-
-    result
+    lumis_core::formatter::ansi::style_to_ansi(style)
 }
 
 /// Render text with ANSI color codes based on a Style.
@@ -303,6 +254,7 @@ mod tests {
     fn test_hex_to_rgb_invalid() {
         assert_eq!(hex_to_rgb("invalid"), None);
         assert_eq!(hex_to_rgb("#fff"), None);
+        assert_eq!(hex_to_rgb("aéaaa"), None);
         assert_eq!(hex_to_rgb(""), None);
         assert_eq!(hex_to_rgb("#gggggg"), None);
     }

--- a/docs/content/usage/custom-formatters.mdx
+++ b/docs/content/usage/custom-formatters.mdx
@@ -147,9 +147,9 @@ Implement the [`Lumis.Formatter`](https://hexdocs.pm/lumis/Lumis.Formatter.html)
 behaviour and pass the module as the formatter. Lumis highlights the source and
 hands `render/3` the event stream, with the resolved language in `options`.
 
-[`Lumis.Formatter.HTML`](https://hexdocs.pm/lumis/Lumis.Formatter.HTML.html) has
-the same pieces `lumis::formatters::html` and `@lumis-sh/lumis/formatters/html`
-do.
+[`Lumis.Formatter.HTML`](https://hexdocs.pm/lumis/Lumis.Formatter.HTML.html) and
+[`Lumis.Formatter.ANSI`](https://hexdocs.pm/lumis/Lumis.Formatter.ANSI.html) have
+the same HTML and terminal pieces the built-in formatters use.
 
 ```elixir
 defmodule MinimalHtmlFormatter do
@@ -284,6 +284,7 @@ name JavaScript's event carries directly.
 | Rust | `lumis::formatters::html` | [docs.rs](https://docs.rs/lumis/latest/lumis/formatters/html/index.html) |
 | Rust | `lumis::formatters::ansi` | [docs.rs](https://docs.rs/lumis/latest/lumis/formatters/ansi/index.html) |
 | Elixir | `Lumis.Formatter.HTML` | [hexdocs](https://hexdocs.pm/lumis/Lumis.Formatter.HTML.html) |
+| Elixir | `Lumis.Formatter.ANSI` | [hexdocs](https://hexdocs.pm/lumis/Lumis.Formatter.ANSI.html) |
 
 ## Tip
 

--- a/docs/content/usage/custom-formatters.mdx
+++ b/docs/content/usage/custom-formatters.mdx
@@ -200,6 +200,66 @@ Lumis.highlight!("defmodule App do\nend",
 `render/3` returns iodata, so there is no need to flatten it into a binary;
 Lumis does that once at the end.
 
+`Lumis.Formatter.ANSI` is the terminal counterpart. `styles/1` is where a scope
+becomes a color, and it belongs in Rust rather than in a `theme.highlights`
+lookup: a scope falls back to its parent, so `tag.delimiter` is painted by `tag`
+in a theme that styles only `tag`. A theme can also style a scope per language,
+and an injected block carries its own language, so the table is per language.
+
+```elixir
+defmodule MinimalTerminalFormatter do
+  @behaviour Lumis.Formatter
+
+  alias Lumis.Formatter.ANSI
+
+  @impl true
+  def render(source, events, options) do
+    theme = Keyword.get(options, :theme)
+
+    {output, _scopes, _tables} =
+      Enum.reduce(events, {[], [], %{}}, fn
+        {:start, %{scope: scope, language: language}}, {output, scopes, tables} ->
+          {output, [{scope, language} | scopes], tables}
+
+        :end, {output, [_scope | scopes], tables} ->
+          {output, scopes, tables}
+
+        {:source, %{start: start, end: stop}}, {output, scopes, tables} ->
+          text = binary_part(source, start, stop - start)
+
+          case scopes do
+            [] ->
+              {[text | output], scopes, tables}
+
+            [{scope, language} | _rest] ->
+              # One table per language, built once and read per token.
+              tables =
+                Map.put_new_lazy(tables, language, fn ->
+                  ANSI.styles(theme: theme, language: language)
+                end)
+
+              painted = ANSI.paint(text, ANSI.style_for(tables[language], scope))
+              {[painted | output], scopes, tables}
+          end
+
+        # Lumis adds event kinds as it grows. Render the ones you know and skip
+        # the rest, or a newer Lumis raises FunctionClauseError here.
+        _event, state ->
+          state
+      end)
+
+    Enum.reverse(output)
+  end
+end
+
+Lumis.highlight!("defmodule App do\nend",
+  formatter: {MinimalTerminalFormatter, language: "elixir", theme: "dracula"}
+)
+```
+
+`ANSI.paint/2` takes the `nil` that `style_for/2` returns for an unstyled scope
+and hands the text back unchanged, so there is no branch to write for it.
+
 ## Highlight options
 
 The built-in formatters take options that change which scopes highlighting

--- a/docs/content/usage/custom-formatters.mdx
+++ b/docs/content/usage/custom-formatters.mdx
@@ -200,11 +200,11 @@ Lumis.highlight!("defmodule App do\nend",
 `render/3` returns iodata, so there is no need to flatten it into a binary;
 Lumis does that once at the end.
 
-`Lumis.Formatter.ANSI` is the terminal counterpart. `styles/1` is where a scope
-becomes a color, and it belongs in Rust rather than in a `theme.highlights`
-lookup: a scope falls back to its parent, so `tag.delimiter` is painted by `tag`
-in a theme that styles only `tag`. A theme can also style a scope per language,
-and an injected block carries its own language, so the table is per language.
+`Lumis.Formatter.ANSI` is the terminal counterpart, and `styles/1` is where a
+scope becomes a color. Reach for it rather than `theme.highlights`, which misses
+the fallbacks `:terminal` applies: `tag.delimiter` is painted by `tag` in a theme
+that styles only `tag`. A theme can also style a scope per language, and an
+injected block carries its own language, so the table is per language.
 
 ```elixir
 defmodule MinimalTerminalFormatter do

--- a/packages/elixir/lumis/README.md
+++ b/packages/elixir/lumis/README.md
@@ -59,9 +59,9 @@ shebang. The theme is optional too, but there is no default: without one,
 Formatters decide the output: `:html_inline`, `:html_linked`,
 `:html_multi_themes`, `:terminal`, `:bbcode_scoped`, or your own.
 
-For your own, implement `Lumis.Formatter` and build the markup with
-`Lumis.Formatter.HTML`, which holds the same pieces the built-in HTML formatters
-are assembled from. See [custom formatters](https://lumis.sh/docs/formatters/custom).
+For your own, implement `Lumis.Formatter` and build the output with
+`Lumis.Formatter.HTML` or `Lumis.Formatter.ANSI`, which hold the same pieces the
+built-in formatters use. See [custom formatters](https://lumis.sh/docs/formatters/custom).
 
 ## Parsers
 

--- a/packages/elixir/lumis/lib/lumis/formatter/ansi.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter/ansi.ex
@@ -1,0 +1,62 @@
+defmodule Lumis.Formatter.ANSI do
+  @moduledoc """
+  The ANSI pieces the built-in `:terminal` formatter is assembled from.
+
+  A module implementing `Lumis.Formatter` gets an event stream and has to turn
+  it into output; these helpers apply the same colors, text decorations, and
+  reset behavior as the built-in formatter.
+  """
+
+  alias Lumis.Native
+  alias Lumis.Theme.Style
+
+  @doc """
+  Converts a six-digit hex color to an RGB tuple.
+
+  A leading `#` is optional. Returns `nil` when the color is not six hexadecimal
+  digits.
+
+      iex> Lumis.Formatter.ANSI.hex_to_rgb("#ff79c6")
+      {255, 121, 198}
+
+      iex> Lumis.Formatter.ANSI.hex_to_rgb("fff")
+      nil
+
+  """
+  @spec hex_to_rgb(String.t()) :: {0..255, 0..255, 0..255} | nil
+  def hex_to_rgb(hex) when is_binary(hex), do: Native.ansi_hex_to_rgb(hex)
+
+  @doc """
+  Builds a 24-bit ANSI color escape sequence from RGB components.
+
+  Set `is_background` to `true` for a background color and `false` for a
+  foreground color.
+  """
+  @spec rgb_to_ansi(0..255, 0..255, 0..255, boolean()) :: String.t()
+  def rgb_to_ansi(r, g, b, is_background)
+      when r in 0..255 and g in 0..255 and b in 0..255 and is_boolean(is_background) do
+    Native.ansi_rgb_to_ansi(r, g, b, is_background)
+  end
+
+  @doc """
+  Converts a `Lumis.Theme.Style` to ANSI escape sequences.
+
+  Covers foreground and background colors, bold, italic, strikethrough, and
+  every underline style supported by `Lumis.Theme.TextDecoration`.
+  """
+  @spec style_to_ansi(Style.t()) :: String.t()
+  def style_to_ansi(%Style{} = style), do: Native.ansi_style_to_ansi(style)
+
+  @doc """
+  Paints `text` with a `Lumis.Theme.Style`.
+
+  The result uses the same reset and newline handling as the built-in
+  `:terminal` formatter. Text with an empty style is returned unchanged.
+  """
+  @spec paint(String.t(), Style.t()) :: String.t()
+  def paint(text, %Style{} = style) when is_binary(text), do: Native.ansi_paint(text, style)
+
+  @doc "Returns the ANSI sequence that clears all formatting."
+  @spec reset() :: String.t()
+  def reset, do: Native.ansi_reset()
+end

--- a/packages/elixir/lumis/lib/lumis/formatter/ansi.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter/ansi.ex
@@ -6,12 +6,6 @@ defmodule Lumis.Formatter.ANSI do
   it into output; these helpers apply the same colors, text decorations, and
   reset behavior as the built-in formatter.
 
-  Every function here calls into the same Rust the built-in `:terminal`
-  formatter uses, including `styles/1`, which resolves a scope against a theme.
-  Resolution is not a map lookup — a scope falls back to its parent, and
-  rainbow-bracket scopes fall back to a table Lumis owns — so a formatter that
-  reads `theme.highlights` itself paints differently than `:terminal` does.
-
   ## Example
 
       defmodule MyTerminalFormatter do
@@ -106,15 +100,16 @@ defmodule Lumis.Formatter.ANSI do
   def style_to_ansi(%Style{} = style), do: Native.ansi_style_to_ansi(style)
 
   @doc """
-  Every scope's style for one theme and language, resolved as `:terminal` resolves it.
+  Every scope's style for one theme and language.
 
-  Resolving a scope is a per-token operation and this is the whole table, so
-  build it once outside the loop and read it inside with `style_for/2`. A scope
-  the theme styles in no way is absent from the table.
+  Resolving a scope is a per-token operation, so this is the whole table: build
+  it once outside the loop and read it inside with `style_for/2`. A scope the
+  theme styles in no way is absent from it.
 
-  A theme can style a scope per language, and an injected block carries its own
-  language on its `:start` event, so a document with injections needs one table
-  per language rather than one for the whole document.
+  A scope resolves the way `:terminal` resolves it, which is not a lookup in
+  `theme.highlights` — `tag.delimiter` falls back to `tag`, and a theme can
+  style a scope per language. An injected block carries its own language on its
+  `:start` event, so a document with injections needs one table per language.
 
   ## Options
 

--- a/packages/elixir/lumis/lib/lumis/formatter/ansi.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter/ansi.ex
@@ -5,9 +5,67 @@ defmodule Lumis.Formatter.ANSI do
   A module implementing `Lumis.Formatter` gets an event stream and has to turn
   it into output; these helpers apply the same colors, text decorations, and
   reset behavior as the built-in formatter.
+
+  Every function here calls into the same Rust the built-in `:terminal`
+  formatter uses, including `styles/1`, which resolves a scope against a theme.
+  Resolution is not a map lookup — a scope falls back to its parent, and
+  rainbow-bracket scopes fall back to a table Lumis owns — so a formatter that
+  reads `theme.highlights` itself paints differently than `:terminal` does.
+
+  ## Example
+
+      defmodule MyTerminalFormatter do
+        @behaviour Lumis.Formatter
+
+        alias Lumis.Formatter.ANSI
+
+        @impl true
+        def render(source, events, options) do
+          theme = Keyword.get(options, :theme)
+
+          {output, _scopes, _tables} =
+            Enum.reduce(events, {[], [], %{}}, fn
+              {:start, %{scope: scope, language: language}}, {output, scopes, tables} ->
+                {output, [{scope, language} | scopes], tables}
+
+              :end, {output, [_scope | scopes], tables} ->
+                {output, scopes, tables}
+
+              {:source, %{start: start, end: stop}}, {output, scopes, tables} ->
+                text = binary_part(source, start, stop - start)
+
+                case scopes do
+                  [] ->
+                    {[text | output], scopes, tables}
+
+                  [{scope, language} | _rest] ->
+                    # One table per language, built once and read per token.
+                    tables =
+                      Map.put_new_lazy(tables, language, fn ->
+                        ANSI.styles(theme: theme, language: language)
+                      end)
+
+                    painted = ANSI.paint(text, ANSI.style_for(tables[language], scope))
+                    {[painted | output], scopes, tables}
+                end
+
+              # Lumis adds event kinds as it grows. Render the ones you know and
+              # skip the rest, or a newer Lumis raises FunctionClauseError here.
+              _event, state ->
+                state
+            end)
+
+          Enum.reverse(output)
+        end
+      end
+
+      Lumis.highlight!("defmodule App do\\nend",
+        formatter: {MyTerminalFormatter, language: "elixir", theme: "dracula"}
+      )
   """
 
   alias Lumis.Native
+  alias Lumis.Theme
   alias Lumis.Theme.Style
 
   @doc """
@@ -48,15 +106,58 @@ defmodule Lumis.Formatter.ANSI do
   def style_to_ansi(%Style{} = style), do: Native.ansi_style_to_ansi(style)
 
   @doc """
+  Every scope's style for one theme and language, resolved as `:terminal` resolves it.
+
+  Resolving a scope is a per-token operation and this is the whole table, so
+  build it once outside the loop and read it inside with `style_for/2`. A scope
+  the theme styles in no way is absent from the table.
+
+  A theme can style a scope per language, and an injected block carries its own
+  language on its `:start` event, so a document with injections needs one table
+  per language rather than one for the whole document.
+
+  ## Options
+
+    * `:theme` (`t:Lumis.Theme.t/0` or a theme name) — the theme to resolve
+      against. Without one the table is empty, which paints nothing.
+    * `:language` — the language whose specialized scopes to prefer, e.g.
+      `comment.elixir` over `comment`. Defaults to `"plaintext"`.
+
+  """
+  @spec styles(keyword()) :: %{String.t() => Style.t()}
+  def styles(options \\ []) when is_list(options) do
+    Native.ansi_styles(
+      resolve_theme(Keyword.get(options, :theme)),
+      Keyword.get(options, :language) || "plaintext"
+    )
+  end
+
+  @doc """
+  A scope's style, read out of a `styles/1` table.
+
+  Returns `nil` for a scope the theme styles in no way, which `paint/2` renders
+  unchanged.
+  """
+  @spec style_for(%{String.t() => Style.t()}, String.t() | nil) :: Style.t() | nil
+  def style_for(_styles, nil), do: nil
+  def style_for(styles, scope) when is_binary(scope), do: Map.get(styles, scope)
+
+  @doc """
   Paints `text` with a `Lumis.Theme.Style`.
 
   The result uses the same reset and newline handling as the built-in
-  `:terminal` formatter. Text with an empty style is returned unchanged.
+  `:terminal` formatter. Text with an empty style, or with the `nil` that
+  `style_for/2` returns for an unstyled scope, is returned unchanged.
   """
-  @spec paint(String.t(), Style.t()) :: String.t()
+  @spec paint(String.t(), Style.t() | nil) :: String.t()
+  def paint(text, nil) when is_binary(text), do: text
   def paint(text, %Style{} = style) when is_binary(text), do: Native.ansi_paint(text, style)
 
   @doc "Returns the ANSI sequence that clears all formatting."
   @spec reset() :: String.t()
   def reset, do: Native.ansi_reset()
+
+  defp resolve_theme(nil), do: nil
+  defp resolve_theme(%Theme{} = theme), do: theme
+  defp resolve_theme(name) when is_binary(name), do: Theme.get(name)
 end

--- a/packages/elixir/lumis/lib/lumis/native.ex
+++ b/packages/elixir/lumis/lib/lumis/native.ex
@@ -79,6 +79,12 @@ defmodule Lumis.Native do
   def highlight(_source, _options), do: :erlang.nif_error(:nif_not_loaded)
   def highlight_events(_source, _options), do: :erlang.nif_error(:nif_not_loaded)
 
+  def ansi_hex_to_rgb(_hex), do: :erlang.nif_error(:nif_not_loaded)
+  def ansi_rgb_to_ansi(_r, _g, _b, _is_background), do: :erlang.nif_error(:nif_not_loaded)
+  def ansi_style_to_ansi(_style), do: :erlang.nif_error(:nif_not_loaded)
+  def ansi_paint(_text, _style), do: :erlang.nif_error(:nif_not_loaded)
+  def ansi_reset, do: :erlang.nif_error(:nif_not_loaded)
+
   def html_escape(_text), do: :erlang.nif_error(:nif_not_loaded)
   def html_escape_braces(_text), do: :erlang.nif_error(:nif_not_loaded)
   def html_classes, do: :erlang.nif_error(:nif_not_loaded)

--- a/packages/elixir/lumis/lib/lumis/native.ex
+++ b/packages/elixir/lumis/lib/lumis/native.ex
@@ -84,6 +84,7 @@ defmodule Lumis.Native do
   def ansi_style_to_ansi(_style), do: :erlang.nif_error(:nif_not_loaded)
   def ansi_paint(_text, _style), do: :erlang.nif_error(:nif_not_loaded)
   def ansi_reset, do: :erlang.nif_error(:nif_not_loaded)
+  def ansi_styles(_theme, _language), do: :erlang.nif_error(:nif_not_loaded)
 
   def html_escape(_text), do: :erlang.nif_error(:nif_not_loaded)
   def html_escape_braces(_text), do: :erlang.nif_error(:nif_not_loaded)

--- a/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
@@ -267,18 +267,7 @@ impl From<ExTheme> for themes::Theme {
             highlights: theme
                 .highlights
                 .into_iter()
-                .map(|(k, v)| {
-                    (
-                        k,
-                        themes::Style {
-                            fg: v.fg,
-                            bg: v.bg,
-                            bold: v.bold,
-                            italic: v.italic,
-                            text_decoration: v.text_decoration.into(),
-                        },
-                    )
-                })
+                .map(|(name, style)| (name, style.into()))
                 .collect(),
         }
     }
@@ -399,6 +388,18 @@ pub struct ExStyle {
     pub bold: bool,
     pub italic: bool,
     pub text_decoration: ExTextDecoration,
+}
+
+impl From<ExStyle> for themes::Style {
+    fn from(style: ExStyle) -> Self {
+        themes::Style {
+            fg: style.fg,
+            bg: style.bg,
+            bold: style.bold,
+            italic: style.italic,
+            text_decoration: style.text_decoration.into(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, NifStruct)]

--- a/packages/elixir/lumis/native/lumis_nif/src/lib.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/lib.rs
@@ -775,6 +775,34 @@ fn ansi_reset() -> &'static str {
     lumis_core::formatter::ansi::ANSI_RESET
 }
 
+/// Every scope's style for one theme and language, resolved the way the
+/// built-in terminal formatter resolves it.
+///
+/// The per-token counterpart of the rest of these, split for the same reason as
+/// [`html_span_attrs`]. `Theme::get_style` walks a scope up to its parent and
+/// consults the rainbow-bracket fallbacks, so an Elixir formatter that looks a
+/// scope up in `theme.highlights` itself gets a different answer than
+/// `:terminal` does. There are only ever 293 answers, so all of them come back
+/// at once and Elixir never resolves anything.
+#[rustler::nif]
+fn ansi_styles(theme: Option<ExTheme>, language: &str) -> HashMap<&'static str, ExStyle> {
+    let Some(theme) = theme.map(themes::Theme::from) else {
+        return HashMap::new();
+    };
+    let language = Language::guess(Some(language), "");
+
+    lumis_core::highlights::HIGHLIGHT_NAMES
+        .iter()
+        .filter_map(|scope| {
+            let specialized = format!("{scope}.{}", language.id_name());
+            let style = theme
+                .get_style(&specialized)
+                .or_else(|| theme.get_style(scope))?;
+            Some((*scope, ExStyle::from(style)))
+        })
+        .collect()
+}
+
 /// `lumis_core::formatter::html`, reachable from Elixir.
 ///
 /// A formatter written in Elixir needs the same pieces the built-in HTML

--- a/packages/elixir/lumis/native/lumis_nif/src/lib.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/lib.rs
@@ -7,7 +7,7 @@ use std::thread;
 mod elixir;
 
 use anyhow::{anyhow, Context, Result};
-use elixir::{ExCssOptions, ExFormatterOption, ExTheme};
+use elixir::{ExCssOptions, ExFormatterOption, ExStyle, ExTheme};
 use lumis_core::annotations::{compose_annotations, Annotation, AnnotationRange, Position};
 use lumis_core::events::HighlightEvent;
 use lumis_core::formatter::Formatter;
@@ -748,6 +748,31 @@ fn build_theme_css(theme: &themes::Theme, options: ExCssOptions) -> String {
     builder.container_style(options.container_style);
 
     builder.build()
+}
+
+#[rustler::nif]
+fn ansi_hex_to_rgb(hex: &str) -> Option<(u8, u8, u8)> {
+    lumis_core::formatter::ansi::hex_to_rgb(hex)
+}
+
+#[rustler::nif]
+fn ansi_rgb_to_ansi(r: u8, g: u8, b: u8, is_background: bool) -> String {
+    lumis_core::formatter::ansi::rgb_to_ansi(r, g, b, is_background)
+}
+
+#[rustler::nif]
+fn ansi_style_to_ansi(style: ExStyle) -> String {
+    lumis_core::formatter::ansi::style_to_ansi(&style.into())
+}
+
+#[rustler::nif]
+fn ansi_paint(text: &str, style: ExStyle) -> String {
+    lumis_core::formatter::ansi::paint(text, &style.into())
+}
+
+#[rustler::nif]
+fn ansi_reset() -> &'static str {
+    lumis_core::formatter::ansi::ANSI_RESET
 }
 
 /// `lumis_core::formatter::html`, reachable from Elixir.

--- a/packages/elixir/lumis/test/lumis/formatter/ansi_test.exs
+++ b/packages/elixir/lumis/test/lumis/formatter/ansi_test.exs
@@ -31,17 +31,18 @@ defmodule Lumis.Formatter.ANSITest do
     def render(source, events, options) do
       theme = Keyword.fetch!(options, :theme)
 
-      {parts, _scopes} =
-        Enum.reduce(events, {[], []}, fn
-          {:start, %{scope: scope, language: language}}, {parts, scopes} ->
-            {parts, [{scope, language} | scopes]}
+      {parts, _scopes, _tables} =
+        Enum.reduce(events, {[], [], %{}}, fn
+          {:start, %{scope: scope, language: language}}, {parts, scopes, tables} ->
+            {parts, [{scope, language} | scopes], tables}
 
-          :end, {parts, [_scope | scopes]} ->
-            {parts, scopes}
+          :end, {parts, [_scope | scopes], tables} ->
+            {parts, scopes, tables}
 
-          {:source, %{start: start, end: stop}}, {parts, scopes} ->
+          {:source, %{start: start, end: stop}}, {parts, scopes, tables} ->
             text = binary_part(source, start, stop - start)
-            {[paint(text, scopes, theme) | parts], scopes}
+            {painted, tables} = paint(text, scopes, theme, tables)
+            {[painted | parts], scopes, tables}
 
           _event, state ->
             state
@@ -50,18 +51,31 @@ defmodule Lumis.Formatter.ANSITest do
       parts |> Enum.reverse() |> IO.iodata_to_binary()
     end
 
-    defp paint(text, [], _theme), do: text
+    defp paint(text, [], _theme, tables), do: {text, tables}
 
-    defp paint(text, [{scope, language} | _scopes], theme) do
-      style =
-        Map.get(theme.highlights, "#{scope}.#{language}") || Map.get(theme.highlights, scope)
+    defp paint(text, [{scope, language} | _scopes], theme, tables) do
+      tables =
+        Map.put_new_lazy(tables, language, fn ->
+          ANSI.styles(theme: theme, language: language)
+        end)
 
-      if style, do: ANSI.paint(text, style), else: text
+      {ANSI.paint(text, ANSI.style_for(tables[language], scope)), tables}
     end
   end
 
+  # A theme, a language, and source whose scopes that theme does not style
+  # directly, so resolution has to fall back the way `:terminal` falls back.
+  @terminal_parity_cases [
+    {"elixir", "dracula", @source},
+    {"html", "github_light", ~s|<div class="a">t</div>\n|},
+    {"markdown", "catppuccin_frappe", "# T\n\n> q\n\n```elixir\ndef run, do: :ok\n```\n"}
+  ]
+
   setup_all do
-    :ok = Lumis.Languages.load("elixir")
+    for {language, _theme, _source} <- @terminal_parity_cases do
+      :ok = Lumis.Languages.load(language)
+    end
+
     :ok
   end
 
@@ -128,7 +142,56 @@ defmodule Lumis.Formatter.ANSITest do
 
   test "paint/2 leaves text unchanged for an empty style" do
     assert ANSI.paint("plain text", %Style{}) == "plain text"
+    assert ANSI.paint("plain text", nil) == "plain text"
     assert ANSI.style_to_ansi(%Style{}) == ""
+  end
+
+  test "styles/1 resolves a scope to its parent, which theme.highlights alone does not" do
+    theme = Theme.get("github_light")
+    styles = ANSI.styles(theme: theme, language: "html")
+
+    assert Map.get(theme.highlights, "tag.delimiter") == nil
+    assert Map.get(theme.highlights, "tag") != nil
+    assert ANSI.style_for(styles, "tag.delimiter") == Map.get(theme.highlights, "tag")
+  end
+
+  test "styles/1 prefers a language's specialized scope" do
+    style = %Style{fg: "#ff79c6"}
+    specialized = %Style{fg: "#282a36"}
+
+    theme = %Theme{
+      theme_for(["comment"], style)
+      | highlights: %{"comment" => style, "comment.elixir" => specialized}
+    }
+
+    assert ANSI.style_for(ANSI.styles(theme: theme, language: "elixir"), "comment") == specialized
+    assert ANSI.style_for(ANSI.styles(theme: theme, language: "rust"), "comment") == style
+  end
+
+  test "styles/1 without a theme paints nothing" do
+    styles = ANSI.styles(language: "elixir")
+
+    assert styles == %{}
+    assert ANSI.style_for(styles, "keyword") == nil
+    assert ANSI.style_for(styles, nil) == nil
+    assert ANSI.paint("def", ANSI.style_for(styles, "keyword")) == "def"
+  end
+
+  test "styles/1 accepts a theme name" do
+    assert ANSI.styles(theme: "dracula", language: "elixir") ==
+             ANSI.styles(theme: Theme.get("dracula"), language: "elixir")
+  end
+
+  test "a formatter built on styles/1 reproduces :terminal for real themes" do
+    for {language, theme_name, source} <- @terminal_parity_cases do
+      theme = Theme.get(theme_name)
+
+      helper_output =
+        Lumis.highlight!(source, formatter: {HelperFormatter, language: language, theme: theme})
+
+      assert helper_output == terminal_output(source, theme, language),
+             "#{language} highlighted with #{theme_name} diverges from the :terminal formatter"
+    end
   end
 
   defp events(source, language) do

--- a/packages/elixir/lumis/test/lumis/formatter/ansi_test.exs
+++ b/packages/elixir/lumis/test/lumis/formatter/ansi_test.exs
@@ -1,0 +1,156 @@
+defmodule Lumis.Formatter.ANSITest do
+  use ExUnit.Case, async: true
+
+  alias Lumis.Formatter.ANSI
+  alias Lumis.Theme
+  alias Lumis.Theme.Style
+  alias Lumis.Theme.TextDecoration
+
+  @source "defmodule App do\n  @doc \"hello\"\n  def run, do: :ok\nend\n"
+
+  defmodule CaptureFormatter do
+    @moduledoc false
+    @behaviour Lumis.Formatter
+
+    @impl true
+    def render(_source, events, options) do
+      send(Keyword.fetch!(options, :owner), {:events, events})
+      []
+    end
+  end
+
+  defmodule HelperFormatter do
+    @moduledoc false
+    @behaviour Lumis.Formatter
+
+    alias Lumis.Formatter.ANSI
+
+    @impl true
+    def render(source, events, options) do
+      theme = Keyword.fetch!(options, :theme)
+
+      {parts, _scopes} =
+        Enum.reduce(events, {[], []}, fn
+          {:start, %{scope: scope, language: language}}, {parts, scopes} ->
+            {parts, [{scope, language} | scopes]}
+
+          :end, {parts, [_scope | scopes]} ->
+            {parts, scopes}
+
+          {:source, %{start: start, end: stop}}, {parts, scopes} ->
+            text = binary_part(source, start, stop - start)
+            {[paint(text, scopes, theme) | parts], scopes}
+
+          _event, state ->
+            state
+        end)
+
+      parts |> Enum.reverse() |> IO.iodata_to_binary()
+    end
+
+    defp paint(text, [], _theme), do: text
+
+    defp paint(text, [{scope, language} | _scopes], theme) do
+      style =
+        Map.get(theme.highlights, "#{scope}.#{language}") || Map.get(theme.highlights, scope)
+
+      if style, do: ANSI.paint(text, style), else: text
+    end
+  end
+
+  setup_all do
+    :ok = Lumis.Languages.load("elixir")
+    :ok
+  end
+
+  test "hex_to_rgb/1 and rgb_to_ansi/4 compose into style_to_ansi/1" do
+    assert {255, 121, 198} = rgb = ANSI.hex_to_rgb("#ff79c6")
+    assert rgb == ANSI.hex_to_rgb("ff79c6")
+    assert ANSI.hex_to_rgb("fff") == nil
+    assert ANSI.hex_to_rgb("not-a-color") == nil
+    assert ANSI.hex_to_rgb("aéaaa") == nil
+
+    {r, g, b} = rgb
+    assert ANSI.style_to_ansi(%Style{fg: "#ff79c6"}) == ANSI.rgb_to_ansi(r, g, b, false)
+    assert ANSI.style_to_ansi(%Style{bg: "#ff79c6"}) == ANSI.rgb_to_ansi(r, g, b, true)
+  end
+
+  test "reset/0 is the reset paint and the terminal formatter emit" do
+    style = %Style{bold: true}
+    painted = ANSI.paint("text", style)
+    scopes = for {:start, %{scope: scope}} <- events(@source, "elixir"), uniq: true, do: scope
+    terminal = terminal_output(@source, theme_for(scopes, style), "elixir")
+
+    assert String.starts_with?(painted, ANSI.reset())
+    assert String.ends_with?(painted, ANSI.reset())
+    assert String.contains?(terminal, ANSI.reset())
+  end
+
+  test "paint/2 and style_to_ansi/1 reproduce the built-in terminal formatter" do
+    events = events(@source, "elixir")
+    scopes = for {:start, %{scope: scope}} <- events, uniq: true, do: scope
+
+    styles = [
+      %Style{fg: "#ff79c6"},
+      %Style{bg: "#282a36"},
+      %Style{bold: true},
+      %Style{italic: true},
+      %Style{text_decoration: %TextDecoration{underline: :solid}},
+      %Style{text_decoration: %TextDecoration{underline: :wavy}},
+      %Style{text_decoration: %TextDecoration{underline: :double}},
+      %Style{text_decoration: %TextDecoration{underline: :dotted}},
+      %Style{text_decoration: %TextDecoration{underline: :dashed}},
+      %Style{text_decoration: %TextDecoration{strikethrough: true}},
+      %Style{
+        fg: "#ff79c6",
+        bg: "#282a36",
+        bold: true,
+        italic: true,
+        text_decoration: %TextDecoration{underline: :wavy, strikethrough: true}
+      }
+    ]
+
+    for style <- styles do
+      theme = theme_for(scopes, style)
+
+      helper_output =
+        Lumis.highlight!(@source,
+          formatter: {HelperFormatter, language: "elixir", theme: theme}
+        )
+
+      assert helper_output == terminal_output(@source, theme, "elixir")
+      assert ANSI.style_to_ansi(style) != ""
+      assert String.contains?(ANSI.paint("token", style), ANSI.style_to_ansi(style))
+    end
+  end
+
+  test "paint/2 leaves text unchanged for an empty style" do
+    assert ANSI.paint("plain text", %Style{}) == "plain text"
+    assert ANSI.style_to_ansi(%Style{}) == ""
+  end
+
+  defp events(source, language) do
+    Lumis.highlight!(source,
+      formatter: {CaptureFormatter, language: language, owner: self()}
+    )
+
+    receive do
+      {:events, events} -> events
+    after
+      1_000 -> flunk("the formatter was never handed an event stream")
+    end
+  end
+
+  defp theme_for(scopes, style) do
+    %Theme{
+      name: "ansi-helper-test",
+      appearance: :dark,
+      revision: "test",
+      highlights: Map.new(scopes, &{&1, style})
+    }
+  end
+
+  defp terminal_output(source, theme, language) do
+    Lumis.highlight!(source, formatter: {:terminal, language: language, theme: theme})
+  end
+end

--- a/packages/elixir/lumis/test/lumis/formatter/ansi_test.exs
+++ b/packages/elixir/lumis/test/lumis/formatter/ansi_test.exs
@@ -1,6 +1,8 @@
 defmodule Lumis.Formatter.ANSITest do
   use ExUnit.Case, async: true
 
+  doctest Lumis.Formatter.ANSI
+
   alias Lumis.Formatter.ANSI
   alias Lumis.Theme
   alias Lumis.Theme.Style

--- a/packages/elixir/lumis/usage-rules.md
+++ b/packages/elixir/lumis/usage-rules.md
@@ -523,6 +523,17 @@ Do not hand-roll ANSI color or text-decoration escape sequences either.
 
 - `hex_to_rgb/1`, `rgb_to_ansi/4`
 - `style_to_ansi/1`, `paint/2`, `reset/0`
+- `styles/1`, `style_for/2`
+
+Do not resolve a scope by reading `theme.highlights` either. A scope falls back
+to its parent, so `tag.delimiter` is painted by `tag` in a theme that styles
+only `tag`, and rainbow-bracket scopes fall back to a table Lumis owns.
+`Map.get(theme.highlights, scope)` misses both and paints differently than
+`:terminal` does. `styles/1` returns the whole resolved table, for the same
+reason `span_attrs/1` does; build one per language you meet and read it with
+`style_for/2`. An injected block carries its own language on its `:start` event,
+and a theme can style a scope per language, so one table for the whole document
+is wrong when the document has injections.
 
 ## HTML Output Structure
 

--- a/packages/elixir/lumis/usage-rules.md
+++ b/packages/elixir/lumis/usage-rules.md
@@ -508,7 +508,7 @@ Lumis.highlight!(code, formatter: {MyFormatter, language: "elixir", theme: "gith
 `render/3` returns iodata; Lumis flattens it once at the end.
 
 Do not hand-roll HTML escaping or scope-to-class mapping. `Lumis.Formatter.HTML`
-calls the same Rust the built-in formatters call:
+gives the built-in formatters' pieces:
 
 - `escape/1`, `escape_braces/1`
 - `scope_to_class/1`, `span_linked_attrs/1`, `span_linked/2`
@@ -519,21 +519,18 @@ calls the same Rust the built-in formatters call:
 a per-token operation. Build the table once outside the loop and read it inside.
 
 Do not hand-roll ANSI color or text-decoration escape sequences either.
-`Lumis.Formatter.ANSI` calls the same Rust helpers as `:terminal`:
+`Lumis.Formatter.ANSI` gives `:terminal`'s pieces:
 
 - `hex_to_rgb/1`, `rgb_to_ansi/4`
 - `style_to_ansi/1`, `paint/2`, `reset/0`
 - `styles/1`, `style_for/2`
 
-Do not resolve a scope by reading `theme.highlights` either. A scope falls back
-to its parent, so `tag.delimiter` is painted by `tag` in a theme that styles
-only `tag`, and rainbow-bracket scopes fall back to a table Lumis owns.
-`Map.get(theme.highlights, scope)` misses both and paints differently than
-`:terminal` does. `styles/1` returns the whole resolved table, for the same
-reason `span_attrs/1` does; build one per language you meet and read it with
-`style_for/2`. An injected block carries its own language on its `:start` event,
-and a theme can style a scope per language, so one table for the whole document
-is wrong when the document has injections.
+Do not resolve a scope with `Map.get(theme.highlights, scope)`. That misses the
+fallbacks `:terminal` applies — `tag.delimiter` is painted by `tag` in a theme
+that styles only `tag` — so it paints differently. Use `styles/1` and read it
+with `style_for/2`, and build one table per language you meet: a theme can style
+a scope per language, and an injected block carries its own language on its
+`:start` event.
 
 ## HTML Output Structure
 

--- a/packages/elixir/lumis/usage-rules.md
+++ b/packages/elixir/lumis/usage-rules.md
@@ -518,6 +518,12 @@ calls the same Rust the built-in formatters call:
 `span_attrs/1` and `classes/0` return whole tables because resolving a scope is
 a per-token operation. Build the table once outside the loop and read it inside.
 
+Do not hand-roll ANSI color or text-decoration escape sequences either.
+`Lumis.Formatter.ANSI` calls the same Rust helpers as `:terminal`:
+
+- `hex_to_rgb/1`, `rgb_to_ansi/4`
+- `style_to_ansi/1`, `paint/2`, `reset/0`
+
 ## HTML Output Structure
 
 Lumis generates semantic HTML with line wrappers:


### PR DESCRIPTION
Closes #1382.

## Summary

- expose the existing `lumis_core::formatter::ansi` helpers through `Lumis.Formatter.ANSI`
- cover RGB conversion, style sequences, painting, and reset behavior through the Elixir NIF
- pin helper output to the built-in `:terminal` formatter across every supported text decoration
- make Rust hex parsing reject non-ASCII input instead of panicking
- document the Elixir ANSI helper surface

## Validation

- `mise run fmt`
- `mise run lint`
- `mise run test-elixir` — 215 passed, 150 excluded
- `cargo test -p lumis-core formatter::ansi` — 10 passed
- `mix lint.rust`
- `mix test.rust` — 2 passed
- `mise run docs-elixir`
- `pnpm --dir docs build`
- negative control: replacing ANSI painting with plain text fails the terminal-parity guard
