### PR TITLE
fix(ansi): reject a hex colour that is only partly hex

### DIFF
--- a/crates/lumis-cli/src/main.rs
+++ b/crates/lumis-cli/src/main.rs
@@ -9,6 +9,7 @@ use formatter_options::{
     OPTSET_GLOBAL, OPTSET_HTML, OPTSET_MULTI_THEME, OPTSET_STYLED, OPTSET_TERMINAL,
 };
 use lumis_core::events::HighlightEvent as CoreHighlightEvent;
+use lumis_core::formatter::ansi::hex_to_rgb;
 use lumis_core::formatter::Formatter as CoreFormatter;
 use lumis_core::formatter::TerminalBackground;
 use lumis_core::languages::Language;
@@ -835,24 +836,11 @@ fn guess_terminal_theme() -> Option<String> {
 fn closest_builtin_theme(background: (u8, u8, u8)) -> Option<String> {
     lumis_core::themes::available_themes()
         .filter_map(|theme| {
-            let theme_background = theme.bg().and_then(parse_hex_color)?;
+            let theme_background = theme.bg().and_then(hex_to_rgb)?;
             Some((color_distance(background, theme_background), &theme.name))
         })
         .min_by_key(|(distance, _)| *distance)
         .map(|(_, name)| name.clone())
-}
-
-fn parse_hex_color(color: &str) -> Option<(u8, u8, u8)> {
-    let color = color.strip_prefix('#')?;
-    if color.len() != 6 {
-        return None;
-    }
-
-    Some((
-        u8::from_str_radix(&color[0..2], 16).ok()?,
-        u8::from_str_radix(&color[2..4], 16).ok()?,
-        u8::from_str_radix(&color[4..6], 16).ok()?,
-    ))
 }
 
 // Redmean color distance weights RGB channels based on human perception.
@@ -1962,13 +1950,6 @@ mod tests {
             closest_builtin_theme((0x22, 0x24, 0x36)).as_deref(),
             Some("tokyonight_moon")
         );
-    }
-
-    #[test]
-    fn parse_hex_color_rejects_invalid_values() {
-        assert_eq!(parse_hex_color("#282a36"), Some((0x28, 0x2a, 0x36)));
-        assert_eq!(parse_hex_color("282a36"), None);
-        assert_eq!(parse_hex_color("#fff"), None);
     }
 
     #[test]

--- a/crates/lumis-core/src/formatter/ansi.rs
+++ b/crates/lumis-core/src/formatter/ansi.rs
@@ -9,16 +9,21 @@ use crate::themes::{Style, UnderlineStyle};
 pub const ANSI_RESET: &str = "\u{1b}[0m";
 
 /// Convert a hex color string to RGB tuple.
+///
+/// A color is exactly six ASCII hex digits, optionally preceded by `#`, and
+/// anything else is `None`. The digit check is what makes that true:
+/// `u8::from_str_radix` accepts a leading sign, so component-wise parsing alone
+/// read `"ff+79c"` as `(255, 7, 156)`.
 pub fn hex_to_rgb(hex: &str) -> Option<(u8, u8, u8)> {
     let hex = hex.trim_start_matches('#');
 
-    if hex.len() != 6 {
+    if hex.len() != 6 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return None;
     }
 
-    let r = u8::from_str_radix(hex.get(0..2)?, 16).ok()?;
-    let g = u8::from_str_radix(hex.get(2..4)?, 16).ok()?;
-    let b = u8::from_str_radix(hex.get(4..6)?, 16).ok()?;
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
 
     Some((r, g, b))
 }
@@ -126,6 +131,12 @@ mod tests {
         assert_eq!(hex_to_rgb("#fff"), None);
         assert_eq!(hex_to_rgb("aéaaa"), None);
         assert_eq!(hex_to_rgb(""), None);
+    }
+
+    #[test]
+    fn test_hex_to_rgb_rejects_a_signed_component() {
+        assert_eq!(hex_to_rgb("ff+79c"), None);
+        assert_eq!(hex_to_rgb("+f+f+f"), None);
     }
 
     #[test]

