### PR TITLE
feat(elixir): inject GPUI sigil

### DIFF
--- a/queries/append/elixir/injections.scm
+++ b/queries/append/elixir/injections.scm
@@ -6,6 +6,14 @@
  (#set! injection.language "heex")
  (#set! injection.combined))
 
+; GPUI template
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#eq? @_sigil_name "GPUI")
+ (#set! injection.language "heex")
+ (#set! injection.combined))
+
 ; SQL injection
 ((sigil
   (sigil_name) @_sigil_name

--- a/queries/processed/elixir/injections.scm
+++ b/queries/processed/elixir/injections.scm
@@ -66,6 +66,14 @@
  (#set! injection.language "heex")
  (#set! injection.combined))
 
+; GPUI template
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#eq? @_sigil_name "GPUI")
+ (#set! injection.language "heex")
+ (#set! injection.combined))
+
 ; SQL injection
 ((sigil
   (sigil_name) @_sigil_name

--- a/samples/elixir.ex
+++ b/samples/elixir.ex
@@ -486,6 +486,14 @@ end
 </div>
 """
 
+# GPUI sigil
+~GPUI"""
+<div class="flex grow flex-col items-center justify-center gap-4">
+  <text class="text-3xl font-semibold">Count: {assigns.count}</text>
+  <UI.button id="increment" label="Increment" variant="primary" phx-click="increment" />
+</div>
+"""
+
 # Regex sigils
 regex_pattern = ~r/[a-zA-Z0-9]+/
 case_insensitive = ~R/hello world/i


### PR DESCRIPTION
Highlights the contents of Elixir's `~GPUI` sigil as HEEx.

[`gpui`](https://hex.pm/packages/gpui) compiles `~GPUI` templates with `Phoenix.LiveView.TagEngine.Parser` ([`GPUI.Template`](https://gpui.hexdocs.pm/GPUI.Template.html#sigil_GPUI/2)), so the sigil body is HEEx-compatible markup — same treatment `~HOLO` already gets.

```elixir
~GPUI"""
<div class="flex grow flex-col items-center justify-center gap-4">
  <text class="text-3xl font-semibold">Count: {assigns.count}</text>
  <UI.button id="increment" label="Increment" variant="primary" phx-click="increment" />
</div>
"""
```

## Changes

- `queries/append/elixir/injections.scm`: inject `heex` into `~GPUI`
- `queries/processed/elixir/injections.scm`: regenerated with `mise run langs-preprocess-queries elixir`
- `samples/elixir.ex`: a `~GPUI` sample

## Verification

Built and staged the Elixir parser locally, then confirmed the injection resolves:

```
$ mise run wasm-build elixir && mise run wasm-stage elixir
$ LUMIS_DATA_DIR=$PWD/tmp/wasm/local lumis dump events --language elixir sample.ex \
    | jq -c '[.[] | select(.type=="start") | .language] | unique'
["elixir","heex"]
```

`cargo test -p lumis-build --test processed_queries` passes.