### PR TITLE
chore(ci): honor nested Git ignore rules

### DIFF
--- a/.github/workflows/complexity.yml
+++ b/.github/workflows/complexity.yml
@@ -35,4 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      - name: Seed ignored Rust build output
+        run: |
+          fixture=packages/elixir/lumis/native/lumis_nif/target/lizard-regression.rs
+          mkdir -p "$(dirname "$fixture")"
+          cp crates/lumis-wasm-runtime/src/tree_sitter_highlight.rs "$fixture"
+          git check-ignore -q "$fixture"
       - run: mise run lint-complexity-rust

--- a/.lizard-whitelist
+++ b/.lizard-whitelist
@@ -1,3 +1,3 @@
 # Vendored upstream tree-sitter iterator; keep its source diff minimal while
 # checking every other Rust function in this file and repository.
-./crates/lumis-wasm-runtime/src/tree_sitter_highlight.rs:next
+crates/lumis-wasm-runtime/src/tree_sitter_highlight.rs:next

--- a/mise.toml
+++ b/mise.toml
@@ -377,7 +377,12 @@ mix credo --strict
 [tasks.'lint-complexity-rust']
 description = "Enforce cyclomatic complexity in every Rust source file"
 tools = { "pipx:lizard" = "1.24.0" }
-run = "lizard -l rust -C 20 -L 100000 -a 100000 -i 0 -w -W .lizard-whitelist ."
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+git ls-files -z --cached --others --exclude-standard -- '*.rs' |
+    xargs -0 lizard -l rust -C 20 -L 100000 -a 100000 -i 0 -w -W .lizard-whitelist --
+'''
 
 [tasks.'lint-lua']
 description = "Lint every Lua file with selene"


### PR DESCRIPTION
## Summary

- feed Lizard the tracked and unignored Rust paths reported by Git
- keep nested-ignored dependency and build output out of local lint
- seed ignored Rust in CI to prevent regression

## Validation

- `mise run lint`
- reproduced the original `makeup_syntect` CCN 83 failure with the old scan
- verified ignored Rust is skipped and visible Rust is checked

Closes #1390