--- a/crates/lumis-core/tests/ansi_parity.rs
+++ b/crates/lumis-core/tests/ansi_parity.rs
@@ -1,0 +1,123 @@
+//! Rust's half of the ANSI helper parity check.
+//!
+//! `fixtures/ansi-parity.json` holds one expected value per case. This asserts
+//! Rust produces it; `packages/javascript/lumis/test/ansi-parity.test.ts`
+//! asserts the TypeScript port produces the same. Rust is the reference, so a
+//! difference is a bug in the port rather than something to record.
+
+use lumis_core::formatter::ansi;
+use lumis_core::themes::Style;
+use serde::Deserialize;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Case {
+    name: String,
+    helper: Helper,
+    expected: Expected,
+    #[serde(default)]
+    hex: String,
+    #[serde(default)]
+    text: String,
+    /// The JSON shape a theme already carries, so neither side reshapes it.
+    #[serde(default)]
+    style: Style,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+enum Helper {
+    HexToRgb,
+    StyleToAnsi,
+    Paint,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Expected {
+    /// `hexToRgb`, where `null` means the string names no color.
+    Rgb(Option<[u8; 3]>),
+    /// `styleToAnsi` and `paint`, which both answer a string.
+    Text(String),
+}
+
+fn manifest() -> Manifest {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/ansi-parity.json");
+    serde_json::from_str(&fs::read_to_string(&path).expect("read ansi-parity.json"))
+        .expect("parse ansi-parity.json")
+}
+
+fn expected_rgb(case: &Case) -> Option<(u8, u8, u8)> {
+    match &case.expected {
+        Expected::Rgb(rgb) => rgb.map(|[r, g, b]| (r, g, b)),
+        Expected::Text(text) => panic!("{}: expected an RGB triple, not {text:?}", case.name),
+    }
+}
+
+fn expected_text(case: &Case) -> &str {
+    match &case.expected {
+        Expected::Text(text) => text,
+        Expected::Rgb(rgb) => panic!("{}: expected a string, not {rgb:?}", case.name),
+    }
+}
+
+#[test]
+fn covers_the_input_a_valid_prefix_used_to_slip_through() {
+    let manifest = manifest();
+    let names: Vec<&str> = manifest
+        .cases
+        .iter()
+        .map(|case| case.name.as_str())
+        .collect();
+
+    for required in [
+        "hex/trailing-non-hex-digit",
+        "hex/last-component-half-valid",
+        "hex/trailing-space",
+        "hex/leading-space",
+        "hex/signed-component",
+        "hex/non-ascii-in-the-last-component",
+        "hex/repeated-hash-is-trimmed",
+        "paint/an-empty-background-still-takes-the-per-line-branch",
+    ] {
+        assert!(
+            names.contains(&required),
+            "the corpus lost its `{required}` case"
+        );
+    }
+}
+
+#[test]
+fn answers_what_the_port_has_to_answer() {
+    let manifest = manifest();
+
+    for case in &manifest.cases {
+        match case.helper {
+            Helper::HexToRgb => assert_eq!(
+                ansi::hex_to_rgb(&case.hex),
+                expected_rgb(case),
+                "{}",
+                case.name
+            ),
+            Helper::StyleToAnsi => assert_eq!(
+                ansi::style_to_ansi(&case.style),
+                expected_text(case),
+                "{}",
+                case.name
+            ),
+            Helper::Paint => assert_eq!(
+                ansi::paint(&case.text, &case.style),
+                expected_text(case),
+                "{}",
+                case.name
+            ),
+        }
+    }
+}

--- a/crates/lumis/src/formatter/ansi.rs
+++ b/crates/lumis/src/formatter/ansi.rs
@@ -38,11 +38,13 @@ pub const ANSI_RESET: &str = lumis_core::formatter::ansi::ANSI_RESET;
 ///
 /// # Arguments
 ///
-/// * `hex` - Hex color string (with or without '#' prefix)
+/// * `hex` - Exactly six hex digits, with or without a '#' prefix
 ///
 /// # Returns
 ///
 /// `Some((r, g, b))` tuple of u8 values if parsing succeeds, `None` otherwise.
+/// A string that merely starts with hex digits names no color either, so
+/// `"ff79cz"` is `None` rather than `(255, 121, 12)`.
 ///
 /// # Examples
 ///
@@ -52,6 +54,7 @@ pub const ANSI_RESET: &str = lumis_core::formatter::ansi::ANSI_RESET;
 /// assert_eq!(hex_to_rgb("#ff5555"), Some((255, 85, 85)));
 /// assert_eq!(hex_to_rgb("ff5555"), Some((255, 85, 85)));
 /// assert_eq!(hex_to_rgb("invalid"), None);
+/// assert_eq!(hex_to_rgb("ff79cz"), None);
 /// ```
 pub fn hex_to_rgb(hex: &str) -> Option<(u8, u8, u8)> {
     lumis_core::formatter::ansi::hex_to_rgb(hex)
@@ -257,6 +260,8 @@ mod tests {
         assert_eq!(hex_to_rgb("aéaaa"), None);
         assert_eq!(hex_to_rgb(""), None);
         assert_eq!(hex_to_rgb("#gggggg"), None);
+        assert_eq!(hex_to_rgb("ff79cz"), None);
+        assert_eq!(hex_to_rgb("ff+79c"), None);
     }
 
     #[test]

--- a/fixtures/ansi-parity.json
+++ b/fixtures/ansi-parity.json
@@ -1,0 +1,303 @@
+{
+  "$comment": [
+    "ANSI formatter helpers, pinned between Rust and the TypeScript port.",
+    "",
+    "`crates/lumis-core/src/formatter/ansi.rs` is the reference and",
+    "`packages/javascript/lumis/src/formatter/ansi-core.ts` is a hand port of it,",
+    "because the browser cannot call into Rust. The two disagreed on invalid hex",
+    "input (#1389): Rust's `u8::from_str_radix` rejects a component it cannot",
+    "consume whole, while `Number.parseInt` takes the longest valid prefix, so a",
+    "malformed theme painted a wrong colour in JavaScript and no colour at all in",
+    "the built-in terminal formatter. Rust also accepted a `+` sign inside a",
+    "component, which names no colour either; both sides now reject it.",
+    "",
+    "`helper` selects what a case exercises:",
+    "  hexToRgb    `hex` in, `rgb` out, or `null` where the string names no colour",
+    "  styleToAnsi `style` in, the opening escape sequence out",
+    "  paint       `text` and `style` in, the rendered string out",
+    "",
+    "`style` is the JSON shape a theme already carries, so Rust deserializes it",
+    "into `lumis_core::themes::Style` and the port reads it as a",
+    "`HighlightStyle` without either side reshaping it.",
+    "",
+    "`expected` is one value both runtimes must produce. Rust is the reference,",
+    "so a difference is a bug in the port unless the Rust half fails too."
+  ],
+  "cases": [
+    {
+      "name": "hex/six-digits",
+      "helper": "hexToRgb",
+      "hex": "ff79c6",
+      "expected": [255, 121, 198]
+    },
+    {
+      "name": "hex/leading-hash",
+      "helper": "hexToRgb",
+      "hex": "#ff79c6",
+      "expected": [255, 121, 198]
+    },
+    {
+      "name": "hex/uppercase",
+      "helper": "hexToRgb",
+      "hex": "#FF79C6",
+      "expected": [255, 121, 198]
+    },
+    {
+      "name": "hex/black-and-white",
+      "helper": "hexToRgb",
+      "hex": "#000000",
+      "expected": [0, 0, 0]
+    },
+    {
+      "name": "hex/repeated-hash-is-trimmed",
+      "helper": "hexToRgb",
+      "hex": "##ff5555",
+      "expected": [255, 85, 85]
+    },
+    {
+      "name": "hex/empty",
+      "helper": "hexToRgb",
+      "hex": "",
+      "expected": null
+    },
+    {
+      "name": "hex/three-digit-shorthand",
+      "helper": "hexToRgb",
+      "hex": "#fff",
+      "expected": null
+    },
+    {
+      "name": "hex/not-a-colour",
+      "helper": "hexToRgb",
+      "hex": "invalid",
+      "expected": null
+    },
+    {
+      "name": "hex/no-digit-is-hex",
+      "helper": "hexToRgb",
+      "hex": "#gggggg",
+      "expected": null
+    },
+    {
+      "name": "hex/trailing-non-hex-digit",
+      "helper": "hexToRgb",
+      "hex": "ff79cz",
+      "expected": null
+    },
+    {
+      "name": "hex/last-component-half-valid",
+      "helper": "hexToRgb",
+      "hex": "fffffg",
+      "expected": null
+    },
+    {
+      "name": "hex/trailing-space",
+      "helper": "hexToRgb",
+      "hex": "ff79c ",
+      "expected": null
+    },
+    {
+      "name": "hex/leading-space",
+      "helper": "hexToRgb",
+      "hex": " f79c1",
+      "expected": null
+    },
+    {
+      "name": "hex/signed-component",
+      "helper": "hexToRgb",
+      "hex": "ff+79c",
+      "expected": null
+    },
+    {
+      "name": "hex/every-component-signed",
+      "helper": "hexToRgb",
+      "hex": "+f+f+f",
+      "expected": null
+    },
+    {
+      "name": "hex/negative-component",
+      "helper": "hexToRgb",
+      "hex": "-0ffff",
+      "expected": null
+    },
+    {
+      "name": "hex/six-bytes-of-non-ascii",
+      "helper": "hexToRgb",
+      "hex": "aéaaa",
+      "expected": null
+    },
+    {
+      "name": "hex/non-ascii-in-the-last-component",
+      "helper": "hexToRgb",
+      "hex": "ff79cé",
+      "expected": null
+    },
+    {
+      "name": "hex/seven-digits",
+      "helper": "hexToRgb",
+      "hex": "ff79c6a",
+      "expected": null
+    },
+    {
+      "name": "style/empty",
+      "helper": "styleToAnsi",
+      "style": {},
+      "expected": ""
+    },
+    {
+      "name": "style/foreground",
+      "helper": "styleToAnsi",
+      "style": { "fg": "#8be9fd" },
+      "expected": "\u001b[38;2;139;233;253m"
+    },
+    {
+      "name": "style/background",
+      "helper": "styleToAnsi",
+      "style": { "bg": "#282a36" },
+      "expected": "\u001b[48;2;40;42;54m"
+    },
+    {
+      "name": "style/invalid-foreground-emits-no-colour",
+      "helper": "styleToAnsi",
+      "style": { "fg": "ff79cz", "bold": true },
+      "expected": "\u001b[1m"
+    },
+    {
+      "name": "style/invalid-background-emits-no-colour",
+      "helper": "styleToAnsi",
+      "style": { "bg": "fffffg", "italic": true },
+      "expected": "\u001b[3m"
+    },
+    {
+      "name": "style/order-is-fg-bg-bold-italic-underline-strikethrough",
+      "helper": "styleToAnsi",
+      "style": {
+        "fg": "#ffffff",
+        "bg": "#000000",
+        "bold": true,
+        "italic": true,
+        "underline": "solid",
+        "strikethrough": true
+      },
+      "expected": "\u001b[38;2;255;255;255m\u001b[48;2;0;0;0m\u001b[1m\u001b[3m\u001b[4m\u001b[9m"
+    },
+    {
+      "name": "style/underline-true-is-solid",
+      "helper": "styleToAnsi",
+      "style": { "underline": true },
+      "expected": "\u001b[4m"
+    },
+    {
+      "name": "style/underline-false-is-none",
+      "helper": "styleToAnsi",
+      "style": { "underline": false },
+      "expected": ""
+    },
+    {
+      "name": "style/underline-none",
+      "helper": "styleToAnsi",
+      "style": { "underline": "none" },
+      "expected": ""
+    },
+    {
+      "name": "style/underline-wavy",
+      "helper": "styleToAnsi",
+      "style": { "underline": "wavy" },
+      "expected": "\u001b[4:3m"
+    },
+    {
+      "name": "style/underline-undercurl-is-wavy",
+      "helper": "styleToAnsi",
+      "style": { "underline": "undercurl" },
+      "expected": "\u001b[4:3m"
+    },
+    {
+      "name": "style/underline-double",
+      "helper": "styleToAnsi",
+      "style": { "underline": "double" },
+      "expected": "\u001b[4:2m"
+    },
+    {
+      "name": "style/underline-dotted",
+      "helper": "styleToAnsi",
+      "style": { "underline": "dotted" },
+      "expected": "\u001b[4:4m"
+    },
+    {
+      "name": "style/underline-dashed",
+      "helper": "styleToAnsi",
+      "style": { "underline": "dashed" },
+      "expected": "\u001b[4:5m"
+    },
+    {
+      "name": "paint/empty-style-is-the-text",
+      "helper": "paint",
+      "text": "fn",
+      "style": {},
+      "expected": "fn"
+    },
+    {
+      "name": "paint/invalid-colour-alone-is-the-text",
+      "helper": "paint",
+      "text": "fn",
+      "style": { "fg": "ff79cz" },
+      "expected": "fn"
+    },
+    {
+      "name": "paint/foreground",
+      "helper": "paint",
+      "text": "fn",
+      "style": { "fg": "#8be9fd" },
+      "expected": "\u001b[0m\u001b[38;2;139;233;253mfn\u001b[0m"
+    },
+    {
+      "name": "paint/foreground-spans-newlines-uninterrupted",
+      "helper": "paint",
+      "text": "a\nb",
+      "style": { "fg": "#8be9fd" },
+      "expected": "\u001b[0m\u001b[38;2;139;233;253ma\nb\u001b[0m"
+    },
+    {
+      "name": "paint/background-resets-before-each-newline",
+      "helper": "paint",
+      "text": "a\nb",
+      "style": { "fg": "#8be9fd", "bg": "#282a36" },
+      "expected": "\u001b[0m\u001b[38;2;139;233;253m\u001b[48;2;40;42;54ma\u001b[0m\n\u001b[38;2;139;233;253m\u001b[48;2;40;42;54mb\u001b[0m"
+    },
+    {
+      "name": "paint/background-does-not-reopen-after-a-trailing-newline",
+      "helper": "paint",
+      "text": "a\n",
+      "style": { "bg": "#282a36" },
+      "expected": "\u001b[0m\u001b[48;2;40;42;54ma\u001b[0m\n"
+    },
+    {
+      "name": "paint/background-reopens-before-multi-byte-text",
+      "helper": "paint",
+      "text": "a\né",
+      "style": { "bg": "#282a36" },
+      "expected": "\u001b[0m\u001b[48;2;40;42;54ma\u001b[0m\n\u001b[48;2;40;42;54mé\u001b[0m"
+    },
+    {
+      "name": "paint/background-reopens-before-an-astral-char",
+      "helper": "paint",
+      "text": "a\n😀",
+      "style": { "bg": "#282a36" },
+      "expected": "\u001b[0m\u001b[48;2;40;42;54ma\u001b[0m\n\u001b[48;2;40;42;54m😀\u001b[0m"
+    },
+    {
+      "name": "paint/an-empty-background-still-takes-the-per-line-branch",
+      "helper": "paint",
+      "text": "a\nb",
+      "style": { "bg": "", "bold": true },
+      "expected": "\u001b[0m\u001b[1ma\u001b[0m\n\u001b[1mb\u001b[0m"
+    },
+    {
+      "name": "paint/an-unparseable-background-still-takes-the-per-line-branch",
+      "helper": "paint",
+      "text": "a\nb",
+      "style": { "bg": "ff79cz", "bold": true },
+      "expected": "\u001b[0m\u001b[1ma\u001b[0m\n\u001b[1mb\u001b[0m"
+    }
+  ]
+}

--- a/packages/elixir/lumis/test/lumis/formatter/ansi_test.exs
+++ b/packages/elixir/lumis/test/lumis/formatter/ansi_test.exs
@@ -85,6 +85,9 @@ defmodule Lumis.Formatter.ANSITest do
     assert ANSI.hex_to_rgb("fff") == nil
     assert ANSI.hex_to_rgb("not-a-color") == nil
     assert ANSI.hex_to_rgb("aéaaa") == nil
+    # Six digits is the whole string, not a prefix of it.
+    assert ANSI.hex_to_rgb("ff79cz") == nil
+    assert ANSI.hex_to_rgb("ff+79c") == nil
 
     {r, g, b} = rgb
     assert ANSI.style_to_ansi(%Style{fg: "#ff79c6"}) == ANSI.rgb_to_ansi(r, g, b, false)

--- a/packages/javascript/lumis/src/formatter/ansi-core.ts
+++ b/packages/javascript/lumis/src/formatter/ansi-core.ts
@@ -3,8 +3,17 @@ import type { HighlightStyle } from "../types.js";
 /** ANSI reset escape sequence. */
 export const ANSI_RESET = "\u001B[0m";
 
+/** Exactly six hex digits, which is what `hex_to_rgb` accepts in Rust. */
+const HEX_COLOR = /^[0-9a-fA-F]{6}$/;
+
 /**
  * Parse a hex color string to RGB components.
+ *
+ * Testing the whole string is what keeps this equal to Rust's
+ * `u8::from_str_radix`, which rejects a component it cannot consume entirely.
+ * `Number.parseInt` instead takes the longest valid prefix and returns `NaN`
+ * only when there is none, so `'ff79cz'` used to read as `[255, 121, 12]` here
+ * and as no color at all in the built-in terminal formatter.
  *
  * ```ts
  * hexToRgb('#ff79c6')  // [255, 121, 198]
@@ -12,18 +21,15 @@ export const ANSI_RESET = "\u001B[0m";
  * ```
  */
 export function hexToRgb(hex: string): [number, number, number] | undefined {
-  const normalized = hex.startsWith("#") ? hex.slice(1) : hex;
-  if (normalized.length !== 6) return undefined;
+  // Rust trims with `trim_start_matches('#')`, which drops every leading `#`.
+  const normalized = hex.replace(/^#+/, "");
+  if (!HEX_COLOR.test(normalized)) return undefined;
 
-  const r = Number.parseInt(normalized.slice(0, 2), 16);
-  const g = Number.parseInt(normalized.slice(2, 4), 16);
-  const b = Number.parseInt(normalized.slice(4, 6), 16);
-
-  if ([r, g, b].some((value) => Number.isNaN(value))) {
-    return undefined;
-  }
-
-  return [r, g, b];
+  return [
+    Number.parseInt(normalized.slice(0, 2), 16),
+    Number.parseInt(normalized.slice(2, 4), 16),
+    Number.parseInt(normalized.slice(4, 6), 16),
+  ];
 }
 
 /**
@@ -99,7 +105,10 @@ export function paint(text: string, style: HighlightStyle | undefined): string {
     return text;
   }
 
-  if (style?.bg) {
+  // Rust branches on `style.bg.is_some()`, so a background that parsed to no
+  // color still resets at each newline. `style?.bg` alone would not, since `''`
+  // is falsy in JavaScript and `Some("")` is not `None` in Rust.
+  if (style?.bg != null) {
     let result = ANSI_RESET + open;
 
     for (let i = 0; i < text.length; i += 1) {

--- a/packages/javascript/lumis/test/ansi-parity.test.ts
+++ b/packages/javascript/lumis/test/ansi-parity.test.ts
@@ -1,0 +1,93 @@
+/**
+ * The TypeScript half of the ANSI helper parity check.
+ *
+ * `fixtures/ansi-parity.json` holds one expected value per case.
+ * `crates/lumis-core/tests/ansi_parity.rs` asserts Rust produces it; this
+ * asserts the port does too. Rust is the reference, so a difference here is a
+ * bug in this port.
+ *
+ * The port exists because the browser cannot call into Rust. Nothing pinned it
+ * until now, and it had drifted: `hexToRgb` read `'ff79cz'` as `[255, 121, 12]`
+ * where Rust read no color at all (#1389).
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { hexToRgb, paint, styleToAnsi } from "../src/formatter/ansi-core.js";
+import type { HighlightStyle } from "../src/types.js";
+
+type Helper = "hexToRgb" | "styleToAnsi" | "paint";
+
+interface Case {
+  name: string;
+  helper: Helper;
+  /** An RGB triple or `null` for `hexToRgb`, a string for the other two. */
+  expected: [number, number, number] | null | string;
+  hex?: string;
+  text?: string;
+  /** The JSON shape a theme already carries, so neither side reshapes it. */
+  style?: HighlightStyle;
+}
+
+const manifest: { cases: Case[] } = JSON.parse(
+  readFileSync(new URL("../../../../fixtures/ansi-parity.json", import.meta.url), "utf8"),
+);
+
+function expectedRgb(testCase: Case): [number, number, number] | undefined {
+  if (typeof testCase.expected === "string") {
+    throw new TypeError(`${testCase.name}: expected an RGB triple, not a string`);
+  }
+  return testCase.expected ?? undefined;
+}
+
+function expectedText(testCase: Case): string {
+  if (typeof testCase.expected !== "string") {
+    throw new TypeError(`${testCase.name}: expected a string, not an RGB triple`);
+  }
+  return testCase.expected;
+}
+
+describe("ansi helper parity", () => {
+  it("covers the input a valid prefix used to slip through", () => {
+    const names = manifest.cases.map((testCase) => testCase.name);
+
+    for (const required of [
+      "hex/trailing-non-hex-digit",
+      "hex/last-component-half-valid",
+      "hex/trailing-space",
+      "hex/leading-space",
+      "hex/signed-component",
+      "hex/non-ascii-in-the-last-component",
+      "hex/repeated-hash-is-trimmed",
+      "paint/an-empty-background-still-takes-the-per-line-branch",
+    ]) {
+      expect(names, `the corpus lost its \`${required}\` case`).toContain(required);
+    }
+  });
+
+  for (const testCase of manifest.cases) {
+    it(`answers what Rust answers for ${testCase.name}`, () => {
+      switch (testCase.helper) {
+        case "hexToRgb": {
+          expect(hexToRgb(testCase.hex ?? ""), testCase.name).toEqual(expectedRgb(testCase));
+          break;
+        }
+        case "styleToAnsi": {
+          expect(styleToAnsi(testCase.style), testCase.name).toBe(expectedText(testCase));
+          break;
+        }
+        case "paint": {
+          expect(paint(testCase.text ?? "", testCase.style), testCase.name).toBe(
+            expectedText(testCase),
+          );
+          break;
+        }
+        // `helper` comes from JSON, so a corpus typo would otherwise run
+        // nothing and report the same green as a case that checked something.
+        default: {
+          throw new TypeError(`${testCase.name}: \`${String(testCase.helper)}\` is not a helper`);
+        }
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #1389.

## Summary

- `hexToRgb` in `packages/javascript/lumis/src/formatter/ansi-core.ts` matched `Number.parseInt`'s longest-valid-prefix rule, so `ff79cz` read as `[255, 121, 12]` where `lumis_core::formatter::ansi::hex_to_rgb` read no colour at all. It now tests the whole string.
- Rust had the mirror-image defect. `u8::from_str_radix` accepts a leading sign, so parsing two characters at a time read `ff+79c` as `(255, 7, 156)`. That is not one of the divergences the issue lists — the issue has Rust rejecting it, and Rust accepted it — so leaving it would have forced the port to reimplement the quirk. Both sides now take exactly six hex digits after the optional `#`, which is what `Lumis.Formatter.ANSI.hex_to_rgb/1` already documented.
- `fixtures/ansi-parity.json` is the shared corpus. `crates/lumis-core/tests/ansi_parity.rs` asserts Rust produces each value and `packages/javascript/lumis/test/ansi-parity.test.ts` asserts the port produces the same, following `fixtures/html-attr-escaping.json` (#1385).
- The corpus covers `styleToAnsi` and `paint` too, since the issue notes they are duplicated in the port as well. It found two more divergences:
  - the port stripped one leading `#` where Rust's `trim_start_matches('#')` strips every one, so `##ff5555` was a colour in Rust and not in JavaScript;
  - `paint` chose its per-line reset branch on the truthiness of `bg` rather than its presence, so `bg: ""` reset at each newline in Rust and not in JavaScript.
- The underline table is the third duplicated piece the issue names. It turned out to already agree for every value a theme can carry, and the corpus now pins that.
- `crates/lumis-cli/src/main.rs` had a third copy of the same parser. Deleted; it calls the core one.

## Validation

- `cargo test -p lumis-core -p lumis --lib --tests` — 213 + 91 + the new 2 passed
- `cargo test -p lumis --doc` — 67 passed
- `cargo test -p lumis-cli --bins` — 16 passed
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check`
- `pnpm --filter @lumis-sh/lumis run test` — 697 passed
- `mise run test-elixir` — 222 passed, 150 excluded
- `mise run lint-js`, `pnpm --filter @lumis-sh/lumis run lint`, `mise run fmt-js -- --check`
- `mise run test-conformance-rust` — 180 passed
- Negative controls: restoring the old TypeScript `hexToRgb` and `paint` fails 14 of the 43 corpus cases; restoring the old Rust `hex_to_rgb` fails `hex/signed-component`.
- `pnpm --filter @lumis-sh/lumis run test:conformance` fails 5 `diff-hunk-injection` cases. Pre-existing — the same 5 fail on `origin/main` with this branch stashed, across `html-inline` and `html-linked` too, which no ANSI change reaches.