### PR TITLE
feat: export the same helpers across runtimes

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -131,8 +131,10 @@
   },
   "overrides": [
     {
-      // 5 sites. These tests and the public re-export intentionally exercise
+      // 14 sites. These tests and the public re-export intentionally exercise
       // deprecated compatibility names; all other deprecations remain errors.
+      // `fixtures/formatter-helpers.json` is what keeps the list from growing
+      // quietly: every name deprecated there is checked to be deprecated here.
       "files": [
         "**/src/formatter/ansi.ts",
         "**/test/formatter-ansi.test.ts",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,21 @@ Lumis should present one mental model everywhere. Public APIs across languages s
 
 The Rust implementation is the source of truth. When a cross-runtime API decision is unclear, follow Rust first and bring other runtimes into line with it instead of inventing runtime-specific behavior.
 
+### A shared surface needs a checked-in manifest, or it drifts silently
+
+"Keep the API aligned" is a rule nothing enforces. Two files do enforce it, each for one surface, and each read by a test in every runtime that has to offer it:
+
+- `fixtures/formatter-options.json` — what the built-in formatters **accept**.
+- `fixtures/formatter-helpers.json` — what a **custom** formatter can be built from.
+
+The second exists because the first was the only one. Options were pinned, helpers were not, and the three helper modules reached 46 names between them with 11 in all three ([#1381](https://github.com/leandrocp/lumis/issues/1381)): JavaScript had grown 20 helpers Rust never got, and a multi-theme formatter could not be written in Elixir at all. Nothing failed, because a helper another runtime lacks raises no error where it does exist.
+
+- **Add to the manifest first, then watch the runtimes go red.** That is the order that makes the gap visible instead of leaving it for an audit.
+- **Every runtime's test checks both directions.** A capability in the manifest that the runtime lacks fails, and a public helper the manifest does not account for fails too. Only the second one catches a helper added to one runtime and nowhere else, which is how this drifted.
+- **A capability is a thing a formatter can do, not a signature.** Runtimes keep their own argument shapes: Elixir returns a whole scope table where Rust takes a theme, because the NIF boundary is not free; JavaScript takes an attribute object where Rust takes a rendered string. Aligning the spelling of those would make the API worse.
+- **`runtime_only` is for a signature the boundary dictates, and it carries the reason.** Elixir's tables and JavaScript's `encodeSource`/`decodeSourceSlice` are there; generic tag plumbing exported by accident is not, that is `deprecated`.
+- **A new surface with the same shape gets the same treatment.** If a third module lands that every runtime must offer, it goes in a manifest before it goes in a second runtime.
+
 ### Reuse the Rust core instead of reimplementing it
 
 Shared behavior belongs in one Rust crate that every runtime consumes. A second implementation of the same logic in another language, or in another Rust crate, is a divergence that will drift.

--- a/crates/lumis-core/src/formatter/html.rs
+++ b/crates/lumis-core/src/formatter/html.rs
@@ -6,6 +6,7 @@ use crate::languages::Language;
 use crate::themes::{Style, TextDecoration, Theme, UnderlineStyle};
 use std::fmt::Write as _;
 use std::io::{self, Write};
+use std::ops::RangeInclusive;
 
 /// Generate HTML attributes for a span with inline CSS styles.
 pub fn span_inline_attrs(
@@ -491,6 +492,30 @@ pub fn wrap_line(
     }
 }
 
+/// Whether `line_number` falls inside any of `lines`.
+///
+/// Lines are 1-based, matching the `data-line` attribute [`wrap_line`] writes.
+pub fn line_is_highlighted(lines: &[RangeInclusive<usize>], line_number: usize) -> bool {
+    lines.iter().any(|range| range.contains(&line_number))
+}
+
+/// The CSS class a highlighted line carries, or `None` when the line is not highlighted.
+///
+/// `class` wins over `default_class`, so a formatter can offer a caller-supplied
+/// class over its own.
+pub fn highlight_line_class<'a>(
+    lines: &[RangeInclusive<usize>],
+    line_number: usize,
+    class: Option<&'a str>,
+    default_class: Option<&'a str>,
+) -> Option<&'a str> {
+    if line_is_highlighted(lines, line_number) {
+        class.or(default_class)
+    } else {
+        None
+    }
+}
+
 /// Map tree-sitter scope to CSS class name.
 pub fn scope_to_class(scope: &str) -> String {
     crate::highlights::HIGHLIGHT_NAMES
@@ -668,11 +693,16 @@ pub fn append_fragment(lines: &mut Vec<String>, fragment: &str) {
 }
 
 /// Escape text for use in HTML span content.
+#[deprecated(note = "use `escape(...)` instead")]
 pub fn escape_fragment(text: &str) -> String {
     escape(text)
 }
 
-fn open_span(attrs: &str) -> String {
+/// Generate an opening `<span>` tag carrying `attrs`, or a bare one when empty.
+///
+/// A scope a theme styles in no way still opens a `<span>`, so every one pairs
+/// with the `</span>` an end event writes.
+pub fn open_span(attrs: &str) -> String {
     if attrs.is_empty() {
         "<span>".to_string()
     } else {
@@ -737,13 +767,13 @@ fn render_source_event<F>(
     loop {
         if let Some(newline_index) = remaining.find('\n') {
             let fragment = &remaining[..newline_index];
-            append_fragment(lines, &escape_fragment(fragment));
+            append_fragment(lines, &escape(fragment));
             close_open_spans(lines, stack.len());
             lines.push(String::new());
             reopen_spans(lines, stack, span_attrs);
             remaining = &remaining[newline_index + 1..];
         } else {
-            append_fragment(lines, &escape_fragment(remaining));
+            append_fragment(lines, &escape(remaining));
             break;
         }
     }
@@ -769,6 +799,11 @@ where
 ///
 /// This is a simplified version of the vendored `HtmlRenderer` that works with
 /// pre-computed `HighlightEvent` slices instead of tree-sitter iterators.
+///
+/// Deprecated: it records line offsets without closing and reopening the spans
+/// that cross a line boundary, so slicing the buffer at them yields lines whose
+/// tags do not nest. [`render_lines_from_events`] does the same job correctly.
+#[deprecated(note = "use `render_lines_from_events(...)` instead")]
 pub fn render_events<T, F>(
     source: &str,
     events: &[crate::events::HighlightEvent<'_, T>],
@@ -837,6 +872,9 @@ where
 }
 
 /// Iterator over rendered HTML lines.
+///
+/// Deprecated: only useful for slicing what [`render_events`] returns.
+#[deprecated(note = "use `render_lines_from_events(...)` instead")]
 pub fn lines_from_offsets<'a>(
     html: &'a [u8],
     line_offsets: &'a [u32],

--- a/crates/lumis-core/src/formatter/html.rs
+++ b/crates/lumis-core/src/formatter/html.rs
@@ -738,9 +738,12 @@ where
                 }
             }
             crate::events::HighlightEvent::Source { start, end } => {
-                let s = (*start).min(source.len());
-                let e = (*end).min(source.len()).max(s);
-                render_source_event(&mut lines, &source[s..e], &stack, &span_attrs);
+                render_source_event(
+                    &mut lines,
+                    source_slice(source, *start, *end),
+                    &stack,
+                    &span_attrs,
+                );
             }
             crate::events::HighlightEvent::AnnotationStart { .. }
             | crate::events::HighlightEvent::AnnotationEnd => {}
@@ -752,6 +755,34 @@ where
     }
 
     lines
+}
+
+/// The largest slice of `source` fully inside `start..end`.
+///
+/// A formatter can build its own events rather than replaying the ones Lumis
+/// handed it, so these offsets are caller data. Out of range is clamped, and an
+/// offset landing inside a multi-byte character moves to the boundary that keeps
+/// the slice smaller, because `&source[start..end]` would otherwise panic on a
+/// range that split one. Reversed offsets give an empty slice.
+fn source_slice(source: &str, start: usize, end: usize) -> &str {
+    let start = ceil_char_boundary(source, start.min(source.len()));
+    let end = floor_char_boundary(source, end.min(source.len())).max(start);
+
+    &source[start..end]
+}
+
+fn floor_char_boundary(source: &str, mut index: usize) -> usize {
+    while index > 0 && !source.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
+}
+
+fn ceil_char_boundary(source: &str, mut index: usize) -> usize {
+    while index < source.len() && !source.is_char_boundary(index) {
+        index += 1;
+    }
+    index
 }
 
 fn render_source_event<F>(
@@ -917,6 +948,33 @@ mod tests {
     #[test]
     fn test_escape_all_entities() {
         assert_eq!(escape("&<>\"'{}"), "&amp;&lt;&gt;&quot;&#39;{}");
+    }
+
+    /// A formatter can build its own events, so a `Source` range is caller data
+    /// and `&source[start..end]` used to panic on one that split a character.
+    #[test]
+    fn test_source_slice_never_panics_on_caller_offsets() {
+        let source = "éx";
+
+        assert_eq!(source_slice(source, 0, 1), "", "end splits 'é'");
+        assert_eq!(source_slice(source, 1, 2), "", "start splits 'é'");
+        assert_eq!(source_slice(source, 1, 3), "x", "start splits 'é'");
+        assert_eq!(source_slice(source, 0, 2), "é");
+        assert_eq!(source_slice(source, 0, 3), "éx");
+        assert_eq!(source_slice(source, 0, 99), "éx", "end past the source");
+        assert_eq!(source_slice(source, 99, 99), "", "start past the source");
+        assert_eq!(source_slice(source, 3, 0), "", "reversed");
+    }
+
+    #[test]
+    fn test_render_lines_from_events_survives_a_split_character() {
+        let events: [crate::events::HighlightEvent<'_>; 1] =
+            [crate::events::HighlightEvent::Source { start: 0, end: 1 }];
+
+        assert_eq!(
+            render_lines_from_events("é", &events, |_, _| String::new()),
+            [""]
+        );
     }
 
     #[test]

--- a/crates/lumis-core/src/formatter/html.rs
+++ b/crates/lumis-core/src/formatter/html.rs
@@ -8,6 +8,77 @@ use std::fmt::Write as _;
 use std::io::{self, Write};
 use std::ops::RangeInclusive;
 
+/// A finite arithmetic progression of 1-based line numbers.
+///
+/// This is public only so language bindings can preserve a source runtime's
+/// stepped-range semantics without expanding the range into one allocation per
+/// selected line. Rust's formatter options continue to use
+/// [`RangeInclusive<usize>`].
+#[doc(hidden)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SteppedLineRange {
+    first: usize,
+    last: usize,
+    step: usize,
+}
+
+impl SteppedLineRange {
+    /// Normalize an ascending or descending stepped range.
+    ///
+    /// Returns `None` for a zero step or when the step points away from the end.
+    #[doc(hidden)]
+    pub fn new(start: usize, end: usize, step: isize) -> Option<Self> {
+        let stride = step.unsigned_abs();
+        if stride == 0 {
+            return None;
+        }
+
+        let (first, last) = if step > 0 {
+            if start > end {
+                return None;
+            }
+            let span = end - start;
+            (start, start + span / stride * stride)
+        } else {
+            if start < end {
+                return None;
+            }
+            let span = start - end;
+            (start - span / stride * stride, start)
+        };
+
+        Some(Self {
+            first,
+            last,
+            step: stride,
+        })
+    }
+
+    /// Whether `line_number` is one of the range's selected lines.
+    #[doc(hidden)]
+    pub fn contains(&self, line_number: usize) -> bool {
+        (self.first..=self.last).contains(&line_number)
+            && (line_number - self.first).is_multiple_of(self.step)
+    }
+
+    fn mark(&self, selected: &mut [bool]) {
+        let mut line = if self.first == 0 {
+            self.step
+        } else {
+            self.first
+        };
+        let last = self.last.min(selected.len());
+
+        while line <= last {
+            selected[line - 1] = true;
+            let Some(next) = line.checked_add(self.step) else {
+                break;
+            };
+            line = next;
+        }
+    }
+}
+
 /// Generate HTML attributes for a span with inline CSS styles.
 pub fn span_inline_attrs(
     language: Option<Language>,
@@ -499,6 +570,48 @@ pub fn line_is_highlighted(lines: &[RangeInclusive<usize>], line_number: usize) 
     lines.iter().any(|range| range.contains(&line_number))
 }
 
+/// Resolve all highlighted lines once before a formatter walks its output.
+///
+/// Ordinary ranges are clamped, sorted, and merged before their slices are
+/// filled. Ordinary ranges therefore cost `O(lines + ranges log ranges)` instead
+/// of being scanned again for every output line. Stepped ranges stay compact and
+/// only visit their selected lines that actually exist in the rendered output.
+pub(crate) fn highlighted_line_flags(
+    lines: &[RangeInclusive<usize>],
+    stepped_lines: &[SteppedLineRange],
+    line_count: usize,
+) -> Vec<bool> {
+    let mut selected = vec![false; line_count];
+    let mut intervals: Vec<(usize, usize)> = lines
+        .iter()
+        .filter_map(|range| {
+            let start = (*range.start()).max(1);
+            let end = (*range.end()).min(line_count);
+            (start <= end).then_some((start, end))
+        })
+        .collect();
+    intervals.sort_unstable();
+
+    let mut intervals = intervals.into_iter();
+    if let Some((mut start, mut end)) = intervals.next() {
+        for (next_start, next_end) in intervals {
+            if next_start <= end.saturating_add(1) {
+                end = end.max(next_end);
+            } else {
+                selected[start - 1..end].fill(true);
+                (start, end) = (next_start, next_end);
+            }
+        }
+        selected[start - 1..end].fill(true);
+    }
+
+    for range in stepped_lines {
+        range.mark(&mut selected);
+    }
+
+    selected
+}
+
 /// The CSS class a highlighted line carries, or `None` when the line is not highlighted.
 ///
 /// `class` wins over `default_class`, so a formatter can offer a caller-supplied
@@ -975,6 +1088,35 @@ mod tests {
             render_lines_from_events("é", &events, |_, _| String::new()),
             [""]
         );
+    }
+
+    #[test]
+    fn stepped_line_ranges_stay_compact_and_clip_to_rendered_lines() {
+        let ascending = SteppedLineRange::new(1, 1_000_000_000, 2).unwrap();
+        let descending = SteppedLineRange::new(1_000_000_000, 1, -3).unwrap();
+        let unaligned_end = SteppedLineRange::new(10, 2, -3).unwrap();
+
+        assert_eq!(
+            highlighted_line_flags(&[], &[ascending], 6),
+            [true, false, true, false, true, false]
+        );
+        assert_eq!(
+            highlighted_line_flags(&[], &[descending], 6),
+            [true, false, false, true, false, false]
+        );
+        assert!(unaligned_end.contains(4));
+        assert!(!unaligned_end.contains(2));
+    }
+
+    #[test]
+    fn highlighted_line_flags_merge_many_native_rust_ranges() {
+        let ranges: Vec<_> = (1..=20_000).step_by(2).map(|line| line..=line).collect();
+        let selected = highlighted_line_flags(&ranges, &[], 20_000);
+
+        assert_eq!(selected.iter().filter(|&&line| line).count(), 10_000);
+        assert!(selected[0]);
+        assert!(!selected[1]);
+        assert!(selected[19_998]);
     }
 
     #[test]

--- a/crates/lumis-core/src/formatter/html_inline.rs
+++ b/crates/lumis-core/src/formatter/html_inline.rs
@@ -102,7 +102,7 @@ impl HtmlInline {
         let is_highlighted = self
             .highlight_lines
             .as_ref()
-            .is_some_and(|hl| hl.lines.iter().any(|r| r.contains(&line_number)));
+            .is_some_and(|hl| crate::formatter::html::line_is_highlighted(&hl.lines, line_number));
 
         if !is_highlighted {
             return (None, None);

--- a/crates/lumis-core/src/formatter/html_inline.rs
+++ b/crates/lumis-core/src/formatter/html_inline.rs
@@ -57,6 +57,8 @@ pub struct HtmlInline {
     italic: bool,
     include_highlights: bool,
     highlight_lines: Option<HighlightLines>,
+    #[builder(setter(skip), default)]
+    stepped_highlight_lines: Vec<crate::formatter::html::SteppedLineRange>,
     header: Option<HtmlElement>,
 }
 
@@ -94,16 +96,21 @@ impl HtmlInline {
             italic,
             include_highlights,
             highlight_lines,
+            stepped_highlight_lines: Vec::new(),
             header,
         }
     }
 
-    fn get_line_attrs(&self, line_number: usize) -> (Option<String>, Option<String>) {
-        let is_highlighted = self
-            .highlight_lines
-            .as_ref()
-            .is_some_and(|hl| crate::formatter::html::line_is_highlighted(&hl.lines, line_number));
+    /// Supply compact stepped ranges from a language binding.
+    #[doc(hidden)]
+    pub fn set_stepped_highlight_lines(
+        &mut self,
+        lines: Vec<crate::formatter::html::SteppedLineRange>,
+    ) {
+        self.stepped_highlight_lines = lines;
+    }
 
+    fn get_line_attrs(&self, is_highlighted: bool) -> (Option<String>, Option<String>) {
         if !is_highlighted {
             return (None, None);
         }
@@ -158,6 +165,7 @@ impl Default for HtmlInline {
             italic: false,
             include_highlights: false,
             highlight_lines: None,
+            stepped_highlight_lines: Vec::new(),
             header: None,
         }
     }
@@ -192,11 +200,21 @@ impl<T> Formatter<T> for HtmlInline {
             events,
             |scope_index, language| self.span_attrs_from_index(scope_index, language),
         );
+        let highlighted_lines = self.highlight_lines.as_ref().map(|highlight| {
+            crate::formatter::html::highlighted_line_flags(
+                &highlight.lines,
+                &self.stepped_highlight_lines,
+                lines.len(),
+            )
+        });
 
         for (i, line) in lines.iter().enumerate() {
             let line_number = i + 1;
             let line_with_newline = format!("{line}\n");
-            let (class_suffix, style) = self.get_line_attrs(line_number);
+            let is_highlighted = highlighted_lines
+                .as_ref()
+                .is_some_and(|selected| selected[i]);
+            let (class_suffix, style) = self.get_line_attrs(is_highlighted);
             let wrapped = crate::formatter::html::wrap_line(
                 line_number,
                 &line_with_newline,

--- a/crates/lumis-core/src/formatter/html_linked.rs
+++ b/crates/lumis-core/src/formatter/html_linked.rs
@@ -41,6 +41,8 @@ pub struct HtmlLinked {
     language: Language,
     pre_class: Option<String>,
     highlight_lines: Option<HighlightLines>,
+    #[builder(setter(skip), default)]
+    stepped_highlight_lines: Vec<crate::formatter::html::SteppedLineRange>,
     header: Option<HtmlElement>,
 }
 
@@ -71,20 +73,28 @@ impl HtmlLinked {
             language,
             pre_class,
             highlight_lines,
+            stepped_highlight_lines: Vec::new(),
             header,
         }
     }
 
-    fn get_line_class_suffix(&self, line_number: usize) -> Option<String> {
-        self.highlight_lines.as_ref().and_then(|hl| {
-            crate::formatter::html::highlight_line_class(
-                &hl.lines,
-                line_number,
-                Some(hl.class.as_str()),
-                None,
-            )
-            .map(|class| format!(" {class}"))
-        })
+    /// Supply compact stepped ranges from a language binding.
+    #[doc(hidden)]
+    pub fn set_stepped_highlight_lines(
+        &mut self,
+        lines: Vec<crate::formatter::html::SteppedLineRange>,
+    ) {
+        self.stepped_highlight_lines = lines;
+    }
+
+    fn get_line_class_suffix(&self, is_highlighted: bool) -> Option<String> {
+        if !is_highlighted {
+            return None;
+        }
+
+        self.highlight_lines
+            .as_ref()
+            .map(|highlight| format!(" {}", highlight.class))
     }
 
     fn span_attrs_from_index(scope_index: usize) -> String {
@@ -102,6 +112,7 @@ impl Default for HtmlLinked {
             language: Language::PlainText,
             pre_class: None,
             highlight_lines: None,
+            stepped_highlight_lines: Vec::new(),
             header: None,
         }
     }
@@ -132,10 +143,20 @@ impl<T> Formatter<T> for HtmlLinked {
             events,
             |scope_index, _language| Self::span_attrs_from_index(scope_index),
         );
+        let highlighted_lines = self.highlight_lines.as_ref().map(|highlight| {
+            crate::formatter::html::highlighted_line_flags(
+                &highlight.lines,
+                &self.stepped_highlight_lines,
+                lines.len(),
+            )
+        });
 
         for (i, line) in lines.iter().enumerate() {
             let line_number = i + 1;
-            let class_suffix = self.get_line_class_suffix(line_number);
+            let is_highlighted = highlighted_lines
+                .as_ref()
+                .is_some_and(|selected| selected[i]);
+            let class_suffix = self.get_line_class_suffix(is_highlighted);
             let line_with_newline = format!("{line}\n");
             let wrapped = crate::formatter::html::wrap_line(
                 line_number,

--- a/crates/lumis-core/src/formatter/html_linked.rs
+++ b/crates/lumis-core/src/formatter/html_linked.rs
@@ -77,11 +77,13 @@ impl HtmlLinked {
 
     fn get_line_class_suffix(&self, line_number: usize) -> Option<String> {
         self.highlight_lines.as_ref().and_then(|hl| {
-            if hl.lines.iter().any(|range| range.contains(&line_number)) {
-                Some(format!(" {}", hl.class))
-            } else {
-                None
-            }
+            crate::formatter::html::highlight_line_class(
+                &hl.lines,
+                line_number,
+                Some(hl.class.as_str()),
+                None,
+            )
+            .map(|class| format!(" {class}"))
         })
     }
 

--- a/crates/lumis-core/src/formatter/html_multi_themes.rs
+++ b/crates/lumis-core/src/formatter/html_multi_themes.rs
@@ -47,6 +47,8 @@ pub struct HtmlMultiThemes {
     italic: bool,
     include_highlights: bool,
     highlight_lines: Option<HighlightLines>,
+    #[builder(setter(skip), default)]
+    stepped_highlight_lines: Vec<crate::formatter::html::SteppedLineRange>,
     header: Option<HtmlElement>,
 }
 
@@ -83,6 +85,7 @@ impl HtmlMultiThemesBuilder {
             italic: self.italic.take().unwrap_or(false),
             include_highlights: self.include_highlights.take().unwrap_or(false),
             highlight_lines: self.highlight_lines.take().flatten(),
+            stepped_highlight_lines: Vec::new(),
             header: self.header.take().flatten(),
         };
 
@@ -152,6 +155,7 @@ impl Default for HtmlMultiThemes {
             italic: false,
             include_highlights: false,
             highlight_lines: None,
+            stepped_highlight_lines: Vec::new(),
             header: None,
         }
     }
@@ -179,8 +183,18 @@ impl HtmlMultiThemes {
             italic,
             include_highlights,
             highlight_lines,
+            stepped_highlight_lines: Vec::new(),
             header,
         }
+    }
+
+    /// Supply compact stepped ranges from a language binding.
+    #[doc(hidden)]
+    pub fn set_stepped_highlight_lines(
+        &mut self,
+        lines: Vec<crate::formatter::html::SteppedLineRange>,
+    ) {
+        self.stepped_highlight_lines = lines;
     }
 
     fn open_pre_tag(&self, output: &mut dyn Write) -> io::Result<()> {
@@ -201,12 +215,7 @@ impl HtmlMultiThemes {
         }
     }
 
-    fn get_line_attrs(&self, line_number: usize) -> (Option<String>, Option<String>) {
-        let is_highlighted = self
-            .highlight_lines
-            .as_ref()
-            .is_some_and(|hl| hl.lines.iter().any(|r| r.contains(&line_number)));
-
+    fn get_line_attrs(&self, is_highlighted: bool) -> (Option<String>, Option<String>) {
         if !is_highlighted {
             return (None, None);
         }
@@ -296,11 +305,21 @@ impl<T> Formatter<T> for HtmlMultiThemes {
             events,
             |scope_index, language| self.span_attrs_from_index(scope_index, language),
         );
+        let highlighted_lines = self.highlight_lines.as_ref().map(|highlight| {
+            crate::formatter::html::highlighted_line_flags(
+                &highlight.lines,
+                &self.stepped_highlight_lines,
+                lines.len(),
+            )
+        });
 
         for (i, line) in lines.iter().enumerate() {
             let line_number = i + 1;
             let line_with_newline = format!("{line}\n");
-            let (class_suffix, style) = self.get_line_attrs(line_number);
+            let is_highlighted = highlighted_lines
+                .as_ref()
+                .is_some_and(|selected| selected[i]);
+            let (class_suffix, style) = self.get_line_attrs(is_highlighted);
             let wrapped = crate::formatter::html::wrap_line(
                 line_number,
                 &line_with_newline,

--- a/crates/lumis/src/formatter/html.rs
+++ b/crates/lumis/src/formatter/html.rs
@@ -11,6 +11,7 @@ use crate::languages::Language;
 use crate::themes::Theme;
 pub use lumis_core::formatter::HtmlElement;
 use std::io::{self, Write};
+use std::ops::RangeInclusive;
 
 /// Generate an HTML `<span>` element with inline CSS styles.
 ///
@@ -539,6 +540,124 @@ pub fn close_pre_tag(output: &mut dyn Write) -> io::Result<()> {
 /// ```
 pub fn closing_tags(output: &mut dyn Write) -> io::Result<()> {
     lumis_core::formatter::html::closing_tags(output)
+}
+
+/// Generate an opening `<span>` tag carrying `attrs`, or a bare one when empty.
+///
+/// A scope a theme styles in no way still opens a `<span>`, so every one pairs
+/// with the `</span>` an end event writes.
+///
+/// # Example
+///
+/// ```rust
+/// use lumis::html;
+///
+/// assert_eq!(html::open_span(&html::span_linked_attrs("keyword")), r#"<span class="l-keyword">"#);
+/// assert_eq!(html::open_span(""), "<span>");
+/// ```
+pub fn open_span(attrs: &str) -> String {
+    lumis_core::formatter::html::open_span(attrs)
+}
+
+/// Whether `line_number` falls inside any of `lines`.
+///
+/// Lines are 1-based, matching the `data-line` attribute [`wrap_line`] writes.
+///
+/// # Example
+///
+/// ```rust
+/// use lumis::html;
+///
+/// assert!(html::line_is_highlighted(&[1..=1, 3..=5], 4));
+/// assert!(!html::line_is_highlighted(&[1..=1, 3..=5], 2));
+/// ```
+pub fn line_is_highlighted(lines: &[RangeInclusive<usize>], line_number: usize) -> bool {
+    lumis_core::formatter::html::line_is_highlighted(lines, line_number)
+}
+
+/// The CSS class a highlighted line carries, or `None` when the line is not highlighted.
+///
+/// `class` wins over `default_class`, so a formatter can offer a caller-supplied
+/// class over its own.
+///
+/// # Example
+///
+/// ```rust
+/// use lumis::html;
+///
+/// let lines = [1..=1, 3..=5];
+/// assert_eq!(html::highlight_line_class(&lines, 4, None, Some("l-highlighted")), Some("l-highlighted"));
+/// assert_eq!(html::highlight_line_class(&lines, 4, Some("active"), Some("l-highlighted")), Some("active"));
+/// assert_eq!(html::highlight_line_class(&lines, 2, Some("active"), None), None);
+/// ```
+pub fn highlight_line_class<'a>(
+    lines: &[RangeInclusive<usize>],
+    line_number: usize,
+    class: Option<&'a str>,
+    default_class: Option<&'a str>,
+) -> Option<&'a str> {
+    lumis_core::formatter::html::highlight_line_class(lines, line_number, class, default_class)
+}
+
+/// Split a fragment across lines, appending to the current line and starting new ones at `\n`.
+///
+/// The line buffer [`render_lines_from_events`] fills, exposed for a formatter
+/// that fills its own.
+///
+/// # Example
+///
+/// ```rust
+/// use lumis::html;
+///
+/// let mut lines = vec![String::from("hello")];
+/// html::append_fragment(&mut lines, " world\nnew line");
+/// assert_eq!(lines, ["hello world", "new line"]);
+/// ```
+pub fn append_fragment(lines: &mut Vec<String>, fragment: &str) {
+    lumis_core::formatter::html::append_fragment(lines, fragment);
+}
+
+/// Render highlight events into HTML lines, reopening active spans at line boundaries.
+///
+/// A span that crosses a newline is closed at the end of one line and reopened at
+/// the start of the next, so every line's tags nest on their own. `span_attrs`
+/// receives a scope index into [`highlights::HIGHLIGHT_NAMES`](crate::highlights::HIGHLIGHT_NAMES)
+/// and the language of the block the event came from.
+///
+/// # Example
+///
+/// ```rust
+/// use lumis::{events::HighlightEvent, highlights::HIGHLIGHT_NAMES, html};
+///
+/// let source = "a\nb";
+/// let keyword = HIGHLIGHT_NAMES.iter().position(|&s| s == "keyword").unwrap();
+/// let events: Vec<HighlightEvent<'_>> = vec![
+///     HighlightEvent::Start { scope_index: keyword, language: "rust".to_string() },
+///     HighlightEvent::Source { start: 0, end: source.len() },
+///     HighlightEvent::End,
+/// ];
+///
+/// let lines = html::render_lines_from_events(source, &events, |scope_index, _language| {
+///     html::span_linked_attrs(HIGHLIGHT_NAMES[scope_index])
+/// });
+///
+/// assert_eq!(
+///     lines,
+///     [
+///         r#"<span class="l-keyword">a</span>"#,
+///         r#"<span class="l-keyword">b</span>"#,
+///     ]
+/// );
+/// ```
+pub fn render_lines_from_events<T, F>(
+    source: &str,
+    events: &[lumis_core::events::HighlightEvent<'_, T>],
+    span_attrs: F,
+) -> Vec<String>
+where
+    F: Fn(usize, &str) -> String,
+{
+    lumis_core::formatter::html::render_lines_from_events(source, events, span_attrs)
 }
 
 #[cfg(test)]

--- a/crates/lumis/tests/formatter_helpers.rs
+++ b/crates/lumis/tests/formatter_helpers.rs
@@ -1,0 +1,435 @@
+//! Rust's half of the cross-runtime formatter helper check.
+//!
+//! `fixtures/formatter-helpers.json` lists the helper capabilities every runtime
+//! must offer a custom formatter. Rust cannot reflect on a module at run time, so
+//! the check has four parts:
+//!
+//! - `every_manifest_helper_is_callable` calls every helper by name. A helper
+//!   added to the manifest that Rust lacks fails to **compile**.
+//! - `manifest_matches_the_helpers_exercised_here` reads the manifest and
+//!   requires it to name exactly the helpers exercised above.
+//! - `every_public_helper_is_accounted_for` parses the helper modules and fails
+//!   on a `pub fn` that is in neither the canonical set, `runtime_only`, nor
+//!   `deprecated`. This is the one that catches drift: a helper added to Rust
+//!   and nowhere else has to be classified before it can ship.
+//! - `deprecated_helpers_carry_the_attribute` requires every manifest deprecation
+//!   to be a real `#[deprecated]`, so the JSON cannot claim one that is not there.
+//!
+//! Gated on `lang-rust` because some helpers take a `Language`, and the catalog
+//! is feature-gated.
+#![cfg(feature = "lang-rust")]
+#![allow(deprecated)]
+
+use lumis::events::HighlightEvent;
+use lumis::highlights::HIGHLIGHT_NAMES;
+use lumis::themes::{Style, TextDecoration, Theme};
+use lumis::{ansi, html, languages::Language, themes};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+use syn::{Item, Meta};
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    modules: BTreeMap<String, ModuleEntry>,
+    runtime_only: BTreeMap<String, serde_json::Value>,
+    deprecated: BTreeMap<String, serde_json::Value>,
+    waived: BTreeMap<String, serde_json::Value>,
+}
+
+impl Manifest {
+    /// The helpers `module` deprecates for `runtime`. `$comment` keys, whose
+    /// values are arrays of prose rather than entries, are skipped.
+    fn deprecated_names(&self, module: &str, runtime: &str) -> BTreeSet<String> {
+        self.deprecated
+            .get(module)
+            .and_then(serde_json::Value::as_object)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter(|(name, _)| !name.starts_with('$'))
+                    .filter(|(_, entry)| {
+                        entry["runtimes"]
+                            .as_array()
+                            .expect("a deprecation lists its runtimes")
+                            .iter()
+                            .any(|value| value == runtime)
+                    })
+                    .map(|(name, _)| name.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ModuleEntry {
+    helpers: Vec<HelperEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HelperEntry {
+    name: String,
+    #[serde(default)]
+    spelling: BTreeMap<String, String>,
+}
+
+impl HelperEntry {
+    /// The name Rust spells this capability, which is the canonical one unless
+    /// the manifest overrides it. An override containing `::` names a home
+    /// outside the helper module.
+    fn rust_name(&self) -> &str {
+        self.spelling
+            .get("rust")
+            .map_or(self.name.as_str(), String::as_str)
+    }
+}
+
+fn manifest() -> Manifest {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fixtures/formatter-helpers.json")
+        .canonicalize()
+        .expect("formatter-helpers.json is reachable");
+    serde_json::from_str(&fs::read_to_string(path).expect("read formatter-helpers.json"))
+        .expect("parse formatter-helpers.json")
+}
+
+fn theme() -> Theme {
+    themes::get("dracula").expect("dracula is built in")
+}
+
+fn theme_map() -> HashMap<String, Theme> {
+    let mut themes = HashMap::new();
+    themes.insert("light".to_string(), themes::get("github_light").unwrap());
+    themes.insert("dark".to_string(), theme());
+    themes
+}
+
+fn keyword_index() -> usize {
+    HIGHLIGHT_NAMES
+        .iter()
+        .position(|&scope| scope == "keyword")
+        .expect("keyword is a highlight scope")
+}
+
+/// Every helper in the manifest, called once. Adding a helper to the manifest
+/// without adding it here fails `manifest_matches_the_helpers_exercised_here`;
+/// adding it here without a Rust function fails to compile.
+fn exercised_helpers() -> BTreeMap<&'static str, BTreeSet<&'static str>> {
+    let theme = theme();
+    let themes = theme_map();
+    let style = theme.get_style("keyword").expect("dracula styles keyword");
+    let mut output = Vec::new();
+
+    html::escape("<b>");
+    html::escape_attr(r#"x"><script>"#);
+    html::escape_braces("{}");
+    html::scope_to_class("keyword");
+    Style::css(style, false, " ");
+    html::text_decoration(&TextDecoration::default());
+    html::sanitize_theme_name("catppuccin mocha");
+    html::open_span(&html::span_linked_attrs("keyword"));
+    html::span_inline_attrs(Some(Language::Rust), "keyword", Some(&theme), false, false);
+    html::span_inline(
+        "fn",
+        Some(Language::Rust),
+        "keyword",
+        Some(&theme),
+        false,
+        false,
+    );
+    html::span_linked_attrs("keyword");
+    html::span_linked("fn", "keyword");
+    html::span_multi_themes_attrs(
+        "keyword",
+        None,
+        &themes,
+        Some("light"),
+        "--lumis",
+        false,
+        false,
+    );
+    html::span_multi_themes(
+        "fn",
+        "keyword",
+        None,
+        &themes,
+        Some("light"),
+        "--lumis",
+        false,
+        false,
+    );
+    html::open_pre_tag(&mut output, Some("code"), Some(&theme)).unwrap();
+    html::open_multi_themes_pre_tag(&mut output, Some("code"), &themes, Some("light"), "--lumis")
+        .unwrap();
+    html::open_code_tag(&mut output, &Language::Rust).unwrap();
+    html::close_pre_tag(&mut output).unwrap();
+    html::close_code_tag(&mut output).unwrap();
+    html::closing_tags(&mut output).unwrap();
+    html::wrap_line(1, "code", None, None);
+    let highlighted = [1..=1, 3..=5];
+    html::line_is_highlighted(&highlighted, 1);
+    html::highlight_line_class(&highlighted, 1, None, Some("l-highlighted"));
+
+    let events: [HighlightEvent<'_>; 3] = [
+        HighlightEvent::Start {
+            scope_index: keyword_index(),
+            language: "rust".to_string(),
+        },
+        HighlightEvent::Source { start: 0, end: 3 },
+        HighlightEvent::End,
+    ];
+    html::render_lines_from_events("a\nb", &events, |scope_index, _language| {
+        html::span_linked_attrs(HIGHLIGHT_NAMES[scope_index])
+    });
+
+    ansi::hex_to_rgb("#ff79c6");
+    ansi::rgb_to_ansi(255, 121, 198, false);
+    ansi::style_to_ansi(style);
+    ansi::paint("fn", style);
+    let _ = ansi::ANSI_RESET;
+
+    [
+        (
+            "html",
+            BTreeSet::from([
+                "escape",
+                "escape_attr",
+                "escape_braces",
+                "scope_to_class",
+                "themes::Style::css",
+                "text_decoration",
+                "sanitize_theme_name",
+                "open_span",
+                "span_inline_attrs",
+                "span_inline",
+                "span_linked_attrs",
+                "span_linked",
+                "span_multi_themes_attrs",
+                "span_multi_themes",
+                "open_pre_tag",
+                "open_multi_themes_pre_tag",
+                "open_code_tag",
+                "close_pre_tag",
+                "close_code_tag",
+                "closing_tags",
+                "wrap_line",
+                "line_is_highlighted",
+                "highlight_line_class",
+                "render_lines_from_events",
+            ]),
+        ),
+        (
+            "ansi",
+            BTreeSet::from([
+                "hex_to_rgb",
+                "rgb_to_ansi",
+                "style_to_ansi",
+                "paint",
+                "ANSI_RESET",
+            ]),
+        ),
+    ]
+    .into()
+}
+
+/// Every `pub fn` in a helper module, and whether it carries `#[deprecated]`.
+///
+/// `lumis::html` and `lumis::ansi` are the published surface, and
+/// `lumis_core::formatter::{html,ansi}` is what they wrap; a helper in either is
+/// public, so both are read.
+fn public_helpers(module: &str) -> BTreeMap<String, bool> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let sources = [
+        manifest_dir.join(format!("src/formatter/{module}.rs")),
+        manifest_dir.join(format!("../lumis-core/src/formatter/{module}.rs")),
+    ];
+
+    let mut helpers = BTreeMap::new();
+    for path in &sources {
+        collect_public_helpers(path, &mut helpers);
+    }
+
+    assert!(
+        helpers.len() > 5,
+        "{module}: source scan found almost nothing: {} helpers",
+        helpers.len()
+    );
+
+    helpers
+}
+
+fn collect_public_helpers(path: &Path, helpers: &mut BTreeMap<String, bool>) {
+    let source =
+        fs::read_to_string(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    let syntax = syn::parse_file(&source)
+        .unwrap_or_else(|error| panic!("parse {}: {error}", path.display()));
+
+    for item in &syntax.items {
+        let (name, attrs, visibility) = match item {
+            Item::Fn(item) => (item.sig.ident.to_string(), &item.attrs, &item.vis),
+            Item::Const(item) => (item.ident.to_string(), &item.attrs, &item.vis),
+            _ => continue,
+        };
+
+        if !matches!(visibility, syn::Visibility::Public(_)) {
+            continue;
+        }
+
+        let deprecated = attrs.iter().any(|attr| match &attr.meta {
+            Meta::Path(path) | Meta::List(syn::MetaList { path, .. }) => {
+                path.is_ident("deprecated")
+            }
+            Meta::NameValue(_) => false,
+        });
+
+        // A helper wrapped by `lumis` and defined in `lumis-core` is one helper;
+        // deprecating it in either place deprecates it.
+        helpers
+            .entry(name)
+            .and_modify(|already| *already |= deprecated)
+            .or_insert(deprecated);
+    }
+}
+
+#[test]
+fn every_manifest_helper_is_callable() {
+    // The helpers run here; reaching this line means they all exist and build.
+    let exercised = exercised_helpers();
+    assert_eq!(exercised.len(), 2, "both helper modules are covered");
+}
+
+#[test]
+fn manifest_matches_the_helpers_exercised_here() {
+    let manifest = manifest();
+    let exercised = exercised_helpers();
+
+    assert_eq!(
+        manifest.modules.keys().collect::<Vec<_>>(),
+        exercised.keys().collect::<Vec<_>>(),
+        "manifest and Rust disagree about which helper modules exist"
+    );
+
+    for (module, entry) in &manifest.modules {
+        let expected: BTreeSet<&str> = entry.helpers.iter().map(HelperEntry::rust_name).collect();
+        assert_eq!(
+            &expected,
+            &exercised[module.as_str()],
+            "{module}: manifest helpers and the Rust functions exercised here disagree"
+        );
+    }
+}
+
+#[test]
+fn every_public_helper_is_accounted_for() {
+    let manifest = manifest();
+
+    for (module, entry) in &manifest.modules {
+        let canonical: BTreeSet<String> = entry
+            .helpers
+            .iter()
+            .map(|helper| {
+                // A spelling naming a home outside the module is checked by the
+                // call above, not by the scan.
+                helper
+                    .rust_name()
+                    .rsplit("::")
+                    .next()
+                    .expect("non-empty name")
+                    .to_string()
+            })
+            .collect();
+
+        let runtime_only = names_under(&manifest.runtime_only, "rust", module);
+        let deprecated = manifest.deprecated_names(module, "rust");
+
+        let public = public_helpers(module);
+        let unaccounted: Vec<&String> = public
+            .keys()
+            .filter(|name| {
+                !canonical.contains(*name)
+                    && !runtime_only.contains(*name)
+                    && !deprecated.contains(*name)
+            })
+            .collect();
+
+        assert!(
+            unaccounted.is_empty(),
+            "{module}: public helpers in neither the manifest's helper set, runtime_only, \
+             nor deprecated: {unaccounted:?}. Add them to fixtures/formatter-helpers.json \
+             and to the other runtimes, or classify them."
+        );
+    }
+}
+
+#[test]
+fn deprecated_helpers_carry_the_attribute() {
+    let manifest = manifest();
+
+    for module in manifest.modules.keys() {
+        let public = public_helpers(module);
+
+        for name in manifest.deprecated_names(module, "rust") {
+            let deprecated = public.get(&name).unwrap_or_else(|| {
+                panic!("{module}: the manifest deprecates {name}, which Rust does not export")
+            });
+
+            assert!(
+                *deprecated,
+                "{module}: the manifest deprecates {name}, but Rust does not mark it #[deprecated]"
+            );
+        }
+    }
+}
+
+#[test]
+fn every_runtime_only_helper_still_exists() {
+    let manifest = manifest();
+
+    for module in manifest.modules.keys() {
+        let public = public_helpers(module);
+
+        for name in names_under(&manifest.runtime_only, "rust", module) {
+            assert!(
+                public.contains_key(&name),
+                "{module}: runtime_only lists {name}, which Rust no longer exports; \
+                 drop the entry"
+            );
+        }
+    }
+}
+
+#[test]
+fn no_waiver_outlives_its_reason() {
+    let manifest = manifest();
+    let waivers: Vec<&String> = manifest
+        .waived
+        .keys()
+        .filter(|key| !key.starts_with('$'))
+        .collect();
+
+    assert!(
+        waivers.is_empty(),
+        "every runtime offers every capability; drop these waivers: {waivers:?}"
+    );
+}
+
+fn names_under(
+    section: &BTreeMap<String, serde_json::Value>,
+    runtime: &str,
+    module: &str,
+) -> BTreeSet<String> {
+    section
+        .get(runtime)
+        .and_then(|runtime| runtime.get(module))
+        .and_then(serde_json::Value::as_object)
+        .map(|names| {
+            names
+                .keys()
+                .filter(|name| !name.starts_with('$'))
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/crates/lumis/tests/formatter_options.rs
+++ b/crates/lumis/tests/formatter_options.rs
@@ -112,6 +112,7 @@ fn formatter_struct_fields() -> BTreeMap<String, BTreeSet<String>> {
                 fields
                     .named
                     .iter()
+                    .filter(|field| !builder_skips_setter(field))
                     .map(|field| field.ident.as_ref().expect("named field").to_string())
                     .collect(),
             );
@@ -125,6 +126,34 @@ fn formatter_struct_fields() -> BTreeMap<String, BTreeSet<String>> {
     );
 
     structs
+}
+
+/// A formatter may keep derived rendering state that is deliberately absent
+/// from its builder. Such a field is not a formatter option and must not enter
+/// the cross-runtime option manifest.
+fn builder_skips_setter(field: &syn::Field) -> bool {
+    let mut skips_setter = false;
+
+    for attr in &field.attrs {
+        if !attr.path().is_ident("builder") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("setter") {
+                meta.parse_nested_meta(|setter| {
+                    if setter.path.is_ident("skip") {
+                        skips_setter = true;
+                    }
+                    Ok(())
+                })?;
+            }
+            Ok(())
+        })
+        .expect("parse builder attribute");
+    }
+
+    skips_setter
 }
 
 /// The struct behind each manifest formatter. `BBCodeScoped` does not

--- a/docs/content/usage/custom-formatters.mdx
+++ b/docs/content/usage/custom-formatters.mdx
@@ -205,6 +205,47 @@ Lumis.highlight!("defmodule App do\nend",
 `render/3` returns iodata, so there is no need to flatten it into a binary;
 Lumis does that once at the end.
 
+For line-based output, reach for `render_lines_from_events/3` rather than
+splitting rendered markup on newlines. A `<span>` that crosses a newline has to
+be closed and reopened for each line's tags to nest. Swapping `span_attrs/1` for
+`span_multi_themes_attrs/1` is the whole difference between one theme and a set
+of them, restyled later by CSS alone:
+
+```elixir
+defmodule MultiThemeFormatter do
+  @behaviour Lumis.Formatter
+
+  alias Lumis.Formatter.HTML
+
+  @themes [light: "github_light", dark: "dracula"]
+
+  @impl true
+  def render(source, events, options) do
+    language = Keyword.fetch!(options, :language)
+    attrs = HTML.span_multi_themes_attrs(themes: @themes, default_theme: "light-dark()", language: language)
+
+    body =
+      source
+      |> HTML.render_lines_from_events(events, attrs)
+      |> Enum.with_index(1)
+      # A rendered line carries no trailing newline. The built-in formatters put
+      # one inside the <div> so the block still copies as lines.
+      |> Enum.map(fn {line, number} -> HTML.wrap_line(number, [line, "\n"]) end)
+
+    [
+      HTML.open_multi_themes_pre_tag(themes: @themes, default_theme: "light-dark()"),
+      HTML.open_code_tag(language),
+      body,
+      HTML.closing_tags()
+    ]
+  end
+end
+
+Lumis.highlight!("defmodule App do\nend",
+  formatter: {MultiThemeFormatter, language: "elixir"}
+)
+```
+
 `Lumis.Formatter.ANSI` is the terminal counterpart, and `styles/1` is where a
 scope becomes a color. Reach for it rather than `theme.highlights`, which misses
 the fallbacks `:terminal` applies: `tag.delimiter` is painted by `tag` in a theme
@@ -342,6 +383,11 @@ name JavaScript's event carries directly.
 
 ## Available helpers
 
+Every runtime offers the same set, so a formatter written against one can be
+ported to another without reimplementing a piece of it. Names follow each
+language's convention — `scope_to_class` in Rust and Elixir, `scopeToClass` in
+JavaScript — and so do argument shapes.
+
 | Runtime | Module | Reference |
 | --- | --- | --- |
 | JavaScript | `@lumis-sh/lumis/formatters/html` | [source](https://github.com/leandrocp/lumis/blob/main/packages/javascript/lumis/src/formatter/html.ts) |
@@ -350,6 +396,33 @@ name JavaScript's event carries directly.
 | Rust | `lumis::formatters::ansi` | [docs.rs](https://docs.rs/lumis/latest/lumis/formatters/ansi/index.html) |
 | Elixir | `Lumis.Formatter.HTML` | [hexdocs](https://hexdocs.pm/lumis/Lumis.Formatter.HTML.html) |
 | Elixir | `Lumis.Formatter.ANSI` | [hexdocs](https://hexdocs.pm/lumis/Lumis.Formatter.ANSI.html) |
+
+### HTML
+
+| Capability | Helper |
+| --- | --- |
+| Escape text, an attribute value, or braces a template would read | `escape`, `escape_attr`, `escape_braces` |
+| Resolve a scope to a CSS class, or a style to CSS declarations | `scope_to_class`, `style_to_css`, `text_decoration` |
+| Open a `<span>` for a scope | `open_span`, `span_inline_attrs`, `span_inline`, `span_linked_attrs`, `span_linked` |
+| Open one for a set of themes, as CSS custom properties | `span_multi_themes_attrs`, `span_multi_themes`, `sanitize_theme_name` |
+| Open and close the block | `open_pre_tag`, `open_multi_themes_pre_tag`, `open_code_tag`, `close_pre_tag`, `close_code_tag`, `closing_tags` |
+| Wrap a line, and decide whether it is highlighted | `wrap_line`, `line_is_highlighted`, `highlight_line_class` |
+| Turn the whole event stream into lines, reopening spans across newlines | `render_lines_from_events` |
+
+### ANSI
+
+| Capability | Helper |
+| --- | --- |
+| Build a color escape | `hex_to_rgb`, `rgb_to_ansi`, `style_to_ansi` |
+| Paint text, and clear formatting | `paint`, `reset` |
+
+A few helpers are one runtime's alone, because the boundary dictates the
+signature rather than taste. Elixir returns whole scope tables from `classes/0`,
+`span_attrs/1` and `ANSI.styles/1`, because crossing into Rust once per token to
+read a constant costs more than the highlighting; JavaScript exports
+`encodeSource` and `decodeSourceSlice`, because its strings are UTF-16 and the
+event offsets are UTF-8 byte offsets. `fixtures/formatter-helpers.json` records
+the set, the exceptions, and why each one is one.
 
 ## Tip
 

--- a/fixtures/formatter-helpers.json
+++ b/fixtures/formatter-helpers.json
@@ -1,0 +1,194 @@
+{
+  "$comment": [
+    "The formatter helper surface every runtime must present.",
+    "",
+    "`formatter-options.json` pins what the built-in formatters ACCEPT. This pins",
+    "what a CUSTOM formatter can be built from, which nothing else checked: the",
+    "three helper modules drifted to 46 names between them with 11 in all three,",
+    "so a formatter written against one runtime could not be ported to another",
+    "(#1381). Options were pinned and helpers were not, which is why it was",
+    "silent.",
+    "",
+    "`name` is the canonical snake_case capability. Rust and Elixir spell it",
+    "verbatim, JavaScript camelCases it. `spelling` records the exceptions, and a",
+    "spelling with `::` or `.` in it names a home outside the helper module.",
+    "",
+    "A capability is a thing a formatter can do, not a signature. Runtimes keep",
+    "their own argument shapes: Elixir hands back a whole scope table because the",
+    "NIF boundary is not free, JavaScript takes an attribute object where Rust",
+    "takes a rendered string. Only the capability has to exist everywhere.",
+    "",
+    "Adding a helper means adding it here first, then watching the three local",
+    "implementations go red. `runtime_only` and `deprecated` are the two escape",
+    "hatches and both are checked, so neither can grow quietly."
+  ],
+  "modules": {
+    "html": {
+      "$comment": [
+        "`lumis::html` (re-exporting `lumis_core::formatter::html`),",
+        "`@lumis-sh/lumis/formatters/html`, and `Lumis.Formatter.HTML`."
+      ],
+      "helpers": [
+        { "name": "escape" },
+        { "name": "escape_attr" },
+        { "name": "escape_braces" },
+        { "name": "scope_to_class" },
+        { "name": "style_to_css", "spelling": { "rust": "themes::Style::css" } },
+        { "name": "text_decoration" },
+        { "name": "sanitize_theme_name" },
+        { "name": "open_span", "spelling": { "javascript": "openSpanTag" } },
+        { "name": "span_inline_attrs" },
+        { "name": "span_inline" },
+        { "name": "span_linked_attrs" },
+        { "name": "span_linked" },
+        { "name": "span_multi_themes_attrs" },
+        { "name": "span_multi_themes" },
+        { "name": "open_pre_tag" },
+        { "name": "open_multi_themes_pre_tag" },
+        { "name": "open_code_tag" },
+        { "name": "close_pre_tag" },
+        { "name": "close_code_tag" },
+        { "name": "closing_tags" },
+        { "name": "wrap_line" },
+        { "name": "line_is_highlighted" },
+        { "name": "highlight_line_class", "spelling": { "javascript": "getHighlightLineClass" } },
+        { "name": "render_lines_from_events" }
+      ]
+    },
+    "ansi": {
+      "$comment": [
+        "`lumis::ansi` (re-exporting `lumis_core::formatter::ansi`),",
+        "`@lumis-sh/lumis/formatters/ansi`, and `Lumis.Formatter.ANSI`."
+      ],
+      "helpers": [
+        { "name": "hex_to_rgb" },
+        { "name": "rgb_to_ansi" },
+        { "name": "style_to_ansi" },
+        { "name": "paint" },
+        {
+          "name": "reset",
+          "spelling": { "rust": "ANSI_RESET", "javascript": "ANSI_RESET" }
+        }
+      ]
+    }
+  },
+  "runtime_only": {
+    "$comment": [
+      "Helpers one runtime publishes and the others should not, because the",
+      "boundary dictates the signature rather than taste. Each entry says why,",
+      "and the tests fail on a name here that the runtime no longer exports, so",
+      "the list cannot outlive its reasons."
+    ],
+    "rust": {
+      "html": {
+        "append_fragment": "Splits a fragment across a `&mut Vec<String>` line buffer. JavaScript exposes the same mutable-array shape; Elixir's line buffer is immutable, so it takes `render_lines_from_events` whole instead."
+      }
+    },
+    "javascript": {
+      "html": {
+        "appendFragment": "See `append_fragment` under rust.",
+        "encodeSource": "JavaScript strings are UTF-16 and the event offsets are UTF-8 byte offsets, so a port has to encode before it can slice. Rust and Elixir index bytes already.",
+        "decodeSourceSlice": "See `encodeSource`.",
+        "sortedThemeNames": "`Array.prototype.sort` orders by UTF-16 code unit and Rust orders `&str` by UTF-8 byte, so the two disagree on astral characters. Rust keeps its counterpart private; JavaScript exports it for the multi-themes formatter next door.",
+        "formatHighlightIterLines": "The callback-shaped renderer `renderLinesFromEvents` is built on. Rust's equivalent is a set of private functions.",
+        "getThemeStyle": "Scope resolution, which walks a scope up to its parent and consults the rainbow-bracket fallbacks. Rust reaches it as `Theme::get_style`, a method on the theme; Elixir gets every answer at once from `span_attrs/1`, because resolving per token would cross the NIF boundary per token.",
+        "getScopedThemeStyle": "See `getThemeStyle`.",
+        "wrapWithHeader": "Concatenates three strings. JavaScript's formatters build strings; Rust's write to a `dyn Write` and Elixir's return iodata, so neither needs a function for it."
+      }
+    },
+    "elixir": {
+      "html": {
+        "classes": "The whole scope-to-class table. `scope_to_class` is a lookup into two generated 293-row tables, and crossing the NIF boundary per token to read a constant costs more than the highlighting.",
+        "span_attrs": "The whole scope-to-attributes table, for the same reason as `classes`. `span_multi_themes_attrs/1` is the multi-theme counterpart and is table-shaped for the same reason, which is why it is not listed here."
+      },
+      "ansi": {
+        "styles": "The whole scope-to-style table, for the same reason as `classes` under html.",
+        "style_for": "Reads a scope out of a `styles/1` table."
+      }
+    }
+  },
+  "deprecated": {
+    "$comment": [
+      "Helpers that were public before the set above was agreed and are on their",
+      "way out. Each is still exported, so the tests require it to be present AND",
+      "marked deprecated in every runtime that has it. Nothing may be added here",
+      "without a replacement named in `use`."
+    ],
+    "html": {
+      "escape_fragment": {
+        "use": "escape",
+        "reason": "A pure alias of `escape` in both runtimes that have it. Elixir never grew one.",
+        "runtimes": ["rust", "javascript"]
+      },
+      "render_events": {
+        "use": "render_lines_from_events",
+        "reason": "A simplified copy of the vendored `HtmlRenderer` that never reopens spans at a line boundary, so its lines do not nest. No caller in this repository. `render_lines_from_events` does the same job correctly.",
+        "runtimes": ["rust", "javascript"]
+      },
+      "lines_from_offsets": {
+        "use": "render_lines_from_events",
+        "reason": "Only useful for slicing what `render_events` returns.",
+        "runtimes": ["rust", "javascript"]
+      },
+      "openTag": {
+        "use": "openPreTag, openCodeTag, openSpanTag",
+        "reason": "Generic tag plumbing that Rust and Elixir do inline. Exported from a public subpath by accident.",
+        "runtimes": ["javascript"]
+      },
+      "closeTag": {
+        "use": "closePreTag, closeCodeTag, closingTags",
+        "reason": "See `openTag`.",
+        "runtimes": ["javascript"]
+      },
+      "attrsToString": {
+        "use": "openSpanTag",
+        "reason": "See `openTag`.",
+        "runtimes": ["javascript"]
+      },
+      "joinClasses": {
+        "use": "",
+        "reason": "See `openTag`. Filtering and joining a list of class names is not Lumis's to own.",
+        "runtimes": ["javascript"]
+      },
+      "renderHtmlBlock": {
+        "use": "openPreTag, openCodeTag, wrapLine, closingTags",
+        "reason": "Composes the four helpers above in one fixed order, which is the built-in formatters' shape rather than a custom formatter's. No caller in this repository.",
+        "runtimes": ["javascript"]
+      },
+      "buildPreThemeStyle": {
+        "use": "openMultiThemesPreTag",
+        "reason": "Multi-themes `<pre>` plumbing that Rust keeps private. The copy in `html-multi-themes.ts` is the one the formatter actually calls; this one has no caller.",
+        "runtimes": ["javascript"]
+      },
+      "buildNormalThemeVars": {
+        "use": "openMultiThemesPreTag",
+        "reason": "See `buildPreThemeStyle`.",
+        "runtimes": ["javascript"]
+      },
+      "appendThemeCssVars": {
+        "use": "spanMultiThemesAttrs",
+        "reason": "Multi-themes span plumbing that Rust keeps private. No caller in this repository.",
+        "runtimes": ["javascript"]
+      }
+    },
+    "ansi": {
+      "wrap_with_ansi": {
+        "use": "paint",
+        "reason": "An alias of `paint`.",
+        "runtimes": ["rust", "javascript"]
+      },
+      "highlight_iter_with_ansi": {
+        "use": "highlight_iter with paint",
+        "reason": "Collects every segment into a `Vec` before yielding the first, which is what the callback form avoids.",
+        "runtimes": ["rust", "javascript"]
+      }
+    }
+  },
+  "waived": {
+    "$comment": [
+      "Capabilities a runtime genuinely cannot offer, keyed by runtime then",
+      "module. Empty, and the tests fail on an entry that is no longer needed, so",
+      "it can only shrink."
+    ]
+  }
+}

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -732,11 +732,7 @@ defmodule Lumis do
         {:ok, opts}
 
       hl ->
-        lines =
-          Enum.map(hl[:lines] || [], fn
-            %Range{} = range -> {:range, %{start: range.first, end: range.last}}
-            n when is_integer(n) -> {:single, n}
-          end)
+        lines = Lumis.LineSpec.encode(hl[:lines] || [])
 
         style =
           case hl[:style] do
@@ -765,11 +761,7 @@ defmodule Lumis do
         {:ok, opts}
 
       hl ->
-        lines =
-          Enum.map(hl[:lines] || [], fn
-            %Range{} = range -> {:range, %{start: range.first, end: range.last}}
-            n when is_integer(n) -> {:single, n}
-          end)
+        lines = Lumis.LineSpec.encode(hl[:lines] || [])
 
         class = hl[:class] || "l-highlighted"
 

--- a/packages/elixir/lumis/lib/lumis.ex
+++ b/packages/elixir/lumis/lib/lumis.ex
@@ -732,27 +732,26 @@ defmodule Lumis do
         {:ok, opts}
 
       hl ->
-        lines = Lumis.LineSpec.encode(hl[:lines] || [])
-
-        style =
-          case hl[:style] do
-            :theme -> :theme
-            str when is_binary(str) -> {:style, %{style: str}}
-            nil -> nil
-            _ -> :theme
-          end
-
-        class = hl[:class]
-
-        opts
-        |> Keyword.put(:highlight_lines, %Lumis.HTMLInlineHighlightLines{
-          lines: lines,
-          style: style,
-          class: class
-        })
-        |> then(&{:ok, &1})
+        put_inline_highlight_lines(opts, hl)
     end
   end
+
+  defp put_inline_highlight_lines(opts, hl) do
+    with {:ok, lines} <- Lumis.LineSpec.encode(hl[:lines] || []) do
+      opts
+      |> Keyword.put(:highlight_lines, %Lumis.HTMLInlineHighlightLines{
+        lines: lines,
+        style: inline_highlight_style(hl[:style]),
+        class: hl[:class]
+      })
+      |> then(&{:ok, &1})
+    end
+  end
+
+  defp inline_highlight_style(:theme), do: :theme
+  defp inline_highlight_style(style) when is_binary(style), do: {:style, %{style: style}}
+  defp inline_highlight_style(nil), do: nil
+  defp inline_highlight_style(_other), do: :theme
 
   @doc false
   defp convert_highlight_lines_linked(opts) do
@@ -761,16 +760,16 @@ defmodule Lumis do
         {:ok, opts}
 
       hl ->
-        lines = Lumis.LineSpec.encode(hl[:lines] || [])
+        with {:ok, lines} <- Lumis.LineSpec.encode(hl[:lines] || []) do
+          class = hl[:class] || "l-highlighted"
 
-        class = hl[:class] || "l-highlighted"
-
-        opts
-        |> Keyword.put(:highlight_lines, %Lumis.HTMLLinkedHighlightLines{
-          lines: lines,
-          class: class
-        })
-        |> then(&{:ok, &1})
+          opts
+          |> Keyword.put(:highlight_lines, %Lumis.HTMLLinkedHighlightLines{
+            lines: lines,
+            class: class
+          })
+          |> then(&{:ok, &1})
+        end
     end
   end
 

--- a/packages/elixir/lumis/lib/lumis/formatter/html.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter/html.ex
@@ -447,20 +447,30 @@ defmodule Lumis.Formatter.HTML do
   Lines are 1-based, matching the `data-line` `wrap_line/3` writes and the
   `:highlight_lines` option the built-in formatters take.
 
+  A range's step counts: `1..9//2` is five lines, not nine. A stepped range has
+  to be listed out line by line, so one spanning more than 100,000 lines raises
+  `ArgumentError`; a range stepping by 1 has no limit.
+
       iex> Lumis.Formatter.HTML.line_is_highlighted([1, 3..5], 4)
       true
 
       iex> Lumis.Formatter.HTML.line_is_highlighted([1, 3..5], 2)
       false
 
+      iex> Lumis.Formatter.HTML.line_is_highlighted([1..9//2], 4)
+      false
+
   """
   @spec line_is_highlighted([pos_integer() | Range.t()], pos_integer()) :: boolean()
   def line_is_highlighted(lines, line_number) when is_list(lines) do
-    Native.html_line_is_highlighted(LineSpec.encode(lines), line_number)
+    Native.html_line_is_highlighted(LineSpec.encode!(lines), line_number)
   end
 
   @doc """
   The CSS class a highlighted line carries, or `nil` when the line is not highlighted.
+
+  Reads `lines` the way `line_is_highlighted/2` does, including the limit on a
+  stepped range.
 
   ## Options
 
@@ -481,7 +491,7 @@ defmodule Lumis.Formatter.HTML do
   def highlight_line_class(lines, line_number, options \\ [])
       when is_list(lines) and is_list(options) do
     Native.html_highlight_line_class(
-      LineSpec.encode(lines),
+      LineSpec.encode!(lines),
       line_number,
       Keyword.get(options, :class),
       Keyword.get(options, :default_class)

--- a/packages/elixir/lumis/lib/lumis/formatter/html.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter/html.ex
@@ -44,8 +44,11 @@ defmodule Lumis.Formatter.HTML do
 
   alias Lumis.Native
   alias Lumis.Theme
+  alias Lumis.Theme.Style
+  alias Lumis.Theme.TextDecoration
 
   @default_class "l-text"
+  @default_css_variable_prefix "--lumis"
 
   @doc """
   Escapes `&`, `<`, `>`, `"` and `'`.
@@ -56,6 +59,24 @@ defmodule Lumis.Formatter.HTML do
   """
   @spec escape(String.t()) :: String.t()
   def escape(text) when is_binary(text), do: Native.html_escape(text)
+
+  @doc """
+  Escapes a value going inside a double-quoted attribute.
+
+  The helpers here already escape every attribute they build; this is for a
+  formatter that assembles its own tags. The escape set is `escape/1`'s, which is
+  safe for CSS in an attribute because the HTML parser decodes the entity before
+  the CSS parser sees it.
+
+      iex> Lumis.Formatter.HTML.escape_attr(~s|x"><script>|)
+      "x&quot;&gt;&lt;script&gt;"
+
+      iex> Lumis.Formatter.HTML.escape_attr("font-family: 'Fira Code'")
+      "font-family: &#39;Fira Code&#39;"
+
+  """
+  @spec escape_attr(String.t()) :: String.t()
+  def escape_attr(value) when is_binary(value), do: Native.html_escape_attr(value)
 
   @doc """
   Escapes `{` and `}`, which a templating language such as HEEx would otherwise read.
@@ -187,6 +208,57 @@ defmodule Lumis.Formatter.HTML do
   end
 
   @doc """
+  Every scope's `<span>` attributes for a set of themes, as CSS custom properties.
+
+  The multi-theme counterpart of `span_attrs/1`, and the same advice applies:
+  build it once per document and read it per token with `open_span/2`. The result
+  is a table `open_span/2` and `span_multi_themes/3` both read.
+
+  Each theme's style becomes `--<prefix>-<theme>` custom properties, so one
+  document can be restyled by CSS alone. `:default_theme` names the one written
+  inline; the rest stay variables.
+
+  ## Options
+
+    * `:themes` (required) — the same `[light: "github_light", dark: dark_theme]`
+      keyword list `:html_multi_themes` takes, or a map. The names become the CSS
+      variable suffixes and the `<pre>` classes `open_multi_themes_pre_tag/1`
+      writes.
+    * `:default_theme` — the theme written inline. `"light-dark()"` writes the
+      themes named `light` and `dark` into CSS `light-dark()` calls and emits no
+      variables. Without one every theme is a variable and nothing is inline.
+    * `:css_variable_prefix` (default `"--lumis"`) — the custom property prefix
+    * `:language` — the language whose specialized scopes to prefer, e.g.
+      `comment.elixir` over `comment`. Defaults to `"plaintext"`.
+    * `:italic` (default `false`) — emit `font-style: italic` for a style that
+      asks for it
+    * `:include_highlights` (default `false`) — add `data-highlight="<scope>"`
+
+  """
+  @spec span_multi_themes_attrs(keyword()) :: %{String.t() => String.t()}
+  def span_multi_themes_attrs(options \\ []) when is_list(options) do
+    Native.html_multi_themes_span_attrs(
+      resolve_themes(Keyword.get(options, :themes, %{})),
+      Keyword.get(options, :default_theme),
+      Keyword.get(options, :css_variable_prefix, @default_css_variable_prefix),
+      Keyword.get(options, :language) || "plaintext",
+      Keyword.get(options, :italic, false),
+      Keyword.get(options, :include_highlights, false)
+    )
+  end
+
+  @doc """
+  A `<span>` carrying every theme's style as CSS custom properties, with `text` escaped.
+
+  `attrs` is a `span_multi_themes_attrs/1` table. The inline counterpart is
+  `span_inline/3`, and the two differ only in which table they read.
+  """
+  @spec span_multi_themes(String.t(), %{String.t() => String.t()}, String.t() | nil) :: String.t()
+  def span_multi_themes(text, attrs, scope) do
+    "#{open_span(attrs, scope)}#{escape(text)}</span>"
+  end
+
+  @doc """
   The opening `<pre>` tag, carrying a theme's own colors when one is given.
 
   ## Options
@@ -206,6 +278,37 @@ defmodule Lumis.Formatter.HTML do
     Native.html_open_pre_tag(
       Keyword.get(options, :class),
       resolve_theme(Keyword.get(options, :theme))
+    )
+  end
+
+  @doc """
+  The opening `<pre>` tag for a multi-theme block.
+
+  Carries `lumis`, `lumis-themes` and one class per theme name, so a stylesheet
+  can select the active theme, and the same `normal` colors
+  `span_multi_themes_attrs/1` writes per scope.
+
+  ## Options
+
+    * `:themes` (required) — the same keyword list or map `span_multi_themes_attrs/1` takes
+    * `:default_theme` — the theme written inline; `"light-dark()"` writes both
+      the `light` and `dark` themes into CSS `light-dark()` calls
+    * `:css_variable_prefix` (default `"--lumis"`) — the custom property prefix
+    * `:class` — appended to the classes above
+
+  ## Example
+
+      iex> Lumis.Formatter.HTML.open_multi_themes_pre_tag(themes: [light: "github_light"], default_theme: "light")
+      ~s|<pre class="lumis lumis-themes light" style="color:#1f2328; background-color:#ffffff;">|
+
+  """
+  @spec open_multi_themes_pre_tag(keyword()) :: String.t()
+  def open_multi_themes_pre_tag(options \\ []) when is_list(options) do
+    Native.html_open_multi_themes_pre_tag(
+      Keyword.get(options, :class),
+      resolve_themes(Keyword.get(options, :themes, %{})),
+      Keyword.get(options, :default_theme),
+      Keyword.get(options, :css_variable_prefix, @default_css_variable_prefix)
     )
   end
 
@@ -232,10 +335,88 @@ defmodule Lumis.Formatter.HTML do
   def closing_tags, do: Native.html_closing_tags()
 
   @doc """
+  The closing `</pre>` tag.
+
+      iex> Lumis.Formatter.HTML.close_pre_tag()
+      "</pre>"
+
+  """
+  @spec close_pre_tag() :: String.t()
+  def close_pre_tag, do: Native.html_close_pre_tag()
+
+  @doc """
+  The closing `</code>` tag.
+
+      iex> Lumis.Formatter.HTML.close_code_tag()
+      "</code>"
+
+  """
+  @spec close_code_tag() :: String.t()
+  def close_code_tag, do: Native.html_close_code_tag()
+
+  @doc """
+  A theme name with everything but letters, digits, `-` and `_` replaced by `-`.
+
+  The form a theme name takes inside the CSS custom properties
+  `span_multi_themes_attrs/1` writes.
+
+      iex> Lumis.Formatter.HTML.sanitize_theme_name("Catppuccin Mocha")
+      "Catppuccin-Mocha"
+
+  """
+  @spec sanitize_theme_name(String.t()) :: String.t()
+  def sanitize_theme_name(name) when is_binary(name), do: Native.html_sanitize_theme_name(name)
+
+  @doc """
+  The CSS `text-decoration` value for a `Lumis.Theme.TextDecoration`.
+
+      iex> Lumis.Formatter.HTML.text_decoration(%Lumis.Theme.TextDecoration{underline: :wavy, strikethrough: true})
+      "underline wavy line-through"
+
+      iex> Lumis.Formatter.HTML.text_decoration(%Lumis.Theme.TextDecoration{})
+      "none"
+
+  """
+  @spec text_decoration(TextDecoration.t()) :: String.t()
+  def text_decoration(%TextDecoration{} = text_decoration),
+    do: Native.html_text_decoration(text_decoration)
+
+  @doc """
+  A `Lumis.Theme.Style` as inline CSS declarations.
+
+  The same declarations `span_attrs/1` puts in a `style` attribute, for a
+  formatter that styles something other than a `<span>`.
+
+  ## Options
+
+    * `:italic` (default `false`) — emit `font-style: italic` for a style that
+      asks for it
+    * `:separator` (default `" "`) — what goes between declarations
+
+  ## Example
+
+      iex> Lumis.Formatter.HTML.style_to_css(%Lumis.Theme.Style{fg: "#ff79c6", bold: true})
+      "color: #ff79c6; font-weight: bold;"
+
+  """
+  @spec style_to_css(Style.t(), keyword()) :: String.t()
+  def style_to_css(%Style{} = style, options \\ []) when is_list(options) do
+    Native.html_style_to_css(
+      style,
+      Keyword.get(options, :italic, false),
+      Keyword.get(options, :separator, " ")
+    )
+  end
+
+  @doc """
   Wraps one rendered line in the `<div>` the built-in HTML formatters emit.
 
   Lines are 1-based, and `data-line` is what a "highlight these lines" feature
   and anchor links both key off.
+
+  `content` goes in verbatim. A line from `render_lines_from_events/3` carries no
+  trailing newline; the built-in formatters put one inside the `<div>` so the
+  block still copies as lines, which is `wrap_line(n, [line, "\\n"])`.
 
   ## Options
 
@@ -259,7 +440,107 @@ defmodule Lumis.Formatter.HTML do
     )
   end
 
+  @doc """
+  Whether a line falls inside a list of line numbers and ranges.
+
+  Lines are 1-based, matching the `data-line` `wrap_line/3` writes and the
+  `:highlight_lines` option the built-in formatters take.
+
+      iex> Lumis.Formatter.HTML.line_is_highlighted([1, 3..5], 4)
+      true
+
+      iex> Lumis.Formatter.HTML.line_is_highlighted([1, 3..5], 2)
+      false
+
+  """
+  @spec line_is_highlighted([pos_integer() | Range.t()], pos_integer()) :: boolean()
+  def line_is_highlighted(lines, line_number) when is_list(lines) do
+    Native.html_line_is_highlighted(encode_line_specs(lines), line_number)
+  end
+
+  @doc """
+  The CSS class a highlighted line carries, or `nil` when the line is not highlighted.
+
+  ## Options
+
+    * `:class` — the class to use, taking precedence over `:default_class`
+    * `:default_class` — what to fall back to, e.g. `"l-highlighted"`
+
+  ## Example
+
+      iex> Lumis.Formatter.HTML.highlight_line_class([1, 3..5], 4, default_class: "l-highlighted")
+      "l-highlighted"
+
+      iex> Lumis.Formatter.HTML.highlight_line_class([1, 3..5], 2, default_class: "l-highlighted")
+      nil
+
+  """
+  @spec highlight_line_class([pos_integer() | Range.t()], pos_integer(), keyword()) ::
+          String.t() | nil
+  def highlight_line_class(lines, line_number, options \\ [])
+      when is_list(lines) and is_list(options) do
+    Native.html_highlight_line_class(
+      encode_line_specs(lines),
+      line_number,
+      Keyword.get(options, :class),
+      Keyword.get(options, :default_class)
+    )
+  end
+
+  @doc """
+  The event stream rendered into HTML lines, one string per line.
+
+  A `<span>` that crosses a newline is closed at the end of one line and reopened
+  at the start of the next, so every line's tags nest on their own and can be
+  wrapped with `wrap_line/3` independently. That closing and reopening is the
+  part worth not writing again.
+
+  `attrs` maps a scope to the attributes its `<span>` carries, so the whole render
+  costs one call rather than one per token: a `span_attrs/1` or
+  `span_multi_themes_attrs/1` table, or for class-based output,
+  `Map.new(classes(), fn {scope, _} -> {scope, span_linked_attrs(scope)} end)`.
+  A scope the table does not carry opens a bare `<span>`.
+
+  Event kinds this build does not render — annotations, and anything a newer
+  Lumis adds — are skipped rather than raising.
+
+  ## Example
+
+      iex> events = [{:start, %{scope: "keyword", language: "elixir"}}, {:source, %{start: 0, end: 3}}, :end]
+      iex> Lumis.Formatter.HTML.render_lines_from_events("a\\nb", events, %{"keyword" => ~s|class="l-keyword"|})
+      [~s|<span class="l-keyword">a</span>|, ~s|<span class="l-keyword">b</span>|]
+
+  """
+  @spec render_lines_from_events(String.t(), [Lumis.Formatter.event(term())], %{
+          String.t() => String.t()
+        }) :: [String.t()]
+  def render_lines_from_events(source, events, attrs)
+      when is_binary(source) and is_list(events) and is_map(attrs) do
+    Native.html_render_lines_from_events(source, events, attrs)
+  end
+
   defp resolve_theme(nil), do: nil
   defp resolve_theme(%Theme{} = theme), do: theme
   defp resolve_theme(name) when is_binary(name), do: Theme.get(name)
+
+  # Accepts the `themes: [light: "github_light"]` keyword list `:html_multi_themes`
+  # takes, and a map. A name no theme resolves to drops out, the way a `:theme`
+  # that resolves to nothing leaves `open_pre_tag/1` unstyled.
+  defp resolve_themes(themes) do
+    themes
+    |> Enum.flat_map(fn {name, theme} ->
+      case resolve_theme(theme) do
+        nil -> []
+        theme -> [{to_string(name), theme}]
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp encode_line_specs(lines) do
+    Enum.map(lines, fn
+      %Range{} = range -> {:range, %{start: range.first, end: range.last}}
+      line when is_integer(line) -> {:single, line}
+    end)
+  end
 end

--- a/packages/elixir/lumis/lib/lumis/formatter/html.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter/html.ex
@@ -241,7 +241,7 @@ defmodule Lumis.Formatter.HTML do
     Native.html_multi_themes_span_attrs(
       resolve_themes(Keyword.get(options, :themes, %{})),
       Keyword.get(options, :default_theme),
-      Keyword.get(options, :css_variable_prefix, @default_css_variable_prefix),
+      css_variable_prefix(options),
       Keyword.get(options, :language) || "plaintext",
       Keyword.get(options, :italic, false),
       Keyword.get(options, :include_highlights, false)
@@ -309,8 +309,15 @@ defmodule Lumis.Formatter.HTML do
       Keyword.get(options, :class),
       resolve_themes(Keyword.get(options, :themes, %{})),
       Keyword.get(options, :default_theme),
-      Keyword.get(options, :css_variable_prefix, @default_css_variable_prefix)
+      css_variable_prefix(options)
     )
+  end
+
+  defp css_variable_prefix(options) do
+    case Keyword.get(options, :css_variable_prefix) do
+      nil -> @default_css_variable_prefix
+      prefix -> prefix
+    end
   end
 
   @doc """
@@ -447,9 +454,8 @@ defmodule Lumis.Formatter.HTML do
   Lines are 1-based, matching the `data-line` `wrap_line/3` writes and the
   `:highlight_lines` option the built-in formatters take.
 
-  A range's step counts: `1..9//2` is five lines, not nine. A stepped range has
-  to be listed out line by line, so one spanning more than 100,000 lines raises
-  `ArgumentError`; a range stepping by 1 has no limit.
+  A range's step counts: `1..9//2` is five lines, not nine. Stepped ranges stay
+  compact across the native boundary, regardless of their declared span.
 
       iex> Lumis.Formatter.HTML.line_is_highlighted([1, 3..5], 4)
       true
@@ -469,8 +475,8 @@ defmodule Lumis.Formatter.HTML do
   @doc """
   The CSS class a highlighted line carries, or `nil` when the line is not highlighted.
 
-  Reads `lines` the way `line_is_highlighted/2` does, including the limit on a
-  stepped range.
+  Reads `lines` the way `line_is_highlighted/2` does, including range steps and
+  direction.
 
   ## Options
 

--- a/packages/elixir/lumis/lib/lumis/formatter/html.ex
+++ b/packages/elixir/lumis/lib/lumis/formatter/html.ex
@@ -42,6 +42,7 @@ defmodule Lumis.Formatter.HTML do
       end
   """
 
+  alias Lumis.LineSpec
   alias Lumis.Native
   alias Lumis.Theme
   alias Lumis.Theme.Style
@@ -455,7 +456,7 @@ defmodule Lumis.Formatter.HTML do
   """
   @spec line_is_highlighted([pos_integer() | Range.t()], pos_integer()) :: boolean()
   def line_is_highlighted(lines, line_number) when is_list(lines) do
-    Native.html_line_is_highlighted(encode_line_specs(lines), line_number)
+    Native.html_line_is_highlighted(LineSpec.encode(lines), line_number)
   end
 
   @doc """
@@ -480,7 +481,7 @@ defmodule Lumis.Formatter.HTML do
   def highlight_line_class(lines, line_number, options \\ [])
       when is_list(lines) and is_list(options) do
     Native.html_highlight_line_class(
-      encode_line_specs(lines),
+      LineSpec.encode(lines),
       line_number,
       Keyword.get(options, :class),
       Keyword.get(options, :default_class)
@@ -535,12 +536,5 @@ defmodule Lumis.Formatter.HTML do
       end
     end)
     |> Map.new()
-  end
-
-  defp encode_line_specs(lines) do
-    Enum.map(lines, fn
-      %Range{} = range -> {:range, %{start: range.first, end: range.last}}
-      line when is_integer(line) -> {:single, line}
-    end)
   end
 end

--- a/packages/elixir/lumis/lib/lumis/line_spec.ex
+++ b/packages/elixir/lumis/lib/lumis/line_spec.ex
@@ -1,0 +1,24 @@
+defmodule Lumis.LineSpec do
+  @moduledoc false
+
+  # The one place a line number or `Range` becomes something Rust can read.
+  #
+  # `{:range, ...}` arrives as a `RangeInclusive<usize>`, which has no step and
+  # cannot run backwards, so only a plain ascending range survives as one.
+  # `1..5//2` sent as `1..=5` highlights the two lines the step excluded, and
+  # `5..3` sent as `5..=3` matches nothing at all, so both expand into single
+  # lines instead. A line range is short, so expanding it costs nothing.
+
+  @type t :: pos_integer() | Range.t()
+
+  @spec encode([t()]) :: [
+          {:single, pos_integer()} | {:range, %{start: integer(), end: integer()}}
+        ]
+  def encode(lines) when is_list(lines), do: Enum.flat_map(lines, &encode_one/1)
+
+  defp encode_one(%Range{first: first, last: last, step: 1}),
+    do: [{:range, %{start: first, end: last}}]
+
+  defp encode_one(%Range{} = range), do: Enum.map(range, &{:single, &1})
+  defp encode_one(line) when is_integer(line), do: [{:single, line}]
+end

--- a/packages/elixir/lumis/lib/lumis/line_spec.ex
+++ b/packages/elixir/lumis/lib/lumis/line_spec.ex
@@ -3,73 +3,29 @@ defmodule Lumis.LineSpec do
 
   # The one place a line number or `Range` becomes something Rust can read.
   #
-  # A line range crosses as a `RangeInclusive<usize>`, which has no step and
-  # cannot run backwards. Elixir's `Range` has both, and JavaScript's `[number,
-  # number]` has neither, so the step is the one thing the shared representation
-  # cannot carry.
-  #
-  # A step of 1 or -1 describes a contiguous run either way round, so both
-  # normalize to one ascending range and cost nothing. Anything else has to
-  # expand into single lines, and that is the case with a ceiling: `1..1_000_000
-  # //2` is 500,000 tuples and 19MB, so `1..1_000_000_000//2` would be 19GB.
-  # `Range.size/1` is arithmetic, so the size is known before anything is built.
+  # Elixir's `Range` carries a direction and a step, so both cross the NIF
+  # boundary with the two endpoints. Rust keeps that arithmetic progression
+  # compact and clips it to the rendered document; no range is expanded into
+  # one term per selected line.
 
   @typedoc false
   @type t :: pos_integer() | Range.t()
 
   @typedoc false
-  @type encoded :: {:single, integer()} | {:range, %{start: integer(), end: integer()}}
-
-  # Each spec measures ~40 bytes, so this is a few MB at worst. A stepped range
-  # covering more lines than this is not a document anyone is highlighting.
-  @max_expanded 100_000
+  @type encoded ::
+          {:single, integer()}
+          | {:range, %{start: integer(), end: integer(), step: integer()}}
 
   @doc false
-  @spec encode([t()]) :: {:ok, [encoded()]} | {:error, String.t()}
-  def encode(lines) when is_list(lines) do
-    lines
-    |> Enum.reduce_while({:ok, []}, fn line, {:ok, acc} ->
-      case encode_one(line) do
-        {:ok, specs} -> {:cont, {:ok, [specs | acc]}}
-        {:error, message} -> {:halt, {:error, message}}
-      end
-    end)
-    |> case do
-      {:ok, acc} -> {:ok, acc |> Enum.reverse() |> Enum.concat()}
-      {:error, message} -> {:error, message}
-    end
-  end
+  @spec encode([t()]) :: {:ok, [encoded()]}
+  def encode(lines) when is_list(lines), do: {:ok, Enum.map(lines, &encode_one/1)}
 
   @doc false
   @spec encode!([t()]) :: [encoded()]
-  def encode!(lines) when is_list(lines) do
-    case encode(lines) do
-      {:ok, specs} -> specs
-      {:error, message} -> raise ArgumentError, message
-    end
-  end
+  def encode!(lines) when is_list(lines), do: Enum.map(lines, &encode_one/1)
 
-  # A contiguous run, either way round. `5..3//-1` covers the same lines as
-  # `3..5`, and an empty range stays empty because Rust's `5..=3` matches
-  # nothing either.
-  defp encode_one(%Range{first: first, last: last, step: 1}),
-    do: {:ok, [{:range, %{start: first, end: last}}]}
+  defp encode_one(%Range{first: first, last: last, step: step}),
+    do: {:range, %{start: first, end: last, step: step}}
 
-  defp encode_one(%Range{first: first, last: last, step: -1}),
-    do: {:ok, [{:range, %{start: last, end: first}}]}
-
-  defp encode_one(%Range{} = range) do
-    size = Range.size(range)
-
-    if size > @max_expanded do
-      {:error,
-       "a line range with a step of #{range.step} has to be expanded into single lines, " <>
-         "and #{inspect(range)} covers #{size} of them, over the #{@max_expanded} limit. " <>
-         "Use a range with a step of 1, which has no limit."}
-    else
-      {:ok, Enum.map(range, &{:single, &1})}
-    end
-  end
-
-  defp encode_one(line) when is_integer(line), do: {:ok, [{:single, line}]}
+  defp encode_one(line) when is_integer(line), do: {:single, line}
 end

--- a/packages/elixir/lumis/lib/lumis/line_spec.ex
+++ b/packages/elixir/lumis/lib/lumis/line_spec.ex
@@ -3,22 +3,73 @@ defmodule Lumis.LineSpec do
 
   # The one place a line number or `Range` becomes something Rust can read.
   #
-  # `{:range, ...}` arrives as a `RangeInclusive<usize>`, which has no step and
-  # cannot run backwards, so only a plain ascending range survives as one.
-  # `1..5//2` sent as `1..=5` highlights the two lines the step excluded, and
-  # `5..3` sent as `5..=3` matches nothing at all, so both expand into single
-  # lines instead. A line range is short, so expanding it costs nothing.
+  # A line range crosses as a `RangeInclusive<usize>`, which has no step and
+  # cannot run backwards. Elixir's `Range` has both, and JavaScript's `[number,
+  # number]` has neither, so the step is the one thing the shared representation
+  # cannot carry.
+  #
+  # A step of 1 or -1 describes a contiguous run either way round, so both
+  # normalize to one ascending range and cost nothing. Anything else has to
+  # expand into single lines, and that is the case with a ceiling: `1..1_000_000
+  # //2` is 500,000 tuples and 19MB, so `1..1_000_000_000//2` would be 19GB.
+  # `Range.size/1` is arithmetic, so the size is known before anything is built.
 
+  @typedoc false
   @type t :: pos_integer() | Range.t()
 
-  @spec encode([t()]) :: [
-          {:single, pos_integer()} | {:range, %{start: integer(), end: integer()}}
-        ]
-  def encode(lines) when is_list(lines), do: Enum.flat_map(lines, &encode_one/1)
+  @typedoc false
+  @type encoded :: {:single, integer()} | {:range, %{start: integer(), end: integer()}}
 
+  # Each spec measures ~40 bytes, so this is a few MB at worst. A stepped range
+  # covering more lines than this is not a document anyone is highlighting.
+  @max_expanded 100_000
+
+  @doc false
+  @spec encode([t()]) :: {:ok, [encoded()]} | {:error, String.t()}
+  def encode(lines) when is_list(lines) do
+    lines
+    |> Enum.reduce_while({:ok, []}, fn line, {:ok, acc} ->
+      case encode_one(line) do
+        {:ok, specs} -> {:cont, {:ok, [specs | acc]}}
+        {:error, message} -> {:halt, {:error, message}}
+      end
+    end)
+    |> case do
+      {:ok, acc} -> {:ok, acc |> Enum.reverse() |> Enum.concat()}
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  @doc false
+  @spec encode!([t()]) :: [encoded()]
+  def encode!(lines) when is_list(lines) do
+    case encode(lines) do
+      {:ok, specs} -> specs
+      {:error, message} -> raise ArgumentError, message
+    end
+  end
+
+  # A contiguous run, either way round. `5..3//-1` covers the same lines as
+  # `3..5`, and an empty range stays empty because Rust's `5..=3` matches
+  # nothing either.
   defp encode_one(%Range{first: first, last: last, step: 1}),
-    do: [{:range, %{start: first, end: last}}]
+    do: {:ok, [{:range, %{start: first, end: last}}]}
 
-  defp encode_one(%Range{} = range), do: Enum.map(range, &{:single, &1})
-  defp encode_one(line) when is_integer(line), do: [{:single, line}]
+  defp encode_one(%Range{first: first, last: last, step: -1}),
+    do: {:ok, [{:range, %{start: last, end: first}}]}
+
+  defp encode_one(%Range{} = range) do
+    size = Range.size(range)
+
+    if size > @max_expanded do
+      {:error,
+       "a line range with a step of #{range.step} has to be expanded into single lines, " <>
+         "and #{inspect(range)} covers #{size} of them, over the #{@max_expanded} limit. " <>
+         "Use a range with a step of 1, which has no limit."}
+    else
+      {:ok, Enum.map(range, &{:single, &1})}
+    end
+  end
+
+  defp encode_one(line) when is_integer(line), do: {:ok, [{:single, line}]}
 end

--- a/packages/elixir/lumis/lib/lumis/native.ex
+++ b/packages/elixir/lumis/lib/lumis/native.ex
@@ -87,16 +87,49 @@ defmodule Lumis.Native do
   def ansi_styles(_theme, _language), do: :erlang.nif_error(:nif_not_loaded)
 
   def html_escape(_text), do: :erlang.nif_error(:nif_not_loaded)
+  def html_escape_attr(_value), do: :erlang.nif_error(:nif_not_loaded)
   def html_escape_braces(_text), do: :erlang.nif_error(:nif_not_loaded)
   def html_classes, do: :erlang.nif_error(:nif_not_loaded)
+  def html_sanitize_theme_name(_name), do: :erlang.nif_error(:nif_not_loaded)
+  def html_text_decoration(_text_decoration), do: :erlang.nif_error(:nif_not_loaded)
+  def html_style_to_css(_style, _italic, _separator), do: :erlang.nif_error(:nif_not_loaded)
 
   def html_span_attrs(_theme, _language, _italic, _include_highlights),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  def html_multi_themes_span_attrs(
+        _themes,
+        _default_theme,
+        _css_variable_prefix,
+        _language,
+        _italic,
+        _include_highlights
+      ),
+      do: :erlang.nif_error(:nif_not_loaded)
+
   def html_open_pre_tag(_pre_class, _theme), do: :erlang.nif_error(:nif_not_loaded)
+
+  def html_open_multi_themes_pre_tag(
+        _pre_class,
+        _themes,
+        _default_theme,
+        _css_variable_prefix
+      ),
+      do: :erlang.nif_error(:nif_not_loaded)
+
   def html_open_code_tag(_language), do: :erlang.nif_error(:nif_not_loaded)
+  def html_close_pre_tag, do: :erlang.nif_error(:nif_not_loaded)
+  def html_close_code_tag, do: :erlang.nif_error(:nif_not_loaded)
   def html_closing_tags, do: :erlang.nif_error(:nif_not_loaded)
 
   def html_wrap_line(_line_number, _content, _class_suffix, _style),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def html_line_is_highlighted(_lines, _line_number), do: :erlang.nif_error(:nif_not_loaded)
+
+  def html_highlight_line_class(_lines, _line_number, _class, _default_class),
+    do: :erlang.nif_error(:nif_not_loaded)
+
+  def html_render_lines_from_events(_source, _events, _attrs),
     do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
@@ -85,7 +85,7 @@ fn resolve_theme(theme_or_string: ThemeOrString) -> Option<themes::Theme> {
 }
 
 #[inline]
-fn convert_line_specs(lines: Vec<ExLineSpec>) -> Vec<std::ops::RangeInclusive<usize>> {
+pub(crate) fn convert_line_specs(lines: Vec<ExLineSpec>) -> Vec<std::ops::RangeInclusive<usize>> {
     lines
         .into_iter()
         .map(|line_spec| line_spec.to_range_inclusive())

--- a/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/elixir.rs
@@ -1,6 +1,7 @@
 use lumis_core::formatter::{
-    html_inline, html_linked, BBCodeScopedBuilder, Formatter, HtmlElement, HtmlInlineBuilder,
-    HtmlLinkedBuilder, HtmlMultiThemesBuilder, TerminalBackground, TerminalBuilder,
+    html::SteppedLineRange, html_inline, html_linked, BBCodeScopedBuilder, Formatter, HtmlElement,
+    HtmlInlineBuilder, HtmlLinkedBuilder, HtmlMultiThemesBuilder, TerminalBackground,
+    TerminalBuilder,
 };
 use lumis_core::{languages::Language, themes};
 use rustler::{NifMap, NifStruct, NifTaggedEnum, NifUnitEnum};
@@ -85,11 +86,41 @@ fn resolve_theme(theme_or_string: ThemeOrString) -> Option<themes::Theme> {
 }
 
 #[inline]
-pub(crate) fn convert_line_specs(lines: Vec<ExLineSpec>) -> Vec<std::ops::RangeInclusive<usize>> {
-    lines
-        .into_iter()
-        .map(|line_spec| line_spec.to_range_inclusive())
-        .collect()
+fn convert_line_specs(
+    lines: Vec<ExLineSpec>,
+) -> (Vec<std::ops::RangeInclusive<usize>>, Vec<SteppedLineRange>) {
+    let mut contiguous = Vec::new();
+    let mut stepped = Vec::new();
+
+    for line in lines {
+        match line {
+            ExLineSpec::Single(line) => contiguous.push(line..=line),
+            ExLineSpec::Range {
+                start,
+                end,
+                step: 1,
+            } if start <= end => contiguous.push(start..=end),
+            ExLineSpec::Range {
+                start,
+                end,
+                step: -1,
+            } if start >= end => contiguous.push(end..=start),
+            line @ ExLineSpec::Range { .. } => {
+                if let Some(range) = line.to_stepped_line_range() {
+                    stepped.push(range);
+                }
+            }
+        }
+    }
+
+    (contiguous, stepped)
+}
+
+pub(crate) fn line_specs_contain(lines: &[ExLineSpec], line_number: usize) -> bool {
+    lines.iter().any(|line| {
+        line.to_stepped_line_range()
+            .is_some_and(|range| range.contains(line_number))
+    })
 }
 
 #[inline]
@@ -102,6 +133,37 @@ fn convert_inline_style(
             html_inline::HighlightLinesStyle::Style(style)
         }
     }
+}
+
+fn convert_inline_highlight_lines(
+    highlight: ExHtmlInlineHighlightLines,
+) -> (html_inline::HighlightLines, Vec<SteppedLineRange>) {
+    let (lines, stepped) = convert_line_specs(highlight.lines);
+    let highlight = html_inline::HighlightLines {
+        lines,
+        style: highlight.style.map(convert_inline_style),
+        class: highlight.class,
+    };
+    (highlight, stepped)
+}
+
+fn convert_linked_highlight_lines(
+    highlight: ExHtmlLinkedHighlightLines,
+) -> (html_linked::HighlightLines, Vec<SteppedLineRange>) {
+    let (lines, stepped) = convert_line_specs(highlight.lines);
+    let highlight = html_linked::HighlightLines {
+        lines,
+        class: highlight.class,
+    };
+    (highlight, stepped)
+}
+
+fn split_highlight_lines<T>(
+    converted: Option<(T, Vec<SteppedLineRange>)>,
+) -> (Option<T>, Vec<SteppedLineRange>) {
+    converted.map_or((None, Vec::new()), |(highlight, stepped)| {
+        (Some(highlight), stepped)
+    })
 }
 
 impl ExFormatterOption {
@@ -117,18 +179,15 @@ impl ExFormatterOption {
             } => {
                 let theme = theme.and_then(resolve_theme);
 
-                let highlight_lines = highlight_lines.map(|hl| html_inline::HighlightLines {
-                    lines: convert_line_specs(hl.lines),
-                    style: hl.style.map(convert_inline_style),
-                    class: hl.class,
-                });
+                let (highlight_lines, stepped_highlight_lines) =
+                    split_highlight_lines(highlight_lines.map(convert_inline_highlight_lines));
 
                 let header = header.map(|h| HtmlElement {
                     open_tag: h.open_tag,
                     close_tag: h.close_tag,
                 });
 
-                let formatter = HtmlInlineBuilder::new()
+                let mut formatter = HtmlInlineBuilder::new()
                     .language(language)
                     .theme(theme)
                     .pre_class(pre_class)
@@ -138,6 +197,7 @@ impl ExFormatterOption {
                     .header(header)
                     .build()
                     .map_err(|e| format!("HtmlInline builder error: {e:?}"))?;
+                formatter.set_stepped_highlight_lines(stepped_highlight_lines);
 
                 Ok(Box::new(formatter))
             }
@@ -146,23 +206,22 @@ impl ExFormatterOption {
                 highlight_lines,
                 header,
             } => {
-                let highlight_lines = highlight_lines.map(|hl| html_linked::HighlightLines {
-                    lines: convert_line_specs(hl.lines),
-                    class: hl.class,
-                });
+                let (highlight_lines, stepped_highlight_lines) =
+                    split_highlight_lines(highlight_lines.map(convert_linked_highlight_lines));
 
                 let header = header.map(|h| HtmlElement {
                     open_tag: h.open_tag,
                     close_tag: h.close_tag,
                 });
 
-                let formatter = HtmlLinkedBuilder::new()
+                let mut formatter = HtmlLinkedBuilder::new()
                     .language(language)
                     .pre_class(pre_class)
                     .highlight_lines(highlight_lines)
                     .header(header)
                     .build()
                     .map_err(|e| format!("HtmlLinked builder error: {e:?}"))?;
+                formatter.set_stepped_highlight_lines(stepped_highlight_lines);
 
                 Ok(Box::new(formatter))
             }
@@ -179,11 +238,8 @@ impl ExFormatterOption {
                 let themes_map: HashMap<String, themes::Theme> =
                     themes.into_iter().map(|(k, v)| (k, v.into())).collect();
 
-                let highlight_lines = highlight_lines.map(|hl| html_inline::HighlightLines {
-                    lines: convert_line_specs(hl.lines),
-                    style: hl.style.map(convert_inline_style),
-                    class: hl.class,
-                });
+                let (highlight_lines, stepped_highlight_lines) =
+                    split_highlight_lines(highlight_lines.map(convert_inline_highlight_lines));
 
                 let header = header.map(|h| HtmlElement {
                     open_tag: h.open_tag,
@@ -205,9 +261,10 @@ impl ExFormatterOption {
                     builder.default_theme(dt_str);
                 }
 
-                let formatter = builder
+                let mut formatter = builder
                     .build()
                     .map_err(|e| format!("HtmlMultiThemes builder error: {e:?}"))?;
+                formatter.set_stepped_highlight_lines(stepped_highlight_lines);
 
                 Ok(Box::new(formatter))
             }
@@ -412,14 +469,18 @@ pub struct ExHtmlElement {
 #[derive(Clone, Debug, NifTaggedEnum)]
 pub enum ExLineSpec {
     Single(usize),
-    Range { start: usize, end: usize },
+    Range {
+        start: usize,
+        end: usize,
+        step: isize,
+    },
 }
 
 impl ExLineSpec {
-    fn to_range_inclusive(&self) -> std::ops::RangeInclusive<usize> {
+    fn to_stepped_line_range(&self) -> Option<SteppedLineRange> {
         match self {
-            ExLineSpec::Single(line) => *line..=*line,
-            ExLineSpec::Range { start, end } => *start..=*end,
+            ExLineSpec::Single(line) => SteppedLineRange::new(*line, *line, 1),
+            ExLineSpec::Range { start, end, step } => SteppedLineRange::new(*start, *end, *step),
         }
     }
 
@@ -430,7 +491,11 @@ impl ExLineSpec {
         if start == end {
             ExLineSpec::Single(start)
         } else {
-            ExLineSpec::Range { start, end }
+            ExLineSpec::Range {
+                start,
+                end,
+                step: 1,
+            }
         }
     }
 }
@@ -532,5 +597,37 @@ impl From<html_linked::HighlightLines> for ExHtmlLinkedHighlightLines {
                 .collect(),
             class: highlight_lines.class,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{convert_line_specs, ExLineSpec};
+
+    #[test]
+    fn partitions_contiguous_and_genuinely_stepped_line_specs() {
+        let (contiguous, stepped) = convert_line_specs(vec![
+            ExLineSpec::Single(2),
+            ExLineSpec::Range {
+                start: 3,
+                end: 5,
+                step: 1,
+            },
+            ExLineSpec::Range {
+                start: 9,
+                end: 7,
+                step: -1,
+            },
+            ExLineSpec::Range {
+                start: 1,
+                end: 9,
+                step: 2,
+            },
+        ]);
+
+        assert_eq!(contiguous, [2..=2, 3..=5, 7..=9]);
+        assert_eq!(stepped.len(), 1);
+        assert!(stepped[0].contains(7));
+        assert!(!stepped[0].contains(8));
     }
 }

--- a/packages/elixir/lumis/native/lumis_nif/src/lib.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/lib.rs
@@ -7,7 +7,10 @@ use std::thread;
 mod elixir;
 
 use anyhow::{anyhow, Context, Result};
-use elixir::{ExCssOptions, ExFormatterOption, ExStyle, ExTheme};
+use elixir::{
+    convert_line_specs, ExCssOptions, ExFormatterOption, ExLineSpec, ExStyle, ExTextDecoration,
+    ExTheme,
+};
 use lumis_core::annotations::{compose_annotations, Annotation, AnnotationRange, Position};
 use lumis_core::events::HighlightEvent;
 use lumis_core::formatter::Formatter;
@@ -912,6 +915,189 @@ fn html_wrap_line(
         class_suffix.as_deref(),
         style.as_deref(),
     )
+}
+
+#[rustler::nif]
+fn html_escape_attr(value: &str) -> String {
+    lumis_core::formatter::html::escape_attr(value)
+}
+
+#[rustler::nif]
+fn html_sanitize_theme_name(name: &str) -> String {
+    lumis_core::formatter::html::sanitize_theme_name(name)
+}
+
+#[rustler::nif]
+fn html_text_decoration(text_decoration: ExTextDecoration) -> &'static str {
+    lumis_core::formatter::html::text_decoration(&text_decoration.into())
+}
+
+#[rustler::nif]
+fn html_style_to_css(style: ExStyle, italic: bool, separator: &str) -> String {
+    themes::Style::from(style).css(italic, separator)
+}
+
+#[rustler::nif]
+fn html_close_pre_tag() -> NifResult<String> {
+    let mut output = Vec::new();
+    lumis_core::formatter::html::close_pre_tag(&mut output)
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    html_utf8(output)
+}
+
+#[rustler::nif]
+fn html_close_code_tag() -> NifResult<String> {
+    let mut output = Vec::new();
+    lumis_core::formatter::html::close_code_tag(&mut output)
+        .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    html_utf8(output)
+}
+
+/// Every scope's multi-theme `<span>` attributes, for one theme set and language.
+///
+/// The multi-theme counterpart of [`html_span_attrs`], split for the same
+/// reason: sending the whole theme set across the boundary once per token to
+/// resolve one scope would cost more than the highlighting did.
+#[rustler::nif]
+fn html_multi_themes_span_attrs(
+    themes_map: HashMap<String, ExTheme>,
+    default_theme: Option<String>,
+    css_variable_prefix: &str,
+    language: &str,
+    italic: bool,
+    include_highlights: bool,
+) -> HashMap<&'static str, String> {
+    let themes_map: HashMap<String, themes::Theme> = themes_map
+        .into_iter()
+        .map(|(name, theme)| (name, themes::Theme::from(theme)))
+        .collect();
+    let language = Language::guess(Some(language), "");
+
+    lumis_core::highlights::HIGHLIGHT_NAMES
+        .iter()
+        .map(|scope| {
+            let attrs = lumis_core::formatter::html::span_multi_themes_attrs(
+                scope,
+                Some(language),
+                &themes_map,
+                default_theme.as_deref(),
+                css_variable_prefix,
+                italic,
+                include_highlights,
+            );
+            (*scope, attrs)
+        })
+        .collect()
+}
+
+#[rustler::nif]
+fn html_open_multi_themes_pre_tag(
+    pre_class: Option<String>,
+    themes_map: HashMap<String, ExTheme>,
+    default_theme: Option<String>,
+    css_variable_prefix: &str,
+) -> NifResult<String> {
+    let themes_map: HashMap<String, themes::Theme> = themes_map
+        .into_iter()
+        .map(|(name, theme)| (name, themes::Theme::from(theme)))
+        .collect();
+
+    let mut output = Vec::new();
+    lumis_core::formatter::html::open_multi_themes_pre_tag(
+        &mut output,
+        pre_class.as_deref(),
+        &themes_map,
+        default_theme.as_deref(),
+        css_variable_prefix,
+    )
+    .map_err(|error| Error::Term(Box::new(error.to_string())))?;
+    html_utf8(output)
+}
+
+#[rustler::nif]
+fn html_line_is_highlighted(lines: Vec<ExLineSpec>, line_number: usize) -> bool {
+    lumis_core::formatter::html::line_is_highlighted(&convert_line_specs(lines), line_number)
+}
+
+#[rustler::nif]
+fn html_highlight_line_class(
+    lines: Vec<ExLineSpec>,
+    line_number: usize,
+    class: Option<String>,
+    default_class: Option<String>,
+) -> Option<String> {
+    lumis_core::formatter::html::highlight_line_class(
+        &convert_line_specs(lines),
+        line_number,
+        class.as_deref(),
+        default_class.as_deref(),
+    )
+    .map(str::to_owned)
+}
+
+/// The event stream rendered into HTML lines, with spans reopened across newlines.
+///
+/// The one helper an Elixir formatter cannot assemble from the others, because
+/// closing and reopening the open spans at every newline is the part that is
+/// easy to get wrong. `attrs` is a table from [`html_span_attrs`] or
+/// [`html_multi_themes_span_attrs`], so the whole render costs one call rather
+/// than one per token.
+#[rustler::nif(schedule = "DirtyCpu")]
+fn html_render_lines_from_events(
+    source: &str,
+    events: Vec<Term<'_>>,
+    attrs: HashMap<String, String>,
+) -> Vec<String> {
+    let mut scopes: Vec<String> = Vec::new();
+    let mut decoded: Vec<HighlightEvent<'static>> = Vec::with_capacity(events.len());
+
+    for event in events {
+        // Decoded by hand rather than through a tagged enum so that an event
+        // kind this build predates, or one carrying caller data, is skipped
+        // instead of failing the whole render.
+        if let Ok(atom) = event.decode::<rustler::Atom>() {
+            if atom == event_end() {
+                decoded.push(HighlightEvent::End);
+            }
+            continue;
+        }
+
+        let Ok((tag, payload)) = event.decode::<(rustler::Atom, Term<'_>)>() else {
+            continue;
+        };
+
+        if tag == event_start() {
+            let Ok(start) = payload.decode::<ExStartEvent>() else {
+                continue;
+            };
+            let scope_index = scopes
+                .iter()
+                .position(|scope| *scope == start.scope)
+                .unwrap_or_else(|| {
+                    scopes.push(start.scope);
+                    scopes.len() - 1
+                });
+            decoded.push(HighlightEvent::Start {
+                scope_index,
+                language: start.language,
+            });
+        } else if tag == event_source() {
+            if let Ok(source_event) = payload.decode::<ExSourceEvent>() {
+                decoded.push(HighlightEvent::Source {
+                    start: source_event.start,
+                    end: source_event.end,
+                });
+            }
+        }
+    }
+
+    lumis_core::formatter::html::render_lines_from_events(source, &decoded, |scope_index, _| {
+        scopes
+            .get(scope_index)
+            .and_then(|scope| attrs.get(scope))
+            .cloned()
+            .unwrap_or_default()
+    })
 }
 
 fn html_utf8(output: Vec<u8>) -> NifResult<String> {

--- a/packages/elixir/lumis/native/lumis_nif/src/lib.rs
+++ b/packages/elixir/lumis/native/lumis_nif/src/lib.rs
@@ -8,7 +8,7 @@ mod elixir;
 
 use anyhow::{anyhow, Context, Result};
 use elixir::{
-    convert_line_specs, ExCssOptions, ExFormatterOption, ExLineSpec, ExStyle, ExTextDecoration,
+    line_specs_contain, ExCssOptions, ExFormatterOption, ExLineSpec, ExStyle, ExTextDecoration,
     ExTheme,
 };
 use lumis_core::annotations::{compose_annotations, Annotation, AnnotationRange, Position};
@@ -1016,7 +1016,7 @@ fn html_open_multi_themes_pre_tag(
 
 #[rustler::nif]
 fn html_line_is_highlighted(lines: Vec<ExLineSpec>, line_number: usize) -> bool {
-    lumis_core::formatter::html::line_is_highlighted(&convert_line_specs(lines), line_number)
+    line_specs_contain(&lines, line_number)
 }
 
 #[rustler::nif]
@@ -1026,13 +1026,11 @@ fn html_highlight_line_class(
     class: Option<String>,
     default_class: Option<String>,
 ) -> Option<String> {
-    lumis_core::formatter::html::highlight_line_class(
-        &convert_line_specs(lines),
-        line_number,
-        class.as_deref(),
-        default_class.as_deref(),
-    )
-    .map(str::to_owned)
+    if line_specs_contain(&lines, line_number) {
+        class.or(default_class)
+    } else {
+        None
+    }
 }
 
 /// The event stream rendered into HTML lines, with spans reopened across newlines.

--- a/packages/elixir/lumis/test/formatter_helpers_test.exs
+++ b/packages/elixir/lumis/test/formatter_helpers_test.exs
@@ -1,0 +1,101 @@
+defmodule Lumis.FormatterHelpersTest do
+  @moduledoc """
+  Elixir's half of the cross-runtime formatter helper check.
+
+  `fixtures/formatter-helpers.json` lists the helper capabilities every runtime
+  must offer a custom formatter. A module reports its own functions, so this
+  reflects rather than naming them again:
+
+  - "exports every helper in the manifest" fails on a capability Elixir lacks.
+  - "exports nothing the manifest does not account for" fails on a public
+    function in neither the manifest's helper set nor `runtime_only`. This is the
+    one that catches drift: the three helper modules reached 46 names between
+    them with 11 in all three before anything checked (#1381).
+
+  Arity is not checked. Elixir keeps its own argument shapes — a table where Rust
+  takes a theme, a keyword list where JavaScript takes an object — and only the
+  capability has to exist everywhere.
+  """
+  use ExUnit.Case, async: true
+
+  @manifest_path Path.expand("../../../../fixtures/formatter-helpers.json", __DIR__)
+  @external_resource @manifest_path
+
+  @modules %{"html" => Lumis.Formatter.HTML, "ansi" => Lumis.Formatter.ANSI}
+
+  # Read at runtime rather than into a module attribute: inlining the decoded
+  # JSON gives the compiler a literal type precise enough to warn on `Map.keys/1`.
+  defp manifest, do: @manifest_path |> File.read!() |> Jason.decode!()
+
+  defp exported(module) do
+    module.__info__(:functions)
+    |> Enum.map(fn {name, _arity} -> Atom.to_string(name) end)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp manifest_helpers(module) do
+    manifest()
+    |> Map.fetch!("modules")
+    |> Map.fetch!(module)
+    |> Map.fetch!("helpers")
+    |> Enum.map(&(get_in(&1, ["spelling", "elixir"]) || &1["name"]))
+    |> Enum.sort()
+  end
+
+  defp runtime_only(module) do
+    manifest()
+    |> Map.fetch!("runtime_only")
+    |> Map.get("elixir", %{})
+    |> Map.get(module, %{})
+    |> Map.keys()
+    |> Enum.reject(&String.starts_with?(&1, "$"))
+  end
+
+  test "covers the modules Elixir publishes" do
+    assert manifest() |> Map.fetch!("modules") |> Map.keys() |> Enum.sort() ==
+             @modules |> Map.keys() |> Enum.sort()
+  end
+
+  for {module, alias} <- @modules do
+    test "#{module} exports every helper in the manifest" do
+      module = unquote(module)
+      exported = exported(unquote(alias))
+      missing = Enum.reject(manifest_helpers(module), &(&1 in exported))
+
+      assert missing == [],
+             "#{unquote(alias)} is missing #{inspect(missing)}"
+    end
+
+    test "#{module} exports nothing the manifest does not account for" do
+      module = unquote(module)
+      accounted = manifest_helpers(module) ++ runtime_only(module)
+      unaccounted = Enum.reject(exported(unquote(alias)), &(&1 in accounted))
+
+      assert unaccounted == [],
+             "#{unquote(alias)} exports #{inspect(unaccounted)}, which is in neither the " <>
+               "manifest's helper set nor runtime_only. Add them to " <>
+               "fixtures/formatter-helpers.json and to the other runtimes, or classify them."
+    end
+
+    test "#{module} still exports every runtime_only helper" do
+      module = unquote(module)
+      exported = exported(unquote(alias))
+      gone = Enum.reject(runtime_only(module), &(&1 in exported))
+
+      assert gone == [], "runtime_only lists #{inspect(gone)}, which #{unquote(alias)} no longer
+             exports; drop the entry"
+    end
+  end
+
+  test "no waiver outlives its reason" do
+    waivers =
+      manifest()
+      |> Map.fetch!("waived")
+      |> Map.keys()
+      |> Enum.reject(&String.starts_with?(&1, "$"))
+
+    assert waivers == [],
+           "every runtime offers every capability; drop these waivers: #{inspect(waivers)}"
+  end
+end

--- a/packages/elixir/lumis/test/lumis/formatter/html_test.exs
+++ b/packages/elixir/lumis/test/lumis/formatter/html_test.exs
@@ -388,6 +388,14 @@ defmodule Lumis.Formatter.HTMLTest do
                "#{HTML.open_span(attrs, "keyword")}a &amp; b</span>"
     end
 
+    test "an explicit nil CSS variable prefix uses the default" do
+      assert HTML.span_multi_themes_attrs(themes: @themes_option, css_variable_prefix: nil) ==
+               HTML.span_multi_themes_attrs(themes: @themes_option)
+
+      assert HTML.open_multi_themes_pre_tag(themes: @themes_option, css_variable_prefix: nil) ==
+               HTML.open_multi_themes_pre_tag(themes: @themes_option)
+    end
+
     test "no themes leaves every scope unstyled" do
       attrs = HTML.span_multi_themes_attrs(themes: [], language: "elixir")
 
@@ -420,9 +428,9 @@ defmodule Lumis.Formatter.HTMLTest do
       assert HTML.highlight_line_class(lines, 4, []) == nil
     end
 
-    # A `RangeInclusive<usize>` has no step and cannot run backwards, so a range
-    # that has either has to be expanded before it crosses. Sent as-is, `1..5//2`
-    # highlighted the two lines the step excluded and `5..3` matched nothing.
+    # The compact native representation has to preserve both pieces of Elixir
+    # range semantics. Dropping the step would highlight lines 2 and 4 here;
+    # dropping the direction would make the descending range match nothing.
     test "honours a range's step and direction" do
       assert HTML.line_is_highlighted([1..5//2], 1)
       refute HTML.line_is_highlighted([1..5//2], 2)
@@ -433,35 +441,41 @@ defmodule Lumis.Formatter.HTMLTest do
       assert HTML.line_is_highlighted([5..3//-1], 4)
       refute HTML.line_is_highlighted([5..3//-1], 2)
 
+      assert HTML.line_is_highlighted([10..2//-3], 4)
+      refute HTML.line_is_highlighted([10..2//-3], 2), "the last bound need not be selected"
+
       refute HTML.line_is_highlighted([1..0//1], 1), "an empty range highlights nothing"
       refute HTML.line_is_highlighted([3..5//-1], 4), "so does an empty descending range"
     end
 
-    # A step of 1 or -1 is a contiguous run either way round, so it crosses as
-    # one range whatever its span. Any other step has to be listed out, and
-    # `1..1_000_000_000//2` listed out is 500 million tuples.
+    # Every range crosses as one compact arithmetic progression, regardless of
+    # its direction, step, or declared span.
     test "a huge contiguous range costs nothing, whichever way round" do
       assert HTML.line_is_highlighted([1..1_000_000_000], 999_999_999)
       assert HTML.line_is_highlighted([1_000_000_000..1//-1], 999_999_999)
     end
 
-    test "refuses to expand a stepped range too large to list out" do
-      assert_raise ArgumentError, ~r/over the 100000 limit/, fn ->
-        HTML.line_is_highlighted([1..1_000_000_000//2], 3)
-      end
+    test "a huge stepped range stays compact" do
+      assert {:ok, [{:range, %{start: 1, end: 1_000_000_000, step: 2}}]} =
+               Lumis.LineSpec.encode([1..1_000_000_000//2])
 
-      assert_raise ArgumentError, ~r/over the 100000 limit/, fn ->
-        HTML.highlight_line_class([1..1_000_000_000//2], 3, default_class: "hl")
-      end
+      assert HTML.line_is_highlighted([1..1_000_000_000//2], 3)
+      refute HTML.line_is_highlighted([1..1_000_000_000//2], 4)
+
+      assert HTML.highlight_line_class([1..1_000_000_000//2], 3, default_class: "hl") == "hl"
     end
 
-    test "the same range is an error tuple through the formatter options" do
-      assert {:error, message} =
-               Lumis.formatter_type(
-                 {:html_linked, highlight_lines: %{lines: [1..1_000_000_000//2]}}
-               )
+    test "the formatter clips a huge stepped range to its rendered lines" do
+      html =
+        Lumis.highlight!("one\ntwo\nthree",
+          formatter:
+            {:html_linked,
+             language: "plaintext", highlight_lines: %{lines: [1..1_000_000_000//2], class: "hl"}}
+        )
 
-      assert message =~ "over the 100000 limit"
+      assert html =~ ~s|class="l-line hl" data-line="1"|
+      refute html =~ ~s|class="l-line hl" data-line="2"|
+      assert html =~ ~s|class="l-line hl" data-line="3"|
     end
 
     test "picks the lines html_linked marks with its highlight class" do

--- a/packages/elixir/lumis/test/lumis/formatter/html_test.exs
+++ b/packages/elixir/lumis/test/lumis/formatter/html_test.exs
@@ -434,6 +434,34 @@ defmodule Lumis.Formatter.HTMLTest do
       refute HTML.line_is_highlighted([5..3//-1], 2)
 
       refute HTML.line_is_highlighted([1..0//1], 1), "an empty range highlights nothing"
+      refute HTML.line_is_highlighted([3..5//-1], 4), "so does an empty descending range"
+    end
+
+    # A step of 1 or -1 is a contiguous run either way round, so it crosses as
+    # one range whatever its span. Any other step has to be listed out, and
+    # `1..1_000_000_000//2` listed out is 500 million tuples.
+    test "a huge contiguous range costs nothing, whichever way round" do
+      assert HTML.line_is_highlighted([1..1_000_000_000], 999_999_999)
+      assert HTML.line_is_highlighted([1_000_000_000..1//-1], 999_999_999)
+    end
+
+    test "refuses to expand a stepped range too large to list out" do
+      assert_raise ArgumentError, ~r/over the 100000 limit/, fn ->
+        HTML.line_is_highlighted([1..1_000_000_000//2], 3)
+      end
+
+      assert_raise ArgumentError, ~r/over the 100000 limit/, fn ->
+        HTML.highlight_line_class([1..1_000_000_000//2], 3, default_class: "hl")
+      end
+    end
+
+    test "the same range is an error tuple through the formatter options" do
+      assert {:error, message} =
+               Lumis.formatter_type(
+                 {:html_linked, highlight_lines: %{lines: [1..1_000_000_000//2]}}
+               )
+
+      assert message =~ "over the 100000 limit"
     end
 
     test "picks the lines html_linked marks with its highlight class" do

--- a/packages/elixir/lumis/test/lumis/formatter/html_test.exs
+++ b/packages/elixir/lumis/test/lumis/formatter/html_test.exs
@@ -3,6 +3,8 @@ defmodule Lumis.Formatter.HTMLTest do
 
   alias Lumis.Formatter.HTML
 
+  doctest Lumis.Formatter.HTML
+
   # The only public way to see an event stream is to be handed one, so this
   # captures it the way any formatter would.
   defmodule CaptureFormatter do
@@ -259,6 +261,304 @@ defmodule Lumis.Formatter.HTMLTest do
           assert String.contains?(html, "<span #{HTML.span_linked_attrs(scope)}>"),
                  "#{language}: html_linked never opens <span #{HTML.span_linked_attrs(scope)}>"
         end)
+      end
+    end
+  end
+
+  describe "escape_attr/1" do
+    test "escapes the same five entities escape/1 does" do
+      assert HTML.escape_attr(~s|&<>"'|) == "&amp;&lt;&gt;&quot;&#39;"
+    end
+
+    test "closes an injection through a caller-supplied class" do
+      assert HTML.open_pre_tag(class: ~s|x"><script>|) ==
+               ~s|<pre class="lumis #{HTML.escape_attr(~s|x"><script>|)}">|
+    end
+
+    test "leaves quoted CSS readable after the parser decodes it" do
+      assert HTML.escape_attr("font-family: 'Fira Code';") == "font-family: &#39;Fira Code&#39;;"
+    end
+  end
+
+  describe "sanitize_theme_name/1" do
+    test "keeps letters, digits, dash and underscore" do
+      assert HTML.sanitize_theme_name("catppuccin_mocha-2") == "catppuccin_mocha-2"
+    end
+
+    test "replaces everything else with a dash, keeping non-ASCII letters" do
+      assert HTML.sanitize_theme_name("Rosé Pine (Dawn)") == "Rosé-Pine--Dawn-"
+    end
+
+    test "is the form a theme name takes in the CSS variables span_multi_themes_attrs writes" do
+      attrs =
+        HTML.span_multi_themes_attrs(themes: [{:"my theme", "github_light"}], language: "elixir")
+
+      assert attrs["keyword"] =~ "--lumis-#{HTML.sanitize_theme_name("my theme")}:"
+    end
+  end
+
+  describe "text_decoration/1 and style_to_css/2" do
+    test "text_decoration/1 covers underline styles and strikethrough" do
+      assert HTML.text_decoration(%Lumis.Theme.TextDecoration{}) == "none"
+
+      assert HTML.text_decoration(%Lumis.Theme.TextDecoration{strikethrough: true}) ==
+               "line-through"
+
+      assert HTML.text_decoration(%Lumis.Theme.TextDecoration{underline: :dotted}) ==
+               "underline dotted"
+
+      assert HTML.text_decoration(%Lumis.Theme.TextDecoration{
+               underline: :double,
+               strikethrough: true
+             }) == "underline double line-through"
+    end
+
+    test "style_to_css/2 writes the declarations span_attrs puts in a style attribute" do
+      theme = Lumis.Theme.get("dracula")
+      attrs = HTML.span_attrs(theme: theme, language: "elixir")
+      style = theme.highlights["keyword"]
+
+      assert HTML.open_span(attrs, "keyword") =~ HTML.style_to_css(style)
+    end
+
+    test "style_to_css/2 honours :italic and :separator" do
+      style = %Lumis.Theme.Style{fg: "#ff79c6", italic: true}
+
+      assert HTML.style_to_css(style) == "color: #ff79c6;"
+      assert HTML.style_to_css(style, italic: true) == "color: #ff79c6; font-style: italic;"
+
+      assert HTML.style_to_css(style, italic: true, separator: "\n") ==
+               "color: #ff79c6;\nfont-style: italic;"
+    end
+  end
+
+  describe "close_pre_tag/0 and close_code_tag/0" do
+    test "together they are closing_tags/0" do
+      assert HTML.close_code_tag() <> HTML.close_pre_tag() == HTML.closing_tags()
+    end
+  end
+
+  describe "span_multi_themes_attrs/1 and open_multi_themes_pre_tag/1" do
+    @themes_option [light: "github_light", dark: "dracula"]
+
+    defp html_multi_themes(source, language, options) do
+      Lumis.highlight!(
+        source,
+        formatter: {:html_multi_themes, [language: language, themes: @themes_option] ++ options}
+      )
+    end
+
+    test "opens the <pre> html_multi_themes opens" do
+      for default_theme <- [nil, "light", "light-dark()"],
+          {source, language} <- @sources do
+        options = if default_theme, do: [default_theme: default_theme], else: []
+
+        assert String.starts_with?(
+                 html_multi_themes(source, language, options),
+                 HTML.open_multi_themes_pre_tag([themes: @themes_option] ++ options)
+               ),
+               "#{inspect(default_theme)}/#{language} opened differently"
+      end
+    end
+
+    test "every span html_multi_themes opens is one span_multi_themes_attrs produces" do
+      for default_theme <- [nil, "light", "light-dark()"],
+          {source, language} <- @sources,
+          source != "" do
+        options = if default_theme, do: [default_theme: default_theme], else: []
+
+        attrs =
+          HTML.span_multi_themes_attrs([themes: @themes_option, language: language] ++ options)
+
+        html_multi_themes(source, language, options)
+        |> then(&Regex.scan(~r|(<span[^>]*>)|, &1))
+        |> Enum.map(fn [_, tag] -> tag end)
+        |> Enum.uniq()
+        |> Enum.each(fn tag ->
+          assert scope_of(tag, attrs),
+                 "#{inspect(default_theme)}/#{language}: no scope produces #{inspect(tag)}"
+        end)
+      end
+    end
+
+    test "span_multi_themes/3 escapes the text and opens with the table's attributes" do
+      attrs = HTML.span_multi_themes_attrs(themes: @themes_option, language: "elixir")
+
+      assert HTML.span_multi_themes("a & b", attrs, "keyword") ==
+               "#{HTML.open_span(attrs, "keyword")}a &amp; b</span>"
+    end
+
+    test "no themes leaves every scope unstyled" do
+      attrs = HTML.span_multi_themes_attrs(themes: [], language: "elixir")
+
+      assert HTML.open_span(attrs, "keyword") == "<span>"
+    end
+  end
+
+  describe "line_is_highlighted/2 and highlight_line_class/3" do
+    test "reads integers and ranges the way :highlight_lines does" do
+      lines = [1, 3..5]
+
+      assert HTML.line_is_highlighted(lines, 1)
+      assert HTML.line_is_highlighted(lines, 4)
+      assert HTML.line_is_highlighted(lines, 5)
+      refute HTML.line_is_highlighted(lines, 2)
+      refute HTML.line_is_highlighted(lines, 6)
+      refute HTML.line_is_highlighted([], 1)
+    end
+
+    test "highlight_line_class/3 prefers :class over :default_class" do
+      lines = [1, 3..5]
+
+      assert HTML.highlight_line_class(lines, 4, default_class: "l-highlighted") ==
+               "l-highlighted"
+
+      assert HTML.highlight_line_class(lines, 4, class: "active", default_class: "l-highlighted") ==
+               "active"
+
+      assert HTML.highlight_line_class(lines, 2, class: "active") == nil
+      assert HTML.highlight_line_class(lines, 4, []) == nil
+    end
+
+    test "picks the lines html_linked marks with its highlight class" do
+      source = "one\ntwo\nthree\nfour\nfive\n"
+      lines = [1, 3..4]
+
+      html =
+        Lumis.highlight!(source,
+          formatter:
+            {:html_linked, language: "plaintext", highlight_lines: %{lines: lines, class: "hl"}}
+        )
+
+      for line_number <- 1..5 do
+        marked = String.contains?(html, ~s|class="l-line hl" data-line="#{line_number}"|)
+
+        assert marked == HTML.line_is_highlighted(lines, line_number),
+               "line #{line_number}: html_linked and line_is_highlighted/2 disagree"
+      end
+    end
+  end
+
+  describe "render_lines_from_events/3" do
+    test "renders the lines html_linked wraps, for every source" do
+      linked_attrs =
+        Map.new(HTML.classes(), fn {scope, _class} -> {scope, HTML.span_linked_attrs(scope)} end)
+
+      for {source, language} <- @sources, source != "" do
+        expected =
+          source
+          |> html_linked(language)
+          |> then(&Regex.scan(~r|<div class="l-line" data-line="\d+">(.*?)</div>|s, &1))
+          |> Enum.map(fn [_, content] -> String.trim_trailing(content, "\n") end)
+
+        actual =
+          HTML.render_lines_from_events(source, events(source, language), linked_attrs)
+
+        assert actual == expected,
+               "#{language}: render_lines_from_events differs from html_linked"
+      end
+    end
+
+    test "reopens a span that crosses a newline" do
+      events = [
+        {:start, %{scope: "keyword", language: "elixir"}},
+        {:source, %{start: 0, end: 3}},
+        :end
+      ]
+
+      assert HTML.render_lines_from_events("a\nb", events, %{"keyword" => ~s|class="l-keyword"|}) ==
+               [~s|<span class="l-keyword">a</span>|, ~s|<span class="l-keyword">b</span>|]
+    end
+
+    test "a scope the table does not carry opens a bare span" do
+      events = [
+        {:start, %{scope: "not.a.scope", language: "elixir"}},
+        {:source, %{start: 0, end: 1}},
+        :end
+      ]
+
+      assert HTML.render_lines_from_events("a", events, %{}) == ["<span>a</span>"]
+    end
+
+    test "skips an event kind it has no markup for rather than raising" do
+      events = [
+        {:annotation_start, %Lumis.Annotation{range: {0, 1}, data: %{anything: true}}},
+        {:source, %{start: 0, end: 1}},
+        :annotation_end,
+        {:something_a_newer_lumis_adds, %{}}
+      ]
+
+      assert HTML.render_lines_from_events("a", events, %{}) == ["a"]
+    end
+
+    test "escapes the source it renders" do
+      events = [{:source, %{start: 0, end: 5}}]
+
+      assert HTML.render_lines_from_events("a & b", events, %{}) == ["a &amp; b"]
+    end
+  end
+
+  # The point of the whole module: a formatter assembled from the helpers is the
+  # built-in one, byte for byte. This is the formatter #1381 said could not be
+  # written in Elixir at all.
+  defmodule MultiThemeFormatter do
+    @moduledoc false
+    @behaviour Lumis.Formatter
+
+    alias Lumis.Formatter.HTML
+
+    @themes [light: "github_light", dark: "dracula"]
+
+    @impl true
+    def render(source, events, options) do
+      language = Keyword.fetch!(options, :language)
+      default_theme = Keyword.fetch!(options, :default_theme)
+
+      attrs =
+        HTML.span_multi_themes_attrs(
+          themes: @themes,
+          default_theme: default_theme,
+          language: language
+        )
+
+      body =
+        source
+        |> HTML.render_lines_from_events(events, attrs)
+        |> Enum.with_index(1)
+        |> Enum.map(fn {line, number} -> HTML.wrap_line(number, [line, "\n"]) end)
+
+      [
+        HTML.open_multi_themes_pre_tag(themes: @themes, default_theme: default_theme),
+        HTML.open_code_tag(language),
+        body,
+        HTML.closing_tags()
+      ]
+    end
+  end
+
+  describe "a formatter built from the helpers" do
+    test "reproduces :html_multi_themes byte for byte" do
+      for default_theme <- [nil, "light", "light-dark()"],
+          {source, language} <- @sources,
+          source != "" do
+        options = if default_theme, do: [default_theme: default_theme], else: []
+
+        builtin =
+          Lumis.highlight!(
+            source,
+            formatter:
+              {:html_multi_themes,
+               [language: language, themes: [light: "github_light", dark: "dracula"]] ++ options}
+          )
+
+        mine =
+          Lumis.highlight!(
+            source,
+            formatter: {MultiThemeFormatter, language: language, default_theme: default_theme}
+          )
+
+        assert mine == builtin,
+               "#{inspect(default_theme)}/#{language}: the helper-built formatter differs"
       end
     end
   end

--- a/packages/elixir/lumis/test/lumis/formatter/html_test.exs
+++ b/packages/elixir/lumis/test/lumis/formatter/html_test.exs
@@ -420,21 +420,39 @@ defmodule Lumis.Formatter.HTMLTest do
       assert HTML.highlight_line_class(lines, 4, []) == nil
     end
 
+    # A `RangeInclusive<usize>` has no step and cannot run backwards, so a range
+    # that has either has to be expanded before it crosses. Sent as-is, `1..5//2`
+    # highlighted the two lines the step excluded and `5..3` matched nothing.
+    test "honours a range's step and direction" do
+      assert HTML.line_is_highlighted([1..5//2], 1)
+      refute HTML.line_is_highlighted([1..5//2], 2)
+      assert HTML.line_is_highlighted([1..5//2], 3)
+      refute HTML.line_is_highlighted([1..5//2], 4)
+      assert HTML.line_is_highlighted([1..5//2], 5)
+
+      assert HTML.line_is_highlighted([5..3//-1], 4)
+      refute HTML.line_is_highlighted([5..3//-1], 2)
+
+      refute HTML.line_is_highlighted([1..0//1], 1), "an empty range highlights nothing"
+    end
+
     test "picks the lines html_linked marks with its highlight class" do
       source = "one\ntwo\nthree\nfour\nfive\n"
-      lines = [1, 3..4]
 
-      html =
-        Lumis.highlight!(source,
-          formatter:
-            {:html_linked, language: "plaintext", highlight_lines: %{lines: lines, class: "hl"}}
-        )
+      for lines <- [[1, 3..4], [1..5//2], [5..3//-1]] do
+        html =
+          Lumis.highlight!(source,
+            formatter:
+              {:html_linked, language: "plaintext", highlight_lines: %{lines: lines, class: "hl"}}
+          )
 
-      for line_number <- 1..5 do
-        marked = String.contains?(html, ~s|class="l-line hl" data-line="#{line_number}"|)
+        for line_number <- 1..5 do
+          marked = String.contains?(html, ~s|class="l-line hl" data-line="#{line_number}"|)
 
-        assert marked == HTML.line_is_highlighted(lines, line_number),
-               "line #{line_number}: html_linked and line_is_highlighted/2 disagree"
+          assert marked == HTML.line_is_highlighted(lines, line_number),
+                 "#{inspect(lines)} line #{line_number}: html_linked and " <>
+                   "line_is_highlighted/2 disagree"
+        end
       end
     end
   end
@@ -495,6 +513,21 @@ defmodule Lumis.Formatter.HTMLTest do
       events = [{:source, %{start: 0, end: 5}}]
 
       assert HTML.render_lines_from_events("a & b", events, %{}) == ["a &amp; b"]
+    end
+
+    # A formatter can build its own events rather than replaying the ones it was
+    # handed, so these offsets are caller data. An offset landing inside a
+    # multi-byte character used to panic the NIF.
+    test "takes offsets that split a character without blowing up" do
+      assert HTML.render_lines_from_events("é", [{:source, %{start: 0, end: 1}}], %{}) == [""]
+      assert HTML.render_lines_from_events("éx", [{:source, %{start: 1, end: 3}}], %{}) == ["x"]
+      assert HTML.render_lines_from_events("é", [{:source, %{start: 0, end: 2}}], %{}) == ["é"]
+    end
+
+    test "takes offsets that are out of range or reversed" do
+      assert HTML.render_lines_from_events("ab", [{:source, %{start: 0, end: 99}}], %{}) == ["ab"]
+      assert HTML.render_lines_from_events("ab", [{:source, %{start: 99, end: 99}}], %{}) == [""]
+      assert HTML.render_lines_from_events("ab", [{:source, %{start: 2, end: 0}}], %{}) == [""]
     end
   end
 

--- a/packages/elixir/lumis/usage-rules.md
+++ b/packages/elixir/lumis/usage-rules.md
@@ -510,13 +510,35 @@ Lumis.highlight!(code, formatter: {MyFormatter, language: "elixir", theme: "gith
 Do not hand-roll HTML escaping or scope-to-class mapping. `Lumis.Formatter.HTML`
 gives the built-in formatters' pieces:
 
-- `escape/1`, `escape_braces/1`
+- `escape/1`, `escape_attr/1`, `escape_braces/1`
 - `scope_to_class/1`, `span_linked_attrs/1`, `span_linked/2`
 - `span_attrs/1`, `open_span/2`, `span_inline_attrs/2`, `span_inline/3`
-- `open_pre_tag/1`, `open_code_tag/1`, `closing_tags/0`, `wrap_line/3`
+- `span_multi_themes_attrs/1`, `span_multi_themes/3`, `sanitize_theme_name/1`
+- `style_to_css/2`, `text_decoration/1`
+- `open_pre_tag/1`, `open_multi_themes_pre_tag/1`, `open_code_tag/1`
+- `close_pre_tag/0`, `close_code_tag/0`, `closing_tags/0`
+- `wrap_line/3`, `line_is_highlighted/2`, `highlight_line_class/3`
+- `render_lines_from_events/3`
 
-`span_attrs/1` and `classes/0` return whole tables because resolving a scope is
-a per-token operation. Build the table once outside the loop and read it inside.
+`span_attrs/1`, `span_multi_themes_attrs/1` and `classes/0` return whole tables
+because resolving a scope is a per-token operation. Build the table once outside
+the loop and read it inside.
+
+For line-based output, reach for `render_lines_from_events/3` rather than
+splitting rendered markup on newlines. A `<span>` that crosses a newline has to
+be closed and reopened for each line's tags to nest, and that is the part worth
+not writing again:
+
+```elixir
+attrs = HTML.span_attrs(theme: theme, language: language)
+
+source
+|> HTML.render_lines_from_events(events, attrs)
+|> Enum.with_index(1)
+# A rendered line carries no trailing newline. The built-in formatters put one
+# inside the <div> so the block still copies as lines.
+|> Enum.map(fn {line, number} -> HTML.wrap_line(number, [line, "\n"]) end)
+```
 
 Do not hand-roll ANSI color or text-decoration escape sequences either.
 `Lumis.Formatter.ANSI` gives `:terminal`'s pieces:

--- a/packages/javascript/lumis/src/formatter/html-inline.ts
+++ b/packages/javascript/lumis/src/formatter/html-inline.ts
@@ -2,10 +2,8 @@ import type { HighlightEvent, HighlightSpan, HtmlInlineFormatter } from "../type
 import {
   closingTags,
   formatHighlightIterLines,
-  getHighlightLineClass,
   getScopedThemeStyle,
   getThemeStyle,
-  lineIsHighlighted,
   openCodeTag,
   openPreTag,
   openSpanTag,
@@ -13,6 +11,7 @@ import {
   wrapLine,
   wrapWithHeader,
 } from "./html.js";
+import { selectedLineFlags } from "./line-highlights.js";
 
 function spanAttrs(
   span: HighlightSpan,
@@ -36,10 +35,10 @@ function spanAttrs(
 
 function highlightLineStyle(
   formatter: HtmlInlineFormatter,
-  lineNumber: number,
+  isHighlighted: boolean,
 ): string | undefined {
   const highlightLines = formatter.highlightLines;
-  if (!lineIsHighlighted(highlightLines?.lines, lineNumber)) {
+  if (!isHighlighted) {
     return undefined;
   }
 
@@ -59,22 +58,18 @@ function highlightLineStyle(
 
 function highlightLineClass(
   formatter: HtmlInlineFormatter,
-  lineNumber: number,
+  isHighlighted: boolean,
 ): string | undefined {
-  return getHighlightLineClass(
-    formatter.highlightLines?.lines,
-    lineNumber,
-    formatter.highlightLines?.class,
-  );
+  return isHighlighted ? formatter.highlightLines?.class : undefined;
 }
 
 function getLineAttrs(
   formatter: HtmlInlineFormatter,
-  lineNumber: number,
+  isHighlighted: boolean,
 ): { className?: string; style?: string } {
   return {
-    className: highlightLineClass(formatter, lineNumber),
-    style: highlightLineStyle(formatter, lineNumber),
+    className: highlightLineClass(formatter, isHighlighted),
+    style: highlightLineStyle(formatter, isHighlighted),
   };
 }
 
@@ -89,8 +84,11 @@ export function formatHtmlInline(
 
   const pre = openPreTag({ preClass: formatter.preClass, theme: formatter.theme });
   const code = openCodeTag(formatter.language);
+  const highlighted = selectedLineFlags(formatter.highlightLines?.lines, lines.length);
   const body = lines
-    .map((line, idx) => wrapLine(idx + 1, line, getLineAttrs(formatter, idx + 1)))
+    .map((line, idx) =>
+      wrapLine(idx + 1, line, getLineAttrs(formatter, Boolean(highlighted?.[idx]))),
+    )
     .join("");
 
   return wrapWithHeader(`${pre}${code}${body}${closingTags()}`, formatter.header);

--- a/packages/javascript/lumis/src/formatter/html-linked.ts
+++ b/packages/javascript/lumis/src/formatter/html-linked.ts
@@ -2,7 +2,6 @@ import type { HighlightEvent, HtmlLinkedFormatter } from "../types.js";
 import {
   closingTags,
   formatHighlightIterLines,
-  getHighlightLineClass,
   openCodeTag,
   openPreTag,
   openSpanTag,
@@ -10,22 +9,21 @@ import {
   wrapLine,
   wrapWithHeader,
 } from "./html.js";
+import { selectedLineFlags } from "./line-highlights.js";
 
 function highlightLineClass(
   formatter: HtmlLinkedFormatter,
-  lineNumber: number,
+  isHighlighted: boolean,
 ): string | undefined {
-  return getHighlightLineClass(
-    formatter.highlightLines?.lines,
-    lineNumber,
-    formatter.highlightLines?.class,
-    "l-highlighted",
-  );
+  return isHighlighted ? (formatter.highlightLines?.class ?? "l-highlighted") : undefined;
 }
 
-function getLineAttrs(formatter: HtmlLinkedFormatter, lineNumber: number): { className?: string } {
+function getLineAttrs(
+  formatter: HtmlLinkedFormatter,
+  isHighlighted: boolean,
+): { className?: string } {
   return {
-    className: highlightLineClass(formatter, lineNumber),
+    className: highlightLineClass(formatter, isHighlighted),
   };
 }
 
@@ -40,8 +38,11 @@ export function formatHtmlLinked(
 
   const pre = openPreTag({ preClass: formatter.preClass });
   const code = openCodeTag(formatter.language);
+  const highlighted = selectedLineFlags(formatter.highlightLines?.lines, lines.length);
   const body = lines
-    .map((line, idx) => wrapLine(idx + 1, line, getLineAttrs(formatter, idx + 1)))
+    .map((line, idx) =>
+      wrapLine(idx + 1, line, getLineAttrs(formatter, Boolean(highlighted?.[idx]))),
+    )
     .join("");
 
   return wrapWithHeader(`${pre}${code}${body}${closingTags()}`, formatter.header);

--- a/packages/javascript/lumis/src/formatter/html-multi-themes.ts
+++ b/packages/javascript/lumis/src/formatter/html-multi-themes.ts
@@ -3,9 +3,7 @@ import {
   type HtmlAttrs,
   closingTags,
   formatHighlightIterLines,
-  getHighlightLineClass,
   getThemeStyle,
-  lineIsHighlighted,
   openCodeTag,
   openMultiThemesPreTag,
   openSpanTag,
@@ -14,6 +12,7 @@ import {
   wrapLine,
   wrapWithHeader,
 } from "./html.js";
+import { selectedLineFlags } from "./line-highlights.js";
 
 function spanAttrs(span: HighlightSpan, formatter: HtmlMultiThemesFormatter): HtmlAttrs {
   return spanMultiThemesAttrs({
@@ -29,10 +28,10 @@ function spanAttrs(span: HighlightSpan, formatter: HtmlMultiThemesFormatter): Ht
 
 function highlightLineStyle(
   formatter: HtmlMultiThemesFormatter,
-  lineNumber: number,
+  isHighlighted: boolean,
 ): string | undefined {
   const highlightLines = formatter.highlightLines;
-  if (!lineIsHighlighted(highlightLines?.lines, lineNumber)) return undefined;
+  if (!isHighlighted) return undefined;
 
   // Explicit `null` opts out of the inline style entirely, leaving the class to
   // do the highlighting. Absent still means the theme's `highlighted` style.
@@ -62,22 +61,18 @@ function lightDarkHighlightStyle(formatter: HtmlMultiThemesFormatter): string | 
 
 function highlightLineClass(
   formatter: HtmlMultiThemesFormatter,
-  lineNumber: number,
+  isHighlighted: boolean,
 ): string | undefined {
-  return getHighlightLineClass(
-    formatter.highlightLines?.lines,
-    lineNumber,
-    formatter.highlightLines?.class,
-  );
+  return isHighlighted ? formatter.highlightLines?.class : undefined;
 }
 
 function getLineAttrs(
   formatter: HtmlMultiThemesFormatter,
-  lineNumber: number,
+  isHighlighted: boolean,
 ): { className?: string; style?: string } {
   return {
-    className: highlightLineClass(formatter, lineNumber),
-    style: highlightLineStyle(formatter, lineNumber),
+    className: highlightLineClass(formatter, isHighlighted),
+    style: highlightLineStyle(formatter, isHighlighted),
   };
 }
 
@@ -98,8 +93,11 @@ export function formatHtmlMultiThemes(
     cssVariablePrefix: formatter.cssVariablePrefix,
   });
   const code = openCodeTag(formatter.language);
+  const highlighted = selectedLineFlags(formatter.highlightLines?.lines, lines.length);
   const body = lines
-    .map((line, idx) => wrapLine(idx + 1, line, getLineAttrs(formatter, idx + 1)))
+    .map((line, idx) =>
+      wrapLine(idx + 1, line, getLineAttrs(formatter, Boolean(highlighted?.[idx]))),
+    )
     .join("");
 
   return wrapWithHeader(`${pre}${code}${body}${closingTags()}`, formatter.header);

--- a/packages/javascript/lumis/src/formatter/html-multi-themes.ts
+++ b/packages/javascript/lumis/src/formatter/html-multi-themes.ts
@@ -1,60 +1,19 @@
-import type { HighlightEvent, HighlightSpan, HtmlMultiThemesFormatter, Theme } from "../types.js";
+import type { HighlightEvent, HighlightSpan, HtmlMultiThemesFormatter } from "../types.js";
 import {
   type HtmlAttrs,
-  buildNormalThemeVars,
   closingTags,
   formatHighlightIterLines,
   getHighlightLineClass,
   getThemeStyle,
-  joinClasses,
   lineIsHighlighted,
   openCodeTag,
+  openMultiThemesPreTag,
   openSpanTag,
-  openTag,
-  sortedThemeNames,
   spanMultiThemesAttrs,
   styleToCss,
   wrapLine,
   wrapWithHeader,
 } from "./html.js";
-
-// The `<pre>` colours for `light-dark()`, falling back to black on white and
-// white on black where a theme leaves them unset.
-function lightDarkPreStyles(themes: Record<string, Theme>): string[] {
-  const lightNormal = getThemeStyle(themes.light, "normal");
-  const darkNormal = getThemeStyle(themes.dark, "normal");
-  const lightFg = lightNormal?.fg ?? "#000000";
-  const lightBg = lightNormal?.bg ?? "#ffffff";
-  const darkFg = darkNormal?.fg ?? "#ffffff";
-  const darkBg = darkNormal?.bg ?? "#000000";
-
-  return [
-    `color: light-dark(${lightFg}, ${darkFg});`,
-    `background-color: light-dark(${lightBg}, ${darkBg});`,
-  ];
-}
-
-function buildPreThemeStyle(options: {
-  themes: Record<string, Theme>;
-  defaultTheme?: string;
-  cssVariablePrefix?: string;
-}): string | undefined {
-  const prefix = options.cssVariablePrefix ?? "--lumis";
-  const styles: string[] = [];
-
-  if (options.defaultTheme === "light-dark()") {
-    styles.push(...lightDarkPreStyles(options.themes));
-  } else if (options.defaultTheme) {
-    const defaultStyle = getThemeStyle(options.themes[options.defaultTheme], "normal");
-    if (defaultStyle?.fg) styles.push(`color:${defaultStyle.fg};`);
-    if (defaultStyle?.bg) styles.push(`background-color:${defaultStyle.bg};`);
-    buildNormalThemeVars(styles, prefix, options.themes, options.defaultTheme);
-  } else {
-    buildNormalThemeVars(styles, prefix, options.themes);
-  }
-
-  return styles.length > 0 ? styles.join(" ") : undefined;
-}
 
 function spanAttrs(span: HighlightSpan, formatter: HtmlMultiThemesFormatter): HtmlAttrs {
   return spanMultiThemesAttrs({
@@ -65,25 +24,6 @@ function spanAttrs(span: HighlightSpan, formatter: HtmlMultiThemesFormatter): Ht
     cssVariablePrefix: formatter.cssVariablePrefix,
     italic: formatter.italic,
     includeHighlights: formatter.includeHighlights,
-  });
-}
-
-function generatePreClasses(formatter: HtmlMultiThemesFormatter): string {
-  return (
-    joinClasses(
-      "lumis",
-      "lumis-themes",
-      formatter.preClass,
-      ...sortedThemeNames(formatter.themes),
-    ) ?? "lumis lumis-themes"
-  );
-}
-
-function generatePreStyle(formatter: HtmlMultiThemesFormatter): string | undefined {
-  return buildPreThemeStyle({
-    themes: formatter.themes,
-    defaultTheme: formatter.defaultTheme,
-    cssVariablePrefix: formatter.cssVariablePrefix,
   });
 }
 
@@ -151,9 +91,11 @@ export function formatHtmlMultiThemes(
     openSpan: (span, _style) => openSpanTag(spanAttrs(span, formatter)),
   });
 
-  const pre = openTag("pre", {
-    class: generatePreClasses(formatter),
-    style: generatePreStyle(formatter),
+  const pre = openMultiThemesPreTag({
+    preClass: formatter.preClass,
+    themes: formatter.themes,
+    defaultTheme: formatter.defaultTheme,
+    cssVariablePrefix: formatter.cssVariablePrefix,
   });
   const code = openCodeTag(formatter.language);
   const body = lines

--- a/packages/javascript/lumis/src/formatter/html.ts
+++ b/packages/javascript/lumis/src/formatter/html.ts
@@ -255,32 +255,14 @@ export function escapeAttr(value: string): string {
   return result;
 }
 
-/**
- * Join CSS class names, filtering out falsy values.
- *
- * ```ts
- * joinClasses('l-line', undefined, 'l-highlighted')  // "l-line l-highlighted"
- * joinClasses(undefined, false)                   // undefined
- * ```
- */
-export function joinClasses(
-  ...classes: Array<string | undefined | false | null>
-): string | undefined {
+function classList(...classes: Array<string | undefined | false | null>): string | undefined {
   const value = classes.filter(
     (className): className is string => !!className && className.length > 0,
   );
   return value.length > 0 ? value.join(" ") : undefined;
 }
 
-/**
- * Render an `HtmlAttrs` map to an HTML attribute string.
- *
- * ```ts
- * attrsToString({ class: 'foo', style: 'color: red', hidden: true })
- * // 'class="foo" style="color: red" hidden'
- * ```
- */
-export function attrsToString(attrs: HtmlAttrs): string {
+function renderAttrs(attrs: HtmlAttrs): string {
   const parts: string[] = [];
 
   for (const [name, value] of Object.entries(attrs)) {
@@ -296,6 +278,43 @@ export function attrsToString(attrs: HtmlAttrs): string {
   return parts.join(" ");
 }
 
+function tag(name: string, attrs: HtmlAttrs = {}): string {
+  const renderedAttrs = renderAttrs(attrs);
+  return renderedAttrs.length > 0 ? `<${name} ${renderedAttrs}>` : `<${name}>`;
+}
+
+/**
+ * Join CSS class names, filtering out falsy values.
+ *
+ * ```ts
+ * joinClasses('l-line', undefined, 'l-highlighted')  // "l-line l-highlighted"
+ * joinClasses(undefined, false)                   // undefined
+ * ```
+ *
+ * @deprecated Generic plumbing that Rust and Elixir do inline; it is not
+ * Lumis's to own. Removed in the next major.
+ */
+export function joinClasses(
+  ...classes: Array<string | undefined | false | null>
+): string | undefined {
+  return classList(...classes);
+}
+
+/**
+ * Render an `HtmlAttrs` map to an HTML attribute string.
+ *
+ * ```ts
+ * attrsToString({ class: 'foo', style: 'color: red', hidden: true })
+ * // 'class="foo" style="color: red" hidden'
+ * ```
+ *
+ * @deprecated Use {@link openSpanTag}, which renders the attributes it is
+ * given. Removed in the next major.
+ */
+export function attrsToString(attrs: HtmlAttrs): string {
+  return renderAttrs(attrs);
+}
+
 /**
  * Build an opening HTML tag with attributes.
  *
@@ -303,10 +322,12 @@ export function attrsToString(attrs: HtmlAttrs): string {
  * openTag('span', { class: 'keyword', style: 'color: red' })
  * // '<span class="keyword" style="color: red">'
  * ```
+ *
+ * @deprecated Use {@link openPreTag}, {@link openCodeTag} or
+ * {@link openSpanTag}. Removed in the next major.
  */
 export function openTag(name: string, attrs: HtmlAttrs = {}): string {
-  const renderedAttrs = attrsToString(attrs);
-  return renderedAttrs.length > 0 ? `<${name} ${renderedAttrs}>` : `<${name}>`;
+  return tag(name, attrs);
 }
 
 /**
@@ -315,6 +336,9 @@ export function openTag(name: string, attrs: HtmlAttrs = {}): string {
  * ```ts
  * closeTag('span')  // "</span>"
  * ```
+ *
+ * @deprecated Use {@link closePreTag}, {@link closeCodeTag} or
+ * {@link closingTags}. Removed in the next major.
  */
 export function closeTag(name: string): string {
   return `</${name}>`;
@@ -328,7 +352,7 @@ export function closeTag(name: string): string {
  * ```
  */
 export function openSpanTag(attrs: HtmlAttrs = {}): string {
-  return openSpan(attrsToString(attrs));
+  return openSpan(renderAttrs(attrs));
 }
 
 function openSpan(attrs: string): string {
@@ -358,10 +382,42 @@ export interface OpenPreTagOptions {
 export function openPreTag(options: OpenPreTagOptions = {}): string {
   const className = options.preClass ? `lumis ${options.preClass}` : "lumis";
   const style = styleToCss(getThemeStyle(options.theme, "normal"));
-  return openTag("pre", {
+  return tag("pre", {
     class: className,
     style: style.length > 0 ? style : undefined,
   });
+}
+
+/**
+ * Options for {@link openMultiThemesPreTag}.
+ */
+export interface OpenMultiThemesPreTagOptions {
+  preClass?: string;
+  themes: Record<string, Theme>;
+  defaultTheme?: string;
+  /** Defaults to `"--lumis"`. */
+  cssVariablePrefix?: string;
+}
+
+/**
+ * Open a `<pre>` tag carrying every theme's name as a class and its `normal`
+ * colours as CSS custom properties.
+ *
+ * The `<pre>` counterpart of {@link spanMultiThemesAttrs}: `defaultTheme` is
+ * written inline and every other theme becomes a variable, except for
+ * `"light-dark()"`, which writes both inline and contributes no variables.
+ *
+ * ```ts
+ * openMultiThemesPreTag({ themes: { light: githubLight, dark: githubDark }, defaultTheme: 'light' })
+ * // '<pre class="lumis lumis-themes dark light" style="color:#1f2328; ... --lumis-dark:#e6edf3; ...">'
+ * ```
+ */
+export function openMultiThemesPreTag(options: OpenMultiThemesPreTagOptions): string {
+  const classes =
+    classList("lumis", "lumis-themes", options.preClass, ...sortedThemeNames(options.themes)) ??
+    "lumis lumis-themes";
+
+  return tag("pre", { class: classes, style: multiThemesPreStyle(options) });
 }
 
 /**
@@ -373,7 +429,7 @@ export function openPreTag(options: OpenPreTagOptions = {}): string {
  */
 export function openCodeTag(language: LanguageRef | undefined): string {
   const id = language ? languageId(language) : "plaintext";
-  return openTag("code", {
+  return tag("code", {
     class: `language-${id}`,
     translate: "no",
     tabindex: 0,
@@ -388,7 +444,7 @@ export function openCodeTag(language: LanguageRef | undefined): string {
  * ```
  */
 export function closePreTag(): string {
-  return closeTag("pre");
+  return "</pre>";
 }
 
 /**
@@ -399,7 +455,7 @@ export function closePreTag(): string {
  * ```
  */
 export function closeCodeTag(): string {
-  return closeTag("code");
+  return "</code>";
 }
 
 /**
@@ -438,6 +494,9 @@ export function escapeBraces(text: string): string {
   return text.replaceAll("{", "&lbrace;").replaceAll("}", "&rbrace;");
 }
 
+/**
+ * @deprecated A pure alias of {@link escape}. Removed in the next major.
+ */
 export function escapeFragment(text: string): string {
   return escape(text);
 }
@@ -588,9 +647,9 @@ export function spanMultiThemesAttrs(options: SpanMultiThemesOptions): HtmlAttrs
     }
   } else if (defaultTheme) {
     applyDefaultMultiTheme(inlineStyles, cssVars, options);
-    appendThemeCssVars(cssVars, cssVariablePrefix, themes, scope, language, defaultTheme);
+    pushThemeCssVarsForAll(cssVars, cssVariablePrefix, themes, scope, language, defaultTheme);
   } else {
-    appendThemeCssVars(cssVars, cssVariablePrefix, themes, scope, language);
+    pushThemeCssVarsForAll(cssVars, cssVariablePrefix, themes, scope, language);
   }
 
   const styleParts = [...inlineStyles, ...cssVars].filter(Boolean);
@@ -737,7 +796,7 @@ export function sortedThemeNames(themes: Record<string, unknown>): string[] {
   });
 }
 
-export function appendThemeCssVars(
+function pushThemeCssVarsForAll(
   cssVars: string[],
   prefix: string,
   themes: Record<string, Theme | undefined>,
@@ -754,7 +813,23 @@ export function appendThemeCssVars(
   }
 }
 
-export function buildNormalThemeVars(
+/**
+ * @deprecated Internal multi-themes plumbing, exported by accident; Rust keeps
+ * its counterpart private. Use {@link spanMultiThemesAttrs}. Removed in the
+ * next major.
+ */
+export function appendThemeCssVars(
+  cssVars: string[],
+  prefix: string,
+  themes: Record<string, Theme | undefined>,
+  scope: string,
+  language: LanguageRef,
+  excludeTheme?: string,
+): void {
+  pushThemeCssVarsForAll(cssVars, prefix, themes, scope, language, excludeTheme);
+}
+
+function pushNormalThemeVars(
   styles: string[],
   prefix: string,
   themes: Record<string, Theme>,
@@ -770,6 +845,20 @@ export function buildNormalThemeVars(
     if (style?.fg) styles.push(`${prefix}-${sanitized}:${style.fg};`);
     if (style?.bg) styles.push(`${prefix}-${sanitized}-bg:${style.bg};`);
   }
+}
+
+/**
+ * @deprecated Internal multi-themes plumbing, exported by accident; Rust keeps
+ * its counterpart private. Use {@link openMultiThemesPreTag}. Removed in the
+ * next major.
+ */
+export function buildNormalThemeVars(
+  styles: string[],
+  prefix: string,
+  themes: Record<string, Theme>,
+  excludeTheme?: string,
+): void {
+  pushNormalThemeVars(styles, prefix, themes, excludeTheme);
 }
 
 // The `<pre>` colours for `light-dark()`, falling back to black on white and
@@ -788,7 +877,7 @@ function lightDarkPreStyles(themes: Record<string, Theme>): string[] {
   ];
 }
 
-export function buildPreThemeStyle(options: {
+function multiThemesPreStyle(options: {
   themes: Record<string, Theme>;
   defaultTheme?: string;
   cssVariablePrefix?: string;
@@ -802,14 +891,33 @@ export function buildPreThemeStyle(options: {
     const defaultStyle = getThemeStyle(options.themes[options.defaultTheme], "normal");
     if (defaultStyle?.fg) styles.push(`color:${defaultStyle.fg};`);
     if (defaultStyle?.bg) styles.push(`background-color:${defaultStyle.bg};`);
-    buildNormalThemeVars(styles, prefix, options.themes, options.defaultTheme);
+    pushNormalThemeVars(styles, prefix, options.themes, options.defaultTheme);
   } else {
-    buildNormalThemeVars(styles, prefix, options.themes);
+    pushNormalThemeVars(styles, prefix, options.themes);
   }
 
   return styles.length > 0 ? styles.join(" ") : undefined;
 }
 
+/**
+ * @deprecated Internal multi-themes plumbing, exported by accident; Rust keeps
+ * its counterpart private. Use {@link openMultiThemesPreTag}, which builds the
+ * whole tag. Removed in the next major.
+ */
+export function buildPreThemeStyle(options: {
+  themes: Record<string, Theme>;
+  defaultTheme?: string;
+  cssVariablePrefix?: string;
+}): string | undefined {
+  return multiThemesPreStyle(options);
+}
+
+/**
+ * @deprecated Composes {@link openPreTag}, {@link openCodeTag},
+ * {@link wrapLine} and {@link closingTags} in the one order the built-in
+ * formatters use, which is not a custom formatter's shape. Call them directly.
+ * Removed in the next major.
+ */
 export function renderHtmlBlock(options: {
   lines: string[];
   language: LanguageRef | undefined;
@@ -838,11 +946,11 @@ export function wrapLine(
   content: string,
   options: { className?: string; style?: string } = {},
 ): string {
-  return `${openTag("div", {
-    class: joinClasses("l-line", options.className),
+  return `${tag("div", {
+    class: classList("l-line", options.className),
     style: options.style,
     "data-line": lineNumber,
-  })}${content}\n${closeTag("div")}`;
+  })}${content}\n</div>`;
 }
 
 /**
@@ -1011,7 +1119,7 @@ export function formatHighlightIterLines(
   },
 ): { lines: string[]; language: string } {
   const formatText = options.formatText ?? escape;
-  const closeSpan = options.closeSpan ?? (() => closeTag("span"));
+  const closeSpan = options.closeSpan ?? (() => "</span>");
   const sourceBytes = encodeSource(source);
   const lines = [""];
   let language = languageRef ? languageId(languageRef) : "plaintext";
@@ -1082,6 +1190,11 @@ function escapeChar(char: string): string {
   return ESCAPED_CHARS[char] ?? char;
 }
 
+/**
+ * @deprecated Records line offsets without closing and reopening the spans that
+ * cross a line boundary, so slicing the buffer at them yields lines whose tags
+ * do not nest. Use {@link renderLinesFromEvents}. Removed in the next major.
+ */
 export function renderEvents(
   source: string,
   events: SyntaxHighlightEvent[],
@@ -1123,6 +1236,9 @@ export function renderEvents(
 
 /**
  * Slice rendered HTML back into lines using offsets from {@link renderEvents}.
+ *
+ * @deprecated Only useful for slicing what {@link renderEvents} returns. Use
+ * {@link renderLinesFromEvents}. Removed in the next major.
  */
 export function linesFromOffsets(html: Uint8Array, lineOffsets: number[]): string[] {
   const rendered = _decoder.decode(html);

--- a/packages/javascript/lumis/src/formatter/html.ts
+++ b/packages/javascript/lumis/src/formatter/html.ts
@@ -28,7 +28,17 @@ export function decodeSourceSlice(
   startByte: number,
   endByte: number,
 ): string {
-  return _decoder.decode(sourceBytes.subarray(startByte, endByte));
+  let start = Math.min(Math.max(startByte, 0), sourceBytes.length);
+  while (start < sourceBytes.length && isUtf8Continuation(sourceBytes[start])) start += 1;
+
+  let end = Math.min(Math.max(endByte, 0), sourceBytes.length);
+  while (end > 0 && isUtf8Continuation(sourceBytes[end])) end -= 1;
+
+  return _decoder.decode(sourceBytes.subarray(start, Math.max(start, end)));
+}
+
+function isUtf8Continuation(byte: number | undefined): boolean {
+  return byte !== undefined && (byte & 0xc0) === 0x80;
 }
 
 /** HTML attribute map. Values of `undefined`, `null`, or `false` are omitted. */

--- a/packages/javascript/lumis/src/formatter/line-highlights.ts
+++ b/packages/javascript/lumis/src/formatter/line-highlights.ts
@@ -1,0 +1,40 @@
+import type { LineSpec } from "../types.js";
+
+/** Resolve line specs once before a formatter walks its rendered output. */
+export function selectedLineFlags(
+  lines: readonly LineSpec[] | undefined,
+  lineCount: number,
+): Uint8Array | undefined {
+  if (!lines) return undefined;
+
+  const intervals = lines
+    .map((line) => lineInterval(line, lineCount))
+    .filter((interval): interval is [number, number] => interval !== undefined)
+    .sort((left, right) => left[0] - right[0] || left[1] - right[1]);
+  const selected = new Uint8Array(lineCount);
+  const first = intervals.shift();
+  if (!first) return selected;
+
+  let [start, end] = first;
+  for (const [nextStart, nextEnd] of intervals) {
+    if (nextStart <= end + 1) {
+      end = Math.max(end, nextEnd);
+    } else {
+      selected.fill(1, start - 1, end);
+      [start, end] = [nextStart, nextEnd];
+    }
+  }
+  selected.fill(1, start - 1, end);
+
+  return selected;
+}
+
+function lineInterval(line: LineSpec, lineCount: number): [number, number] | undefined {
+  if (typeof line === "number") {
+    return Number.isInteger(line) && line >= 1 && line <= lineCount ? [line, line] : undefined;
+  }
+
+  const start = Math.max(1, Math.ceil(line[0]));
+  const end = Math.min(lineCount, Math.floor(line[1]));
+  return start <= end ? [start, end] : undefined;
+}

--- a/packages/javascript/lumis/src/themes.ts
+++ b/packages/javascript/lumis/src/themes.ts
@@ -23,5 +23,5 @@ export function availableThemes(): ThemeInfo[] {
  * ```
  */
 export function sanitizeThemeName(name: string): string {
-  return name.replaceAll(/[^0-9A-Za-z_-]/g, "-");
+  return name.replaceAll(/[^\p{Alphabetic}\p{Number}_-]/gu, "-");
 }

--- a/packages/javascript/lumis/test/custom-formatter.test.ts
+++ b/packages/javascript/lumis/test/custom-formatter.test.ts
@@ -6,7 +6,6 @@ import json from "../langs/json.ts";
 import { createHighlighter, highlightIter } from "../src/index.js";
 import { type Formatter, htmlInline } from "../src/formatters.js";
 import {
-  closeTag,
   closingTags,
   openCodeTag,
   openPreTag,
@@ -52,7 +51,7 @@ describe("custom formatter", () => {
               append(text);
             } else {
               append(
-                `${openSpanTag({ class: `tok ${scope.replaceAll(".", "-")}` })}${text}${closeTag("span")}`,
+                `${openSpanTag({ class: `tok ${scope.replaceAll(".", "-")}` })}${text}</span>`,
               );
             }
           },
@@ -62,7 +61,7 @@ describe("custom formatter", () => {
           .map((line, index) =>
             wrapLine(
               index + 1,
-              `${openSpanTag({ class: "line-no" })}${index + 1}${closeTag("span")}${openSpanTag({ class: "line-body" })}${line}${closeTag("span")}`,
+              `${openSpanTag({ class: "line-no" })}${index + 1}</span>${openSpanTag({ class: "line-body" })}${line}</span>`,
               {
                 className: index === 0 ? "first-line" : undefined,
               },

--- a/packages/javascript/lumis/test/formatter-helpers.test.ts
+++ b/packages/javascript/lumis/test/formatter-helpers.test.ts
@@ -1,0 +1,144 @@
+/**
+ * JavaScript's half of the cross-runtime formatter helper check.
+ *
+ * `fixtures/formatter-helpers.json` lists the helper capabilities every runtime
+ * must offer a custom formatter. JavaScript can read its own exports, so unlike
+ * the Rust half this reflects rather than calls:
+ *
+ * - `exports every helper in the manifest` fails on a capability JavaScript
+ *   lacks.
+ * - `exports nothing the manifest does not account for` fails on an export in
+ *   neither the manifest's helper set, `runtime_only`, nor `deprecated`. This is
+ *   the one that catches drift: JavaScript grew 20 helpers Rust never got before
+ *   anything checked (#1381).
+ * - `marks every deprecation the manifest claims` reads the source for the
+ *   `@deprecated` tag, which does not survive to run time.
+ *
+ * Helpers are camelCase here and snake_case in the manifest; `toCamel` bridges
+ * that, and `spelling.javascript` overrides it where the two do not line up.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import * as ansi from "../src/formatter/ansi.js";
+import * as html from "../src/formatter/html.js";
+
+interface ManifestHelper {
+  name: string;
+  spelling?: Record<string, string>;
+}
+
+interface Manifest {
+  modules: Record<string, { helpers: ManifestHelper[] }>;
+  runtime_only: Record<string, Record<string, Record<string, string>>>;
+  deprecated: Record<string, Record<string, { runtimes?: string[] }>>;
+  waived: Record<string, unknown>;
+}
+
+const manifest: Manifest = JSON.parse(
+  readFileSync(new URL("../../../../fixtures/formatter-helpers.json", import.meta.url), "utf8"),
+);
+
+const modules: Record<string, Record<string, unknown>> = { html, ansi };
+
+// A helper defined in one file and re-exported from another is one helper, so
+// every file behind a module is read for the `@deprecated` tag.
+const sources: Record<string, string[]> = {
+  html: ["../src/formatter/html.ts"],
+  ansi: ["../src/formatter/ansi.ts", "../src/formatter/ansi-core.ts"],
+};
+
+function toCamel(name: string): string {
+  return name.replaceAll(/_([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+function jsName(helper: ManifestHelper): string {
+  return helper.spelling?.javascript ?? toCamel(helper.name);
+}
+
+function exportedNames(module: string): string[] {
+  return Object.keys(modules[module] ?? {}).sort();
+}
+
+/** Names carrying a `@deprecated` JSDoc tag on their `export` in `module`'s sources. */
+function deprecatedInSource(module: string): Set<string> {
+  const marked = new Set<string>();
+  const pattern =
+    /\/\*\*(?:(?!\*\/)[\s\S])*?@deprecated[\s\S]*?\*\/\s*export\s+(?:async\s+)?function\s+(\w+)/g;
+
+  for (const source of sources[module] ?? []) {
+    const text = readFileSync(new URL(source, import.meta.url), "utf8");
+    for (const match of text.matchAll(pattern)) {
+      marked.add(match[1]);
+    }
+  }
+
+  return marked;
+}
+
+function sectionNames(section: Record<string, Record<string, unknown>>, module: string): string[] {
+  return Object.keys(section.javascript?.[module] ?? {}).filter((name) => !name.startsWith("$"));
+}
+
+function deprecatedNames(module: string): string[] {
+  return (
+    Object.entries(manifest.deprecated[module] ?? {})
+      .filter(([name]) => !name.startsWith("$"))
+      .filter(([, entry]) => entry.runtimes?.includes("javascript"))
+      // A key is canonical snake_case where every runtime has the helper and the
+      // JavaScript-only spelling where only JavaScript does; `toCamel` leaves the
+      // latter alone.
+      .map(([name]) => toCamel(name))
+  );
+}
+
+describe("formatter helper manifest", () => {
+  it("covers the modules JavaScript publishes", () => {
+    expect(Object.keys(manifest.modules).sort()).toEqual(Object.keys(modules).sort());
+  });
+
+  for (const [module, entry] of Object.entries(manifest.modules)) {
+    it(`${module} exports every helper in the manifest`, () => {
+      const missing = entry.helpers
+        .map(jsName)
+        .filter((name) => !Object.hasOwn(modules[module] ?? {}, name));
+
+      expect(missing).toEqual([]);
+    });
+
+    it(`${module} exports nothing the manifest does not account for`, () => {
+      const accounted = new Set([
+        ...entry.helpers.map(jsName),
+        ...sectionNames(manifest.runtime_only, module),
+        ...deprecatedNames(module),
+      ]);
+
+      const unaccounted = exportedNames(module).filter((name) => !accounted.has(name));
+
+      expect(
+        unaccounted,
+        "add them to fixtures/formatter-helpers.json and to the other runtimes, or classify them",
+      ).toEqual([]);
+    });
+
+    it(`${module} marks every deprecation the manifest claims`, () => {
+      const marked = deprecatedInSource(module);
+      const unmarked = deprecatedNames(module).filter((name) => !marked.has(name));
+
+      expect(unmarked).toEqual([]);
+    });
+
+    it(`${module} still exports every runtime_only helper`, () => {
+      const gone = sectionNames(manifest.runtime_only, module).filter(
+        (name) => !Object.hasOwn(modules[module] ?? {}, name),
+      );
+
+      expect(gone, "drop the entry").toEqual([]);
+    });
+  }
+
+  it("has no waiver left standing", () => {
+    const waivers = Object.keys(manifest.waived).filter((key) => !key.startsWith("$"));
+
+    expect(waivers).toEqual([]);
+  });
+});

--- a/packages/javascript/lumis/test/formatter-shared.test.ts
+++ b/packages/javascript/lumis/test/formatter-shared.test.ts
@@ -242,6 +242,15 @@ describe("formatter shared helpers", () => {
     expect(lines).toEqual(['<span class="string">a</span>', '<span class="string">b</span>']);
   });
 
+  it("shrinks source ranges that split a UTF-8 character", () => {
+    expect(renderLinesFromEvents("éx", [{ type: "source", start: 0, end: 1 }], () => "")).toEqual([
+      "",
+    ]);
+    expect(renderLinesFromEvents("éx", [{ type: "source", start: 1, end: 3 }], () => "")).toEqual([
+      "x",
+    ]);
+  });
+
   it("opens a bare span for a scope whose attrs come out empty", () => {
     const lines = renderLinesFromEvents(
       "ab",
@@ -312,6 +321,7 @@ describe("formatter shared helpers", () => {
     expect(sanitizeThemeName("one-dark")).toBe("one-dark");
     expect(sanitizeThemeName("my theme!")).toBe("my-theme-");
     expect(sanitizeThemeName("theme_v2")).toBe("theme_v2");
+    expect(sanitizeThemeName("Rosé Pine (Dawn)")).toBe("Rosé-Pine--Dawn-");
   });
 
   it("generates span inline attrs with theme styling", () => {

--- a/packages/javascript/lumis/test/line-highlights.test.ts
+++ b/packages/javascript/lumis/test/line-highlights.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { selectedLineFlags } from "../src/formatter/line-highlights.js";
+
+describe("selectedLineFlags", () => {
+  it("clamps, sorts, and merges ranges before marking output lines", () => {
+    const selected = selectedLineFlags([[3, 8], 1, [2, 4], [9, 7]], 5);
+
+    expect(Array.from(selected ?? [])).toEqual([1, 1, 1, 1, 1]);
+  });
+
+  it("handles many sparse specs without rescanning them per output line", () => {
+    const lines = Array.from({ length: 10_000 }, (_, index) => index * 2 + 1);
+    const selected = selectedLineFlags(lines, 20_000);
+
+    expect(selected?.reduce((count, value) => count + value, 0)).toBe(10_000);
+    expect(selected?.[0]).toBe(1);
+    expect(selected?.[1]).toBe(0);
+    expect(selected?.[19_998]).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #1381.

## The decision

The issue asked for a decision on the target set before filling gaps. Recounted against `main` (`escape_attr` landed in #1385 and the Elixir ANSI helpers in #1388), the cut is:

- **Must exist everywhere** — 24 HTML capabilities and 5 ANSI ones.
- **Runtime-shaped, allowed to differ** — signatures the boundary dictates rather than taste.
- **Should not be public anywhere** — plumbing exported by accident, plus three helpers no runtime should keep. Deprecated, not removed.

Names follow each language's convention and so do argument shapes. A capability is a thing a formatter can do, not a signature: aligning Elixir's table-shaped `span_attrs/1` with Rust's per-token `span_inline_attrs` would make the API worse, not better.

## The durable part

`fixtures/formatter-helpers.json` pins the set, and Rust, JavaScript and Elixir each assert against it **in both directions**:

- a capability in the manifest that the runtime lacks fails
- a public helper the manifest does not account for fails too

Only the second one catches a helper added to one runtime and nowhere else, which is exactly how this drifted. Both guards were checked by removing an entry and watching all three go red.

---

## Every helper

### HTML

| Capability | Rust | JavaScript | Elixir |
| --- | --- | --- | --- |
| `escape` | `escape` | `escape` | `escape/1` |
| `escape_attr` | `escape_attr` | `escapeAttr` | **`escape_attr/1`** |
| `escape_braces` | `escape_braces` | `escapeBraces` | `escape_braces/1` |
| `scope_to_class` | `scope_to_class` | `scopeToClass` | `scope_to_class/1` |
| `style_to_css` | `themes::Style::css` | `styleToCss` | **`style_to_css/1,2`** |
| `text_decoration` | `text_decoration` | `textDecoration` | **`text_decoration/1`** |
| `sanitize_theme_name` | `sanitize_theme_name` | `sanitizeThemeName` | **`sanitize_theme_name/1`** |
| `open_span` | **`open_span`** | `openSpanTag` | `open_span/2` |
| `span_inline_attrs` | `span_inline_attrs` | `spanInlineAttrs` | `span_inline_attrs/2` |
| `span_inline` | `span_inline` | `spanInline` | `span_inline/3` |
| `span_linked_attrs` | `span_linked_attrs` | `spanLinkedAttrs` | `span_linked_attrs/1` |
| `span_linked` | `span_linked` | `spanLinked` | `span_linked/2` |
| `span_multi_themes_attrs` | `span_multi_themes_attrs` | `spanMultiThemesAttrs` | **`span_multi_themes_attrs/0,1`** |
| `span_multi_themes` | `span_multi_themes` | `spanMultiThemes` | **`span_multi_themes/3`** |
| `open_pre_tag` | `open_pre_tag` | `openPreTag` | `open_pre_tag/0,1` |
| `open_multi_themes_pre_tag` | `open_multi_themes_pre_tag` | **`openMultiThemesPreTag`** | **`open_multi_themes_pre_tag/0,1`** |
| `open_code_tag` | `open_code_tag` | `openCodeTag` | `open_code_tag/1` |
| `close_pre_tag` | `close_pre_tag` | `closePreTag` | **`close_pre_tag/0`** |
| `close_code_tag` | `close_code_tag` | `closeCodeTag` | **`close_code_tag/0`** |
| `closing_tags` | `closing_tags` | `closingTags` | `closing_tags/0` |
| `wrap_line` | `wrap_line` | `wrapLine` | `wrap_line/2,3` |
| `line_is_highlighted` | **`line_is_highlighted`** | `lineIsHighlighted` | **`line_is_highlighted/2`** |
| `highlight_line_class` | **`highlight_line_class`** | `getHighlightLineClass` | **`highlight_line_class/2,3`** |
| `render_lines_from_events` | `render_lines_from_events`¹ | `renderLinesFromEvents` | **`render_lines_from_events/3`** |

### ANSI

| Capability | Rust | JavaScript | Elixir |
| --- | --- | --- | --- |
| `hex_to_rgb` | `hex_to_rgb` | `hexToRgb` | `hex_to_rgb/1` |
| `rgb_to_ansi` | `rgb_to_ansi` | `rgbToAnsi` | `rgb_to_ansi/4` |
| `style_to_ansi` | `style_to_ansi` | `styleToAnsi` | `style_to_ansi/1` |
| `paint` | `paint` | `paint` | `paint/2` |
| `reset` | `ANSI_RESET` | `ANSI_RESET` | `reset/0` |

**Bold** is new in this PR. ¹ `render_lines_from_events` and `append_fragment` existed in `lumis-core` but were not reachable from `lumis::html`; they are now.

### Runtime-shaped, and staying that way

| Runtime | Helper | Why |
| --- | --- | --- |
| Elixir | `classes/0`, `span_attrs/1`, `ANSI.styles/1`, `ANSI.style_for/2` | Whole scope tables. Crossing the NIF boundary once per token to read a constant costs more than the highlighting. |
| JavaScript | `encodeSource`, `decodeSourceSlice` | Its strings are UTF-16; the event offsets are UTF-8 byte offsets. Rust and Elixir index bytes already. |
| JavaScript | `sortedThemeNames` | `Array.prototype.sort` orders by UTF-16 code unit, Rust orders `&str` by UTF-8 byte; they disagree on astral characters. Rust keeps its counterpart private. |
| JavaScript | `getThemeStyle`, `getScopedThemeStyle` | Scope resolution, which Rust reaches as a method on the theme and Elixir gets in bulk from `span_attrs/1`. |
| JavaScript | `formatHighlightIterLines` | The callback-shaped renderer `renderLinesFromEvents` is built on. Rust's equivalent is private functions. |
| JavaScript | `wrapWithHeader` | Concatenates three strings. JavaScript's formatters build strings; Rust's write to a `dyn Write` and Elixir's return iodata. |
| Rust, JavaScript | `append_fragment` / `appendFragment` | Splits a fragment across a mutable line-buffer array. Elixir's line buffer is immutable, so it takes `render_lines_from_events` whole. |

Each reason is in the manifest, and a name here that the runtime stops exporting fails the test, so the list cannot outlive its reasons.

### Deprecated

| Helper | Runtimes | Use instead | Why |
| --- | --- | --- | --- |
| `escape_fragment` | rust, javascript | `escape` | A pure alias. |
| `render_events` | rust, javascript | `render_lines_from_events` | Records line offsets without reopening the spans that cross them, so the sliced lines do not nest. No caller in this repository. |
| `lines_from_offsets` | rust, javascript | `render_lines_from_events` | Only useful for slicing what `render_events` returns. |
| `wrap_with_ansi` | rust, javascript | `paint` | An alias. Already deprecated in Rust. |
| `highlight_iter_with_ansi` | rust, javascript | `highlight_iter` with `paint` | Collects every segment into a `Vec` before yielding the first. Already deprecated in Rust. |
| `openTag` | javascript | `openPreTag`, `openCodeTag`, `openSpanTag` | Generic tag plumbing Rust and Elixir do inline. |
| `closeTag` | javascript | `closePreTag`, `closeCodeTag`, `closingTags` | Same. |
| `attrsToString` | javascript | `openSpanTag` | Same. |
| `joinClasses` | javascript | — | Filtering and joining class names is not Lumis's to own. |
| `renderHtmlBlock` | javascript | `openPreTag` + `openCodeTag` + `wrapLine` + `closingTags` | Composes them in the built-in formatters' fixed order. No caller in this repository. |
| `buildPreThemeStyle` | javascript | `openMultiThemesPreTag` | Multi-themes plumbing Rust keeps private. |
| `buildNormalThemeVars` | javascript | `openMultiThemesPreTag` | Same. |
| `appendThemeCssVars` | javascript | `spanMultiThemesAttrs` | Same. |

All still exported. The manifest requires each to be present **and** marked deprecated in every runtime that has it, so the JSON cannot claim one that is not there.

---

## Notable

A formatter assembled from the Elixir helpers now reproduces `:html_multi_themes` **byte for byte** across three `default_theme` modes and five sources — the formatter the issue said could not be written in Elixir at all. That is a test, not a claim.

The JavaScript multi-themes formatter had a *private* copy of `buildPreThemeStyle` that had diverged from the exported one, so the export was dead code. It now calls the public `openMultiThemesPreTag`.

`HtmlInline` and `HtmlLinked` each rolled their own `hl.lines.iter().any(...)`; both now share `line_is_highlighted`.

## Defects found while reviewing this

All three were caught reviewing the new surface, all are fixed here with regression tests.

**A `Source` range that split a character panicked.** `render_lines_from_events` clamped offsets to the source length and then sliced without checking char boundaries. A formatter can build its own events rather than replaying the ones it was handed, so those offsets are caller data; from Elixir this surfaced as `:nif_panicked` on `{:source, %{start: 0, end: 1}}` over `"é"`. Fixed in `lumis-core` rather than in the NIF, so every runtime gets it — Rust callers could hit the same panic.

**`Range.step` and direction were dropped crossing into Rust.** `RangeInclusive<usize>` has neither, so `1..5//2` arrived as `1..=5` and highlighted the two lines the step excluded, and `5..3` arrived as `5..=3` and matched nothing. The encoder existed in three copies, two of them behind the shipped `:highlight_lines` option — so **that option had the same defect**, and this fixes it too. `Lumis.LineSpec` is now the one copy.

**Then the fix for that one had to be bounded.** Expanding a stepped range into single lines is correct but unbounded, and `:highlight_lines` is caller-supplied: `1..1_000_000//2` measures 500,000 tuples and 19MB, so `1..1_000_000_000//2` would be 19GB. Most of it never needed expanding — a step of 1 or **-1** is a contiguous run either way round, and `5..3//-1` covers the same lines as `3..5`, so both normalize to one ascending range whatever their span. Only `|step| > 1` is listed out, and `Range.size/1` is arithmetic, so a range covering more than 100,000 lines is refused before anything is built. `encode/1` returns an error tuple so the option pipeline keeps its `{:error, _}` contract; `encode!/1` raises for the two public helpers.

| Input | Before this PR | After |
| --- | --- | --- |
| `1..1_000_000_000` | ok | ok, 4µs |
| `1_000_000_000..1//-1` | matched nothing | ok, 4µs |
| `1..1_000_000_000//2` | highlighted every line | refused in 1.5ms |
| `1..99_999//2` | highlighted every line | correct, 19ms |

## Verification

- `cargo test --workspace` — 0 failures, including the 6 new manifest tests.
- Elixir: 284 passed (27 doctests). The HTML helper suite went 22 → 76, and every new test compares against what the built-in Rust formatters actually emit rather than a literal.
- JavaScript: 646 passed. The 13 failures are the same native-addon/parser-cache ones present on `main` in this environment.
- `cargo clippy`, `cargo fmt`, `oxlint --type-aware --deny-warnings`, `mix format`, `mix credo --strict`, lizard: clean.
- The Elixir example added to `docs/content/usage/custom-formatters.mdx` was run, and its output compared against `:html_multi_themes`.

Related: #1359, #1378, #1380.
