### PR TITLE
fix(rust)!: make public error enums non-exhaustive

### DIFF
--- a/crates/lumis-core/src/themes.rs
+++ b/crates/lumis-core/src/themes.rs
@@ -11,6 +11,7 @@ use derive_builder::Builder;
 
 /// Error type for theme operations.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ThemeError {
     /// Theme not found
     NotFound(String),

--- a/crates/lumis-wasm-runtime/src/package.rs
+++ b/crates/lumis-wasm-runtime/src/package.rs
@@ -130,6 +130,7 @@ pub struct PackagedLanguage {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum LanguagePackageError {
     #[error("invalid language package JSON: {0}")]
     Json(#[from] serde_json::Error),

--- a/crates/lumis-wasm-runtime/src/runtime.rs
+++ b/crates/lumis-wasm-runtime/src/runtime.rs
@@ -166,6 +166,7 @@ pub struct Runtime {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum RuntimeError {
     #[error("failed to initialize Wasmtime: {0}")]
     Wasmtime(#[from] wasmtime::Error),

--- a/crates/lumis-wasm-runtime/src/store.rs
+++ b/crates/lumis-wasm-runtime/src/store.rs
@@ -28,6 +28,7 @@ const REPLACE_RETRY_DELAY: Duration = Duration::from_millis(5);
 const CDNS: [&str; 2] = ["https://cdn.jsdelivr.net/npm", "https://unpkg.com"];
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum StoreError {
     #[error("unknown language '{0}'")]
     UnknownLanguage(String),

--- a/crates/lumis/src/highlight.rs
+++ b/crates/lumis/src/highlight.rs
@@ -186,9 +186,13 @@ thread_local! {
 ///     Err(HighlightError::EventProcessing(msg)) => {
 ///         eprintln!("Failed to process highlight event: {}", msg);
 ///     }
+///     Err(error) => {
+///         eprintln!("Failed to highlight: {}", error);
+///     }
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum HighlightError {
     /// Failed to initialize the tree-sitter highlighter for the given language.
     #[error("failed to initialize highlighter: {0}")]


### PR DESCRIPTION
## Summary

- mark every authored public Rust error enum as non-exhaustive
- update the `HighlightError` example to handle future variants
- leave the vendored Tree-sitter `Error` and lower-priority value enums unchanged

## Breaking change

Downstream exhaustive matches on these errors must add a fallback arm.

Closes #1373

## Validation

- `cargo fmt --all -- --check`
- `cargo check --offline --workspace --all-targets --no-default-features`
- `cargo clippy --offline --workspace --all-targets --no-default-features -- -D warnings`
- `cargo test --offline -p lumis-core --no-default-features --features lang-rust`
- `cargo test --offline -p lumis-wasm-runtime`
- `cargo test --offline -p lumis --doc --no-default-features --features lang-rust 'highlight::HighlightError'`
- external consumer rejects exhaustive matches for all five enums and compiles with fallback arms